### PR TITLE
Improve long-running stream timeout UX and restart auto-recovery

### DIFF
--- a/ductor_bot/bot/app.py
+++ b/ductor_bot/bot/app.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import html as html_mod
+import json
 import logging
 from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -135,6 +137,81 @@ async def _cancel_task(task: asyncio.Task[None] | None) -> None:
             await task
 
 
+def _read_boot_id() -> str:
+    """Read Linux boot ID when available (empty string on failure)."""
+    try:
+        return Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _load_startup_state(path: Path) -> dict[str, str]:
+    """Load persisted startup state from JSON."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def _save_startup_state(path: Path, state: dict[str, str]) -> None:
+    """Persist startup state JSON atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _load_inflight_turns(path: Path) -> dict[str, dict[str, object]]:
+    """Load per-chat inflight foreground turns from disk."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    chats = data.get("chats")
+    if not isinstance(chats, dict):
+        return {}
+    out: dict[str, dict[str, object]] = {}
+    for key, value in chats.items():
+        if isinstance(value, dict):
+            out[str(key)] = dict(value)
+    return out
+
+
+def _save_inflight_turns(path: Path, turns: dict[str, dict[str, object]]) -> None:
+    """Persist per-chat inflight foreground turns atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    payload = {"chats": turns}
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _parse_utc_iso(ts: str) -> datetime | None:
+    """Parse ISO timestamp to UTC datetime (best effort)."""
+    if not ts:
+        return None
+    try:
+        parsed = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
 class TelegramBot:
     """Telegram frontend. All logic lives in the Orchestrator."""
 
@@ -208,6 +285,224 @@ class TelegramBot:
         for uid in self._config.allowed_user_ids:
             await send_rich(self._bot, uid, text, opts)
 
+    async def _notify_startup_status(self) -> None:
+        """Notify allowed users when service is started/restarted/rebooted."""
+        state_path = self._orch.paths.ductor_home / "startup-state.json"
+        prev = await asyncio.to_thread(_load_startup_state, state_path)
+        now = datetime.now(UTC)
+        now_label = now.strftime("%Y-%m-%d %H:%M:%S UTC")
+        current_boot_id = await asyncio.to_thread(_read_boot_id)
+
+        prev_boot_id = prev.get("boot_id", "")
+        prev_started_at = prev.get("started_at", "")
+
+        if prev_boot_id and current_boot_id and prev_boot_id != current_boot_id:
+            title = "System reboot detected"
+            body = f"Ductor service is online again.\nTime: {now_label}"
+        elif prev_started_at:
+            title = "Service restarted"
+            body = f"Ductor service restarted and is online.\nTime: {now_label}"
+        else:
+            title = "Service started"
+            body = f"Ductor service is online.\nTime: {now_label}"
+
+        await self._broadcast(
+            fmt(f"**{title}**", SEP, body),
+            SendRichOpts(allowed_roots=self._file_roots(self._orch.paths)),
+        )
+
+        await asyncio.to_thread(
+            _save_startup_state,
+            state_path,
+            {
+                "boot_id": current_boot_id,
+                "started_at": now.isoformat(),
+            },
+        )
+
+    def _inflight_turns_path(self) -> Path:
+        """Return the JSON path used for crash-safe foreground turn recovery."""
+        return self._orch.paths.ductor_home / "inflight-turns.json"
+
+    async def _mark_inflight_turn(
+        self,
+        chat_id: int,
+        text: str,
+        *,
+        message_id: int,
+        thread_id: int | None,
+    ) -> None:
+        """Persist the current foreground turn before execution starts."""
+        path = self._inflight_turns_path()
+        turns = await asyncio.to_thread(_load_inflight_turns, path)
+        turns[str(chat_id)] = {
+            "chat_id": chat_id,
+            "text": text,
+            "message_id": message_id,
+            "thread_id": thread_id,
+            "created_at": datetime.now(UTC).isoformat(),
+            "attempts": 0,
+        }
+        await asyncio.to_thread(_save_inflight_turns, path, turns)
+
+    async def _clear_inflight_turn(self, chat_id: int) -> None:
+        """Remove persisted foreground turn after successful completion."""
+        path = self._inflight_turns_path()
+        turns = await asyncio.to_thread(_load_inflight_turns, path)
+        if str(chat_id) not in turns:
+            return
+        turns.pop(str(chat_id), None)
+        await asyncio.to_thread(_save_inflight_turns, path, turns)
+
+    async def _resume_inflight_turns(self) -> None:
+        """Auto-resume unfinished foreground turns detected after restart."""
+        path = self._inflight_turns_path()
+        turns = await asyncio.to_thread(_load_inflight_turns, path)
+        if not turns:
+            logger.info("No inflight foreground turns to resume")
+            return
+
+        logger.info("Found %d inflight foreground turn(s) for auto-resume", len(turns))
+        now = datetime.now(UTC)
+        changed = False
+        for key in list(turns):
+            payload = turns.get(key, {})
+            chat_id = int(payload.get("chat_id", 0) or 0)
+            text = str(payload.get("text", "") or "").strip()
+            if chat_id <= 0 or not text:
+                turns.pop(key, None)
+                changed = True
+                continue
+
+            attempts = int(payload.get("attempts", 0) or 0)
+            created_at = _parse_utc_iso(str(payload.get("created_at", "") or ""))
+            if created_at and (now - created_at).total_seconds() > 2 * 60 * 60:
+                turns.pop(key, None)
+                changed = True
+                continue
+            if attempts >= 3:
+                turns.pop(key, None)
+                changed = True
+                await send_rich(
+                    self._bot,
+                    chat_id,
+                    fmt(
+                        "**Auto-resume skipped**",
+                        SEP,
+                        "A previous task failed to auto-resume multiple times. "
+                        "Send `continue from where you left off` to retry manually.",
+                    ),
+                    SendRichOpts(allowed_roots=self._file_roots(self._orch.paths)),
+                )
+                continue
+
+            thread_raw = payload.get("thread_id")
+            thread_id = int(thread_raw) if isinstance(thread_raw, int) else None
+            logger.info("Auto-resuming inflight turn chat=%d attempts=%d", chat_id, attempts + 1)
+
+            try:
+                await send_rich(
+                    self._bot,
+                    chat_id,
+                    fmt(
+                        "**Resuming previous work**",
+                        SEP,
+                        "Service restart was detected. Continuing the interrupted task automatically.",
+                    ),
+                    SendRichOpts(
+                        allowed_roots=self._file_roots(self._orch.paths), thread_id=thread_id
+                    ),
+                )
+                await self._handle_non_streaming(None, chat_id, text, thread_id=thread_id)
+            except Exception:
+                logger.exception("Failed to auto-resume foreground turn chat=%d", chat_id)
+                payload["attempts"] = attempts + 1
+                turns[key] = payload
+                changed = True
+                with contextlib.suppress(Exception):
+                    await send_rich(
+                        self._bot,
+                        chat_id,
+                        fmt(
+                            "**Auto-resume failed**",
+                            SEP,
+                            "The interrupted task could not be resumed automatically. "
+                            "Send `continue from where you left off` and I will continue from context.",
+                        ),
+                        SendRichOpts(
+                            allowed_roots=self._file_roots(self._orch.paths), thread_id=thread_id
+                        ),
+                    )
+            else:
+                turns.pop(key, None)
+                changed = True
+
+        if changed:
+            await asyncio.to_thread(_save_inflight_turns, path, turns)
+
+    def _build_named_session_resume_prompt(self, last_prompt: str, has_session_id: bool) -> str:
+        """Build recovery prompt for interrupted named background sessions."""
+        if has_session_id:
+            return (
+                "Service restart interrupted your work. Continue from the latest unfinished step "
+                "in this same session. Do not repeat completed work. Then provide a concise "
+                "progress update and next actions."
+            )
+        base = last_prompt.strip()
+        if base:
+            return base
+        return (
+            "Service restart interrupted this task. Continue the previous work and provide "
+            "the latest result."
+        )
+
+    async def _resume_interrupted_named_sessions(self) -> None:
+        """Auto-resume named background sessions that were running before restart."""
+        sessions = self._orch.pop_recovered_named_sessions()
+        if not sessions:
+            logger.info("No interrupted named sessions to auto-resume")
+            return
+
+        logger.info("Found %d interrupted named session(s) for auto-resume", len(sessions))
+        for ns in sessions:
+            # Inter-agent sessions are resumed by explicit bus traffic, not startup replay.
+            if ns.name.startswith("ia-"):
+                continue
+
+            prompt = self._build_named_session_resume_prompt(ns.last_prompt, bool(ns.session_id))
+            try:
+                logger.info("Auto-resuming named session name=%s chat=%d", ns.name, ns.chat_id)
+                await send_rich(
+                    self._bot,
+                    ns.chat_id,
+                    fmt(
+                        f"**[{ns.name}] Auto-resuming**",
+                        SEP,
+                        "Service restart was detected. Resuming this background session now.",
+                    ),
+                    SendRichOpts(allowed_roots=self._file_roots(self._orch.paths)),
+                )
+                self._orch.submit_named_followup_bg(
+                    ns.chat_id,
+                    ns.name,
+                    prompt,
+                    message_id=0,
+                    thread_id=None,
+                )
+            except Exception:
+                logger.exception("Failed to auto-resume named session name=%s", ns.name)
+                with contextlib.suppress(Exception):
+                    await send_rich(
+                        self._bot,
+                        ns.chat_id,
+                        fmt(
+                            f"**[{ns.name}] Auto-resume failed**",
+                            SEP,
+                            f"Send `@{ns.name} continue from where you left off` to continue manually.",
+                        ),
+                        SendRichOpts(allowed_roots=self._file_roots(self._orch.paths)),
+                    )
+
     async def _on_startup(self) -> None:
         from ductor_bot.orchestrator.core import Orchestrator
 
@@ -236,11 +531,15 @@ class TelegramBot:
                     ),
                 )
 
+        await self._notify_startup_status()
+
         self._orchestrator.set_cron_result_handler(self._on_cron_result)
         self._orchestrator.set_heartbeat_handler(self._on_heartbeat_result)
         self._orchestrator.set_webhook_result_handler(self._on_webhook_result)
         self._orchestrator.set_webhook_wake_handler(self._handle_webhook_wake)
         self._orchestrator.set_session_result_handler(self._on_session_result)
+        await self._resume_interrupted_named_sessions()
+        await self._resume_inflight_turns()
 
         # Check for post-upgrade notification
         upgrade = await asyncio.to_thread(consume_upgrade_sentinel, self._orch.paths.ductor_home)
@@ -1003,11 +1302,28 @@ class TelegramBot:
         chat_id = message.chat.id
         thread_id = get_thread_id(message)
         logger.debug("Message text=%s", text[:80])
+        await self._mark_inflight_turn(
+            chat_id,
+            text,
+            message_id=message.message_id,
+            thread_id=thread_id,
+        )
+        completed = False
 
-        if self._config.streaming.enabled:
-            await self._handle_streaming(message, chat_id, text, thread_id=thread_id)
-        else:
-            await self._handle_non_streaming(message, chat_id, text, thread_id=thread_id)
+        try:
+            if self._config.streaming.enabled:
+                await self._handle_streaming(message, chat_id, text, thread_id=thread_id)
+            else:
+                await self._handle_non_streaming(message, chat_id, text, thread_id=thread_id)
+            completed = True
+        except TelegramAPIError as exc:
+            # Network/API blips should not terminate the whole bot process.
+            logger.warning("Telegram API error while handling message chat=%s: %s", chat_id, exc)
+        except Exception:
+            logger.exception("Unhandled error in message handler chat=%s", chat_id)
+        finally:
+            if completed:
+                await self._clear_inflight_turn(chat_id)
 
     async def _resolve_text(self, message: Message) -> str | None:
         """Extract processable text from *message* (plain text or media prompt)."""

--- a/ductor_bot/bot/message_dispatch.py
+++ b/ductor_bot/bot/message_dispatch.py
@@ -105,6 +105,9 @@ async def run_streaming_message(
             "thinking": "THINKING",
             "compacting": "COMPACTING",
             "recovering": "Please wait, recovering...",
+            "timeout_warn_60": "Still working. About 60 seconds left before timeout.",
+            "timeout_warn_10": "Still working. About 10 seconds left before timeout.",
+            "timeout_extended": "Long-running task detected. Timeout window extended automatically.",
         }
         label = system_map.get(status or "")
         if label is None:

--- a/ductor_bot/cli/executor.py
+++ b/ductor_bot/cli/executor.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
+import time
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
 
@@ -19,11 +21,57 @@ from ductor_bot.cli.base import (
     CLIConfig,
     _win_feed_stdin,
 )
-from ductor_bot.cli.stream_events import ResultEvent, StreamEvent
+from ductor_bot.cli.stream_events import ResultEvent, StreamEvent, SystemStatusEvent
 from ductor_bot.cli.types import CLIResponse
 from ductor_bot.infra.process_tree import force_kill_process_tree
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_DYNAMIC_TIMEOUT_MAX_SECONDS = 3600.0
+_DYNAMIC_TIMEOUT_MAX_ENV = "DUCTOR_DYNAMIC_TIMEOUT_MAX_SECONDS"
+_STREAM_TIMEOUT_POLL_SECONDS = 5.0
+_TIMEOUT_WARN_60_SECONDS = 60.0
+_TIMEOUT_WARN_10_SECONDS = 10.0
+
+
+def _resolve_dynamic_timeout_max(timeout_seconds: float | None) -> float | None:
+    """Return the dynamic maximum timeout cap for one stream.
+
+    Priority:
+    1) ``DUCTOR_DYNAMIC_TIMEOUT_MAX_SECONDS`` env var (if valid positive float)
+    2) default: max(configured timeout, 1 hour)
+    """
+    if timeout_seconds is None or timeout_seconds <= 0:
+        return None
+
+    raw = os.environ.get(_DYNAMIC_TIMEOUT_MAX_ENV, "").strip()
+    if raw:
+        try:
+            configured = float(raw)
+        except ValueError:
+            logger.warning("Invalid %s='%s' (must be number)", _DYNAMIC_TIMEOUT_MAX_ENV, raw)
+        else:
+            if configured > 0:
+                return max(timeout_seconds, configured)
+            logger.warning("%s must be > 0, got '%s'", _DYNAMIC_TIMEOUT_MAX_ENV, raw)
+    return max(timeout_seconds, _DEFAULT_DYNAMIC_TIMEOUT_MAX_SECONDS)
+
+
+def _timeout_result_text(elapsed_seconds: float, base_timeout: float | None, cap_seconds: float | None) -> str:
+    """Build a user-facing timeout message (English by default)."""
+    elapsed_label = f"{elapsed_seconds:.0f}s"
+    base_label = f"{base_timeout:.0f}s" if base_timeout and base_timeout > 0 else "configured window"
+    if cap_seconds and cap_seconds > 0:
+        cap_label = f"{cap_seconds:.0f}s"
+        return (
+            f"Request timed out after {elapsed_label}. "
+            f"The timeout window started at {base_label} and was auto-extended up to {cap_label}.\n"
+            "If this is expected to run longer, try again and ask to continue from the previous state."
+        )
+    return (
+        f"Request timed out after {elapsed_label} (configured timeout: {base_label}).\n"
+        "If this is expected to run longer, try again and ask to continue from the previous state."
+    )
 
 
 def _build_subprocess_env(config: CLIConfig) -> dict[str, str] | None:
@@ -138,22 +186,95 @@ async def run_streaming_subprocess(
     tracked = reg.register(config.chat_id, process, config.process_label) if reg else None
     stderr_drain = asyncio.create_task(process.stderr.read())
 
+    base_timeout = spec.timeout_seconds
+    dynamic_timeout_cap = _resolve_dynamic_timeout_max(base_timeout)
+    stream_started_at = time.monotonic()
+    deadline = (
+        stream_started_at + base_timeout if base_timeout is not None and base_timeout > 0 else None
+    )
+    warned_60 = False
+    warned_10 = False
+
     try:
-        async with asyncio.timeout(spec.timeout_seconds):
-            while True:
+        while True:
+            if deadline is None:
                 line_bytes = await process.stdout.readline()
-                if not line_bytes:
-                    break
-                line = line_bytes.decode(errors="replace").rstrip()
-                logger.debug("Stream line: %s", line[:120])
-                async for event in line_handler(line):
-                    yield event
+            else:
+                while True:
+                    now = time.monotonic()
+                    elapsed = now - stream_started_at
+                    remaining = deadline - now
+
+                    if remaining <= 0:
+                        if dynamic_timeout_cap is not None and elapsed < dynamic_timeout_cap:
+                            extended_deadline = min(
+                                stream_started_at + dynamic_timeout_cap,
+                                deadline + (base_timeout or 0),
+                            )
+                            if extended_deadline > deadline:
+                                deadline = extended_deadline
+                                warned_60 = False
+                                warned_10 = False
+                                logger.info(
+                                    "%s stream timeout auto-extended elapsed=%.0fs cap=%.0fs",
+                                    provider_label,
+                                    elapsed,
+                                    dynamic_timeout_cap,
+                                )
+                                yield SystemStatusEvent(
+                                    type="system",
+                                    subtype="status",
+                                    status="timeout_extended",
+                                )
+                                continue
+                        raise TimeoutError
+
+                    if remaining <= _TIMEOUT_WARN_60_SECONDS and not warned_60:
+                        warned_60 = True
+                        yield SystemStatusEvent(
+                            type="system",
+                            subtype="status",
+                            status="timeout_warn_60",
+                        )
+                    if remaining <= _TIMEOUT_WARN_10_SECONDS and not warned_10:
+                        warned_10 = True
+                        yield SystemStatusEvent(
+                            type="system",
+                            subtype="status",
+                            status="timeout_warn_10",
+                        )
+
+                    poll_for = min(remaining, _STREAM_TIMEOUT_POLL_SECONDS)
+                    try:
+                        line_bytes = await asyncio.wait_for(process.stdout.readline(), timeout=poll_for)
+                        break
+                    except TimeoutError:
+                        continue
+
+            if not line_bytes:
+                break
+            line = line_bytes.decode(errors="replace").rstrip()
+            logger.debug("Stream line: %s", line[:120])
+            async for event in line_handler(line):
+                yield event
         stderr_bytes = await stderr_drain
     except TimeoutError:
         force_kill_process_tree(process.pid)
         await process.wait()
-        logger.warning("%s stream timed out after %.0fs", provider_label, spec.timeout_seconds)
-        yield ResultEvent(type="result", result="", is_error=True)
+        elapsed_seconds = max(0.0, time.monotonic() - stream_started_at)
+        logger.warning(
+            "%s stream timed out elapsed=%.0fs base=%.0fs cap=%.0fs",
+            provider_label,
+            elapsed_seconds,
+            base_timeout or 0.0,
+            dynamic_timeout_cap or 0.0,
+        )
+        yield ResultEvent(
+            type="result",
+            result=_timeout_result_text(elapsed_seconds, base_timeout, dynamic_timeout_cap),
+            is_error=True,
+            returncode=124,
+        )
         return
     finally:
         await _cancel_drain(stderr_drain)
@@ -210,7 +331,11 @@ async def run_oneshot_subprocess(
         force_kill_process_tree(process.pid)
         await process.wait()
         logger.warning("%s timed out after %.0fs", provider_label, spec.timeout_seconds)
-        return CLIResponse(result="", is_error=True, timed_out=True)
+        return CLIResponse(
+            result=f"Request timed out after {spec.timeout_seconds:.0f}s.",
+            is_error=True,
+            timed_out=True,
+        )
     finally:
         if tracked and reg:
             reg.unregister(tracked)

--- a/ductor_bot/orchestrator/core.py
+++ b/ductor_bot/orchestrator/core.py
@@ -704,7 +704,7 @@ class Orchestrator:
             msg = f"Session '{session_name}' is still processing"
             raise ValueError(msg)
 
-        ns.status = "running"
+        self._named_sessions.mark_running(chat_id, session_name, prompt)
         exec_config = resolve_cli_config(self._config, self._codex_cache)
         sub = BackgroundSubmit(
             chat_id=chat_id,
@@ -769,6 +769,10 @@ class Orchestrator:
     def list_named_sessions(self, chat_id: int) -> list[NamedSession]:
         """List active named sessions for a chat."""
         return self._named_sessions.list_active(chat_id)
+
+    def pop_recovered_named_sessions(self, chat_id: int | None = None) -> list[NamedSession]:
+        """Pop sessions that were running when the previous process stopped."""
+        return self._named_sessions.pop_recovered_running(chat_id)
 
     def active_background_tasks(self, chat_id: int | None = None) -> list[BackgroundTask]:
         """Return active background tasks, optionally filtered by chat_id."""

--- a/ductor_bot/session/named.py
+++ b/ductor_bot/session/named.py
@@ -140,6 +140,7 @@ class NamedSession:
     prompt_preview: str
     status: str  # "running" | "idle" | "ended"
     created_at: float
+    last_prompt: str = ""
     message_count: int = 0
 
 
@@ -152,6 +153,7 @@ def _session_from_dict(data: dict[str, Any]) -> NamedSession:
         model=str(data.get("model", "")),
         session_id=str(data.get("session_id", "")),
         prompt_preview=str(data.get("prompt_preview", "")),
+        last_prompt=str(data.get("last_prompt", data.get("prompt_preview", ""))),
         status=str(data.get("status", "ended")),
         created_at=float(data.get("created_at", 0.0)),
         message_count=int(data.get("message_count", 0)),
@@ -170,10 +172,12 @@ class NamedSessionRegistry:
         self._path = path
         self._lock = asyncio.Lock()
         self._sessions: dict[tuple[int, str], NamedSession] = {}
+        self._recovered_running: dict[tuple[int, str], NamedSession] = {}
         self._load()
 
     def _load(self) -> None:
         """Load sessions from JSON on disk."""
+        self._recovered_running.clear()
         raw = load_json(self._path)
         if not raw:
             return
@@ -185,6 +189,7 @@ class NamedSessionRegistry:
             # Downgrade stale "running" to "idle" after restart
             if ns.status == "running":
                 ns.status = "idle"
+                self._recovered_running[(ns.chat_id, ns.name)] = ns
             self._sessions[(ns.chat_id, ns.name)] = ns
         logger.info("Loaded %d named sessions from %s", len(self._sessions), self._path)
 
@@ -219,6 +224,7 @@ class NamedSessionRegistry:
             model=model,
             session_id="",
             prompt_preview=prompt_preview[:60],
+            last_prompt=prompt_preview[:4000],
             status="running",
             created_at=time.time(),
         )
@@ -283,6 +289,16 @@ class NamedSessionRegistry:
         ns.status = status
         self._persist()
 
+    def mark_running(self, chat_id: int, name: str, prompt: str) -> None:
+        """Mark a named session running and capture its latest prompt."""
+        ns = self._sessions.get((chat_id, name))
+        if ns is None:
+            return
+        ns.status = "running"
+        ns.prompt_preview = prompt[:60]
+        ns.last_prompt = prompt[:4000]
+        self._persist()
+
     def add(self, session: NamedSession) -> None:
         """Add a pre-built session to the registry and persist.
 
@@ -297,3 +313,19 @@ class NamedSessionRegistry:
         return {
             s.name for s in self._sessions.values() if s.chat_id == chat_id and s.status != "ended"
         }
+
+    def pop_recovered_running(self, chat_id: int | None = None) -> list[NamedSession]:
+        """Return and remove sessions that were running before the last startup."""
+        if not self._recovered_running:
+            return []
+        if chat_id is None:
+            out = list(self._recovered_running.values())
+            self._recovered_running.clear()
+            return sorted(out, key=lambda s: s.created_at)
+
+        out: list[NamedSession] = []
+        for key in list(self._recovered_running):
+            cid, _name = key
+            if cid == chat_id:
+                out.append(self._recovered_running.pop(key))
+        return sorted(out, key=lambda s: s.created_at)


### PR DESCRIPTION
## Summary
This PR hardens long-running stream behavior and restart recovery to prevent user-visible work loss.

It introduces timeout warning stages, bounded timeout extension, startup lifecycle notifications, and automatic best-effort recovery of interrupted foreground and named-session work.

## Problem
Users running long tasks were seeing streams terminate near timeout with weak recovery context. After service restart/reboot, interrupted work often required manual re-prompting, causing avoidable friction and repeated effort.

## Root Cause
Timeout handling, startup recovery, and ingress exception boundaries were implemented as separate concerns without an end-to-end reliability contract.

Specifically:
- timeout path had no staged warnings or bounded extension semantics,
- startup path did not replay all interrupted work classes,
- named sessions lacked persisted prompt context for safe resume,
- message ingress could leak transient Telegram API/network errors upward.

## Scope of Changes
### 1) `ductor_bot/cli/executor.py`
- Added dynamic timeout cap via `DUCTOR_DYNAMIC_TIMEOUT_MAX_SECONDS`.
- Added stream warning events at T-60s and T-10s:
  - `timeout_warn_60`
  - `timeout_warn_10`
- Added bounded timeout extension event:
  - `timeout_extended`
- Improved timeout completion messaging so users get actionable guidance instead of ambiguous failure signals.

### 2) `ductor_bot/bot/message_dispatch.py`
- Added user-facing message labels for:
  - `timeout_warn_60`
  - `timeout_warn_10`
  - `timeout_extended`

### 3) `ductor_bot/bot/app.py`
- Added startup lifecycle detection and broadcast:
  - service started
  - service restarted
  - reboot detected
- Added persistent foreground in-flight turn tracking and startup replay.
- Added startup auto-resume for named sessions interrupted before restart.
- Added defensive exception handling in `_on_message` for `TelegramAPIError` and generic unexpected exceptions.

### 4) `ductor_bot/session/named.py`
- Added `last_prompt` persistence for named sessions.
- Added recovered-running session bookkeeping across startup.
- Added helper APIs:
  - `mark_running(...)`
  - `pop_recovered_running(...)`

### 5) `ductor_bot/orchestrator/core.py`
- Updated named-session flow to persist latest prompt via `mark_running(...)`.
- Added recovery accessor plumbing via `pop_recovered_named_sessions(...)`.

## Behavior Changes (User-visible)
- Stream now shows pre-timeout warning signals before hard timeout.
- Long-running tasks may continue via bounded extension (config-driven).
- On startup, users receive explicit lifecycle status (start/restart/reboot).
- Interrupted work is resumed automatically when recovery context is available.

## Risk / Compatibility
- Timeout extension is bounded and configurable; it does not create unbounded execution.
- Recovery is best-effort with safety limits to avoid replay loops.
- Existing workflows remain compatible; this is reliability hardening, not a workflow rewrite.

## Validation
- ✅ `python3 -m py_compile` passed for all modified files.
- ✅ Runtime logs confirmed timeout warnings/extensions and startup recovery pathways.
- ⚠️ Full `pytest` suite was not executed in this environment (`pytest` not installed).

## Operational Notes
- To enable/adjust max extension cap, set:
  - `DUCTOR_DYNAMIC_TIMEOUT_MAX_SECONDS=<seconds>`
- Recommended to keep cap finite and aligned with operational limits.

## Checklist
- [x] Root cause identified and documented
- [x] User-visible reliability gaps addressed
- [x] Startup recovery implemented for foreground + named sessions
- [x] Timeout UX improved with warnings and extension signal
- [x] Defensive ingress exception handling added
- [x] Validation run in target runtime

Closes #19
