### PR TITLE
feat: add --summary flag to async inter-agent communication

### DIFF
--- a/ductor_bot/_home_defaults/workspace/tools/agent_tools/ask_agent_async.py
+++ b/ductor_bot/_home_defaults/workspace/tools/agent_tools/ask_agent_async.py
@@ -13,12 +13,14 @@ Environment variables DUCTOR_AGENT_NAME, DUCTOR_INTERAGENT_PORT, and
 DUCTOR_INTERAGENT_HOST are automatically set by the Ductor framework.
 
 Usage:
-    python3 ask_agent_async.py [--new] TARGET_AGENT "Your message here"
+    python3 ask_agent_async.py [--new] [--summary "Short description"] TARGET_AGENT "Your message here"
 
 Options:
-    --new   Start a fresh session, discarding any prior inter-agent context
-            with the recipient. Without this flag, the recipient resumes
-            the existing session (if any).
+    --new                Start a fresh session, discarding any prior inter-agent context
+                         with the recipient. Without this flag, the recipient resumes
+                         the existing session (if any).
+    --summary "text"     Short description shown in the recipient's Telegram chat
+                         notification instead of a truncated message excerpt.
 """
 
 from __future__ import annotations
@@ -33,12 +35,27 @@ import urllib.request
 def main() -> None:
     args = sys.argv[1:]
     new_session = False
-    if args and args[0] == "--new":
-        new_session = True
-        args = args[1:]
+    summary = ""
+
+    # Parse flags
+    while args:
+        if args[0] == "--new":
+            new_session = True
+            args = args[1:]
+        elif args[0] == "--summary":
+            if len(args) < 2:
+                print("Error: --summary requires a value", file=sys.stderr)
+                sys.exit(1)
+            summary = args[1]
+            args = args[2:]
+        else:
+            break
 
     if len(args) < 2:
-        print('Usage: python3 ask_agent_async.py [--new] TARGET_AGENT "message"', file=sys.stderr)
+        print(
+            'Usage: python3 ask_agent_async.py [--new] [--summary "desc"] TARGET_AGENT "message"',
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     target = args[0]
@@ -51,6 +68,8 @@ def main() -> None:
     body: dict[str, object] = {"from": sender, "to": target, "message": message}
     if new_session:
         body["new_session"] = True
+    if summary:
+        body["summary"] = summary
     payload = json.dumps(body).encode()
 
     req = urllib.request.Request(

--- a/ductor_bot/multiagent/bus.py
+++ b/ductor_bot/multiagent/bus.py
@@ -49,6 +49,7 @@ class AsyncInterAgentTask:
     recipient: str
     message: str
     new_session: bool = False
+    summary: str = ""
     timestamp: float = field(default_factory=time.time)
     asyncio_task: asyncio.Task[None] | None = field(default=None, repr=False)
 
@@ -193,6 +194,7 @@ class InterAgentBus:
         message: str,
         *,
         new_session: bool = False,
+        summary: str = "",
     ) -> str | None:
         """Send a message to another agent asynchronously.
 
@@ -202,6 +204,9 @@ class InterAgentBus:
 
         If *new_session* is True, the recipient agent will end any existing
         inter-agent session with this sender and start a fresh one.
+
+        If *summary* is provided, it is shown as the notification preview in
+        the recipient's Telegram chat instead of a truncated message excerpt.
         """
         if recipient not in self._agents:
             return None
@@ -213,6 +218,7 @@ class InterAgentBus:
             recipient=recipient,
             message=message,
             new_session=new_session,
+            summary=summary,
         )
         atask = asyncio.create_task(
             self._run_async(task),
@@ -346,8 +352,11 @@ class InterAgentBus:
             if not chat_id:
                 return
 
-            # Truncate long messages for the preview
-            preview = task.message if len(task.message) <= 200 else task.message[:200] + "…"
+            # Use explicit summary if provided, otherwise truncate message
+            if task.summary:
+                preview = task.summary
+            else:
+                preview = task.message if len(task.message) <= 200 else task.message[:200] + "…"
             session_name = f"ia-{task.sender}"
             text = (
                 f"📥 **Async task received** from `{task.sender}`\n"

--- a/ductor_bot/multiagent/internal_api.py
+++ b/ductor_bot/multiagent/internal_api.py
@@ -131,6 +131,7 @@ class InternalAgentAPI:
         recipient = data.get("to", "")
         message = data.get("message", "")
         new_session = bool(data.get("new_session", False))
+        summary = str(data.get("summary", ""))
 
         if not recipient or not message:
             return web.json_response(
@@ -150,6 +151,7 @@ class InternalAgentAPI:
             recipient=recipient,
             message=message,
             new_session=new_session,
+            summary=summary,
         )
         if task_id is None:
             return web.json_response(


### PR DESCRIPTION
## Summary

- Adds a `--summary` flag to `ask_agent_async.py` that lets the sender provide a short human-readable description for the recipient's Telegram notification
- Without `--summary`, the notification shows a truncated (200 char) excerpt of the full message — with the flag, the sender controls exactly what preview text is shown
- Passes `summary` through the full stack: CLI tool → internal API (`/interagent/send_async`) → `InterAgentBus.send_async()` → `AsyncInterAgentTask` dataclass → `_notify_recipient()`

## Changed files

| File | Change |
|------|--------|
| `ask_agent_async.py` | Flag parsing (`--new` and `--summary` in any order), updated usage docs |
| `bus.py` | `summary` field on `AsyncInterAgentTask`, `send_async()` parameter, preview logic in `_notify_recipient()` |
| `internal_api.py` | Extract `summary` from request body and pass to bus |

## Example

```bash
# With summary — recipient sees "Audit Python packages" in notification
python3 ask_agent_async.py --summary "Audit Python packages" researcher "Scan all packages for CVEs..."

# Without summary — recipient sees truncated message (existing behavior)
python3 ask_agent_async.py researcher "Scan all packages for CVEs..."
```

## Backward compatibility

Fully backward compatible — existing calls without `--summary` continue to use the truncated message preview.

## Test plan

- [ ] Verify `--summary` flag is parsed correctly (with and without `--new`)
- [ ] Verify summary is passed through to `_notify_recipient()` and shown in Telegram notification
- [ ] Verify empty/missing summary falls back to truncated message preview
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)