### PR TITLE
fix: preserve session on CLI timeout for auto-resume

### DIFF
--- a/ductor_bot/cli/executor.py
+++ b/ductor_bot/cli/executor.py
@@ -151,8 +151,13 @@ async def run_streaming_subprocess(
     except TimeoutError:
         force_kill_process_tree(process.pid)
         await process.wait()
-        logger.warning("%s stream timed out after %.0fs", provider_label, spec.timeout_seconds)
-        yield ResultEvent(type="result", result="", is_error=True)
+        timeout_s = spec.timeout_seconds or 0
+        logger.warning("%s stream timed out after %.0fs", provider_label, timeout_s)
+        yield ResultEvent(
+            type="result",
+            result=f"__TIMEOUT__{int(timeout_s)}",
+            is_error=True,
+        )
         return
     finally:
         await _cancel_drain(stderr_drain)

--- a/ductor_bot/cli/service.py
+++ b/ductor_bot/cli/service.py
@@ -19,6 +19,7 @@ from ductor_bot.cli.stream_events import (
     CompactBoundaryEvent,
     ResultEvent,
     StreamEvent,
+    SystemInitEvent,
     SystemStatusEvent,
     ThinkingEvent,
     ToolUseEvent,
@@ -45,9 +46,13 @@ class _StreamCallbacks:
         self._on_text = on_text
         self._on_tool = on_tool
         self._on_status = on_status
+        self.init_session_id: str | None = None
 
     async def dispatch(self, event: StreamEvent) -> tuple[str, ResultEvent | None]:
         """Handle one event. Returns (accumulated_text_chunk, result_or_none)."""
+        if isinstance(event, SystemInitEvent) and event.session_id:
+            self.init_session_id = event.session_id
+            return "", None
         if isinstance(event, AssistantTextDelta) and event.text:
             if self._on_text is not None:
                 await self._on_text(event.text)
@@ -213,17 +218,28 @@ class CLIService:
                 request,
                 accumulated_text,
                 stream_error=stream_error,
+                init_session_id=callbacks.init_session_id,
             )
 
+        # Carry forward session_id from SystemInitEvent when the ResultEvent
+        # lacks one (e.g. timeout kill before final event).
+        if not result_event.session_id and callbacks.init_session_id:
+            result_event.session_id = callbacks.init_session_id
+
+        # Detect timeout marker from executor.
+        timed_out = (result_event.result or "").startswith("__TIMEOUT__")
+
         logger.info(
-            "CLI streaming completed label=%s fallback=%s",
+            "CLI streaming completed label=%s fallback=%s timed_out=%s",
             request.process_label,
             stream_error,
+            timed_out,
         )
         cli_resp = CLIResponse(
             session_id=result_event.session_id,
-            result=result_event.result or accumulated_text,
+            result="" if timed_out else (result_event.result or accumulated_text),
             is_error=result_event.is_error,
+            timed_out=timed_out,
             returncode=result_event.returncode,
             duration_ms=result_event.duration_ms,
             duration_api_ms=result_event.duration_api_ms,
@@ -240,13 +256,15 @@ class CLIService:
         accumulated_text: str,
         *,
         stream_error: bool,
+        init_session_id: str | None = None,
     ) -> AgentResponse:
         """Handle failed or incomplete streaming: use accumulated text or retry."""
         was_aborted = self._process_registry.was_aborted(request.chat_id)
         logger.info(
-            "Stream fallback: aborted=%s accumulated=%d",
+            "Stream fallback: aborted=%s accumulated=%d init_sid=%s",
             was_aborted,
             len(accumulated_text),
+            (init_session_id or "?")[:8],
         )
 
         if was_aborted:
@@ -257,7 +275,7 @@ class CLIService:
                 "Stream completed without ResultEvent, using %d chars",
                 len(accumulated_text),
             )
-            return AgentResponse(result=accumulated_text)
+            return AgentResponse(result=accumulated_text, session_id=init_session_id)
 
         logger.warning(
             "Streaming failed error=%s accumulated=%d chars, retrying non-streaming",

--- a/ductor_bot/orchestrator/flows.py
+++ b/ductor_bot/orchestrator/flows.py
@@ -19,7 +19,7 @@ from ductor_bot.log_context import set_log_context
 from ductor_bot.orchestrator.hooks import HookContext
 from ductor_bot.orchestrator.registry import OrchestratorResult
 from ductor_bot.session import SessionData, SessionKey
-from ductor_bot.text.response_format import session_error_text
+from ductor_bot.text.response_format import session_error_text, timeout_error_text
 from ductor_bot.workspace.loader import read_mainmemory
 
 if TYPE_CHECKING:
@@ -153,6 +153,37 @@ async def _reset_on_error(
     return OrchestratorResult(
         text=session_error_text(model_name, cli_detail),
     )
+
+
+async def _handle_timeout(
+    orch: Orchestrator,
+    key: SessionKey,
+    session: SessionData,
+    response: AgentResponse,
+    request: AgentRequest,
+) -> OrchestratorResult:
+    """Preserve session after timeout and return a clear user-facing message.
+
+    Unlike ``_reset_on_error``, this persists the session_id from the response
+    so that the next user message can ``--resume`` the timed-out session.
+    """
+    model_name, _provider_name = _request_target(orch, request)
+    await orch._process_registry.kill_all(key.chat_id)
+
+    # Persist the session_id captured from SystemInitEvent so resume works.
+    if response.session_id and response.session_id != session.session_id:
+        logger.info(
+            "Timeout: preserving session_id %s for resume",
+            response.session_id[:8],
+        )
+        session.session_id = response.session_id
+    await orch._sessions.update_session(
+        session, cost_usd=response.cost_usd, tokens=response.total_tokens
+    )
+
+    timeout_s = request.timeout_seconds or 0
+    logger.warning("Session timed out after %.0fs model=%s", timeout_s, model_name)
+    return OrchestratorResult(text=timeout_error_text(model_name, timeout_s))
 
 
 _SIGKILL_USER_MSG = "Execution was interrupted. Please send the same request again."
@@ -320,6 +351,8 @@ async def normal(
         if orch._process_registry.was_aborted(key.chat_id):
             logger.info("Normal flow aborted by user")
             return OrchestratorResult(text="")
+        if response.timed_out:
+            return await _handle_timeout(orch, key, session, response, request)
         if response.is_error:
             if _is_sigkill(response):
                 logger.warning("recovery.sigkill chat=%s action=user-retry", key.chat_id)
@@ -378,6 +411,8 @@ async def normal_streaming(
         if orch._process_registry.was_aborted(key.chat_id):
             logger.info("Streaming flow aborted by user")
             return OrchestratorResult(text="")
+        if response.timed_out:
+            return await _handle_timeout(orch, key, session, response, request)
         if response.is_error:
             if _is_sigkill(response):
                 logger.warning("recovery.sigkill chat=%s action=user-retry", key.chat_id)

--- a/ductor_bot/text/response_format.py
+++ b/ductor_bot/text/response_format.py
@@ -109,6 +109,21 @@ def timeout_result_text(elapsed: float, configured: float) -> str:
     )
 
 
+TIMEOUT_ERROR_TEXT = fmt(
+    "**Timeout**",
+    SEP,
+    "[{model}] CLI was terminated after {minutes} min.\n"
+    "Your session has been preserved -- send another message to continue where it left off.\n"
+    "Use /new to start a fresh session.",
+)
+
+
+def timeout_error_text(model: str, timeout_seconds: float) -> str:
+    """Build the error message shown when the CLI times out (session preserved)."""
+    minutes = int(timeout_seconds / 60)
+    return TIMEOUT_ERROR_TEXT.format(model=model, minutes=minutes)
+
+
 # -- Startup lifecycle messages --
 
 

--- a/tests/orchestrator/test_flows.py
+++ b/tests/orchestrator/test_flows.py
@@ -116,7 +116,8 @@ async def test_normal_timeout_preserves_session(orch: Orchestrator) -> None:
     object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Hello")
-    assert "Session Error" in result.text
+    assert "Timeout" in result.text
+    assert "session has been preserved" in result.text
     assert mock_execute.call_count == 1
 
 


### PR DESCRIPTION
## Summary

- When the CLI times out mid-execution, the session ID was previously lost (especially for new sessions where the `ResultEvent` never arrives), causing the next message to start a fresh session without context
- Captures `session_id` from `SystemInitEvent` during streaming so it survives a timeout kill
- Adds a dedicated `_handle_timeout()` flow that persists the session for auto-resume
- Shows a clear user-facing message explaining the timeout and that the session is preserved

## Changes

- **executor.py**: `__TIMEOUT__` marker in `ResultEvent.result` for reliable timeout detection
- **service.py**: Capture `SystemInitEvent.session_id` in `_StreamCallbacks`, detect timeout marker, set `timed_out` on `CLIResponse`, carry forward `init_session_id` in fallback path
- **flows.py**: `_handle_timeout()` preserves session + `timed_out` checks in `normal()` and `normal_streaming()`
- **response_format.py**: `timeout_error_text()` with session-preserved messaging

## Context

This is complementary to the `TimeoutController` in v0.11.0 which handles timeout *prevention* (warnings, activity-based extensions). This PR handles timeout *recovery* — what happens when the timeout actually fires despite the controller's best efforts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)