### PR TITLE
fix: propagate internal API startup failures

### DIFF
--- a/ductor_bot/multiagent/internal_api.py
+++ b/ductor_bot/multiagent/internal_api.py
@@ -59,19 +59,29 @@ class InternalAgentAPI:
     def port(self) -> int:
         return self._port
 
-    async def start(self) -> None:
-        """Start the internal API server."""
+    async def start(self) -> bool:
+        """Start the internal API server.
+
+        Returns:
+            True when the listener is active, False when bind/start fails.
+        """
         self._runner = web.AppRunner(self._app, access_log=None)
         await self._runner.setup()
         try:
             site = web.TCPSite(self._runner, self._bind_host, self._port)
             await site.start()
-            logger.info("Internal agent API listening on %s:%d", self._bind_host, self._port)
         except OSError:
             logger.exception(
                 "Failed to start internal agent API on port %d",
                 self._port,
             )
+            # Best effort cleanup so callers can safely retry/start-stop.
+            await self._runner.cleanup()
+            self._runner = None
+            return False
+        else:
+            logger.info("Internal agent API listening on %s:%d", self._bind_host, self._port)
+            return True
 
     async def stop(self) -> None:
         """Stop the internal API server."""

--- a/ductor_bot/multiagent/supervisor.py
+++ b/ductor_bot/multiagent/supervisor.py
@@ -79,7 +79,10 @@ class AgentSupervisor:
             self._bus, docker_mode=self._main_config.docker.enabled
         )
         self._internal_api.set_health_ref(self._health)
-        await self._internal_api.start()
+        started = await self._internal_api.start()
+        if not started:
+            msg = "Internal agent API failed to start"
+            raise RuntimeError(msg)
         logger.info("InterAgentBus and internal API started")
 
         # 1. Start main agent

--- a/tests/multiagent/test_internal_api.py
+++ b/tests/multiagent/test_internal_api.py
@@ -240,3 +240,19 @@ class TestHandleHealth:
         assert data["agents"]["sub1"]["status"] == "crashed"
         assert data["agents"]["sub1"]["last_crash_error"] == "OOM"
         assert data["agents"]["sub1"]["restart_count"] == 1
+
+
+class TestLifecycle:
+    """Test InternalAgentAPI lifecycle return values."""
+
+    async def test_start_returns_false_on_bind_error(self, api: InternalAgentAPI) -> None:
+        from unittest.mock import patch
+
+        with patch(
+            "aiohttp.web.TCPSite.start",
+            new_callable=AsyncMock,
+            side_effect=OSError("bind failed"),
+        ):
+            started = await api.start()
+
+        assert started is False

--- a/tests/multiagent/test_supervisor.py
+++ b/tests/multiagent/test_supervisor.py
@@ -46,6 +46,25 @@ class TestSupervisorInit:
         assert supervisor._agents_path == tmp_path / "agents.json"
 
 
+class TestStartupFailures:
+    """Test startup error propagation."""
+
+    async def test_internal_api_start_failure_is_propagated(
+        self,
+        supervisor: AgentSupervisor,
+    ) -> None:
+        with (
+            patch(
+                "ductor_bot.multiagent.internal_api.InternalAgentAPI.start",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("ductor_bot.multiagent.supervisor.AgentStack.create", new_callable=AsyncMock),
+            pytest.raises(RuntimeError, match="Internal agent API failed to start"),
+        ):
+            await supervisor.start()
+
+
 class TestStopAgent:
     """Test stop_agent() behavior."""
 


### PR DESCRIPTION
## Summary
- Propagate internal API startup failures to supervisor startup instead of only logging them.
- Make `InternalAgentAPI.start()` return a success flag and clean up runner state on bind/start errors.
- Make `AgentSupervisor.start()` fail fast with a clear `RuntimeError` when the internal API does not start.
- Add regression tests for both internal API lifecycle behavior and supervisor failure propagation.

## Problem
If the internal HTTP API failed to bind (for example due to a port conflict), the failure was logged but not surfaced to startup orchestration. The supervisor continued booting and reported startup progress even though a required internal control plane was unavailable.

That creates a partial-start state where follow-up failures happen later and are harder to diagnose, instead of failing immediately at startup with a direct cause.

## Root Cause
- `InternalAgentAPI.start()` had a `None` return contract and swallowed `OSError` after logging.
- `AgentSupervisor.start()` unconditionally assumed internal API startup succeeded.
- There was no explicit startup contract that allowed the supervisor to gate boot progression on internal API readiness.

## Scope of Changes
- `ductor_bot/multiagent/internal_api.py`
  - Change `start()` return type from `None` to `bool`.
  - Return `True` on successful listener start.
  - On `OSError`, log exception, perform runner cleanup, reset runner handle, and return `False`.
- `ductor_bot/multiagent/supervisor.py`
  - Check the return value of `self._internal_api.start()`.
  - Raise `RuntimeError("Internal agent API failed to start")` when startup fails.
- `tests/multiagent/test_internal_api.py`
  - Add `TestLifecycle.test_start_returns_false_on_bind_error`.
- `tests/multiagent/test_supervisor.py`
  - Add `TestStartupFailures.test_internal_api_start_failure_is_propagated`.

## Verification
- `python3.11 -m pytest -q tests/multiagent/test_internal_api.py tests/multiagent/test_supervisor.py` ✅
- `python3.11 -m ruff format . --check` ✅
- `python3.11 -m ruff check .` ✅
- `python3.11 -m mypy ductor_bot` ✅

Note: `python3.11 -m pytest` (full suite) has pre-existing failures in this environment unrelated to this change (e.g., missing `claude` CLI and existing workspace-dependent tests).
