### PR TITLE
[Feature]: Improve cron job support and UX for Codex `gpt-5.4`

### DIFF
--- a/ductor_bot/_home_defaults/workspace/cron_tasks/RULES-all-clis.md
+++ b/ductor_bot/_home_defaults/workspace/cron_tasks/RULES-all-clis.md
@@ -12,13 +12,12 @@ For cron tool commands (add/edit/remove/list), see `tools/cron_tools/CLAUDE.md`.
 
 2. **Which model?** (`--model <name>`)
    - Claude models: `haiku`, `sonnet`, `opus`
-   - Codex models: `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1-codex-mini`
+   - Codex models: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2`
    - Gemini models: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-3.1-pro-preview`
    - Default if user doesn't specify: Use global config model
 
 3. **If Codex provider: Which thinking level?** (`--reasoning-effort <level>`)
    - Options: `low`, `medium`, `high`, `xhigh`
-   - Note: `gpt-5.1-codex-mini` only supports `medium` and `high`
    - Default if user doesn't specify: `medium` (model default)
 
 **YOU MUST present these options to the user and wait for their answers BEFORE calling cron_add.py!**
@@ -40,7 +39,7 @@ You: "I'll create a cron job to check weather every 3 minutes. Let me configure 
 
 2. **Model**: Which model?
    - If Claude: `haiku` (fast), `sonnet` (balanced), `opus` (most capable)
-   - If Codex: `gpt-5.2-codex` (recommended), `gpt-5.3-codex`, `gpt-5.1-codex-max`, etc.
+   - If Codex: `gpt-5.4` (recommended), `gpt-5.4-mini`, `gpt-5.3-codex`, etc.
    - If Gemini: `gemini-2.5-pro` (recommended), `gemini-2.5-flash`, `gemini-2.5-flash-lite`, etc.
 
 3. **Thinking level** (Codex only): How deeply should it reason?
@@ -87,11 +86,10 @@ Each cron task can override global config settings in `cron_jobs.json`:
 - `model`: Model name (optional, defaults to global config)
   - Claude models: `"haiku"`, `"sonnet"`, `"opus"`
   - Codex models:
-    - `"gpt-5.2-codex"` - Frontier agentic coding model
-    - `"gpt-5.3-codex"` - Latest frontier agentic coding model
-    - `"gpt-5.1-codex-max"` - Codex-optimized for deep and fast reasoning
-    - `"gpt-5.2"` - Latest frontier model
-    - `"gpt-5.1-codex-mini"` - Cheaper, faster (limited reasoning)
+    - `"gpt-5.4"` - Latest frontier agentic coding model
+    - `"gpt-5.4-mini"` - Smaller, faster frontier coding model
+    - `"gpt-5.3-codex"` - Frontier Codex-optimized coding model
+    - `"gpt-5.2"` - Optimized for long-running agent work
   - Gemini models:
     - `"gemini-2.5-pro"` - Balanced, most capable
     - `"gemini-2.5-flash"` - Fast and cost-effective
@@ -100,8 +98,7 @@ Each cron task can override global config settings in `cron_jobs.json`:
     - `"gemini-3-flash-preview"` - Next-gen fast preview
     - `"gemini-3.1-pro-preview"` - Latest preview
 - `reasoning_effort`: Thinking level (Codex only, optional, defaults to `"medium"`)
-  - Most models: `"low"`, `"medium"`, `"high"`, `"xhigh"`
-  - `gpt-5.1-codex-mini`: `"medium"`, `"high"` only
+  - Typical values: `"low"`, `"medium"`, `"high"`, `"xhigh"`
 - `cli_parameters`: List of additional CLI flags (optional, advanced users only)
 
 **Fallback behavior:**
@@ -131,7 +128,7 @@ Codex task:
   "task_folder": "analyzer",
   "agent_instruction": "Analyze daily data with extended thinking",
   "provider": "codex",
-  "model": "gpt-5.2-codex",
+  "model": "gpt-5.4",
   "reasoning_effort": "high"
 }
 ```

--- a/ductor_bot/_home_defaults/workspace/cron_tasks/RULES-codex-only.md
+++ b/ductor_bot/_home_defaults/workspace/cron_tasks/RULES-codex-only.md
@@ -8,12 +8,11 @@ For cron tool commands (add/edit/remove/list), see `tools/cron_tools/CLAUDE.md`.
 **CRITICAL: When creating a new cron job, you MUST ALWAYS ask the user these questions:**
 
 1. **Which model?** (`--model <name>`)
-   - Options: `gpt-5.2-codex` (recommended), `gpt-5.3-codex`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1-codex-mini`
+   - Options: `gpt-5.4` (recommended), `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2`
    - Default if user doesn't specify: Use global config model
 
 2. **Which thinking level?** (`--reasoning-effort <level>`)
    - Options: `low`, `medium` (default), `high`, `xhigh`
-   - Note: `gpt-5.1-codex-mini` only supports `medium` and `high`
    - Default if user doesn't specify: `medium` (model default)
 
 **YOU MUST present these options to the user and wait for their answers BEFORE calling cron_add.py!**
@@ -29,11 +28,10 @@ User: "Create a cron job to analyze data every hour"
 You: "I'll create a cron job to analyze data every hour. Let me configure the execution:
 
 1. **Model**: Which Codex model?
-   - `gpt-5.2-codex` (recommended, balanced performance)
-   - `gpt-5.3-codex` (latest, most capable)
-   - `gpt-5.1-codex-max` (optimized for deep reasoning)
-   - `gpt-5.2` (latest frontier model)
-   - `gpt-5.1-codex-mini` (faster, cheaper, limited reasoning)
+   - `gpt-5.4` (recommended, most capable)
+   - `gpt-5.4-mini` (faster, cheaper)
+   - `gpt-5.3-codex` (Codex-optimized)
+   - `gpt-5.2` (good for long-running agent work)
 
 2. **Thinking level**: How deeply should it reason?
    - `low` (fast, surface-level)
@@ -78,14 +76,12 @@ Each cron task can override global config settings in `cron_jobs.json`:
 
 - `model`: Model name (optional, defaults to global config)
   - Available models:
-    - `"gpt-5.2-codex"` - Frontier agentic coding model
-    - `"gpt-5.3-codex"` - Latest frontier agentic coding model
-    - `"gpt-5.1-codex-max"` - Codex-optimized for deep and fast reasoning
-    - `"gpt-5.2"` - Latest frontier model
-    - `"gpt-5.1-codex-mini"` - Cheaper, faster (limited reasoning)
+    - `"gpt-5.4"` - Latest frontier agentic coding model
+    - `"gpt-5.4-mini"` - Smaller, faster frontier coding model
+    - `"gpt-5.3-codex"` - Frontier Codex-optimized coding model
+    - `"gpt-5.2"` - Optimized for long-running agent work
 - `reasoning_effort`: Thinking level (optional, defaults to `"medium"`)
-  - Most models: `"low"`, `"medium"`, `"high"`, `"xhigh"`
-  - `gpt-5.1-codex-mini`: `"medium"`, `"high"` only
+  - Typical values: `"low"`, `"medium"`, `"high"`, `"xhigh"`
 - `cli_parameters`: List of additional CLI flags (optional, advanced users only)
 
 **Fallback behavior:**
@@ -100,12 +96,12 @@ Each cron task can override global config settings in `cron_jobs.json`:
   "schedule": "0 8 * * *",
   "task_folder": "analyzer",
   "agent_instruction": "Analyze daily data with extended thinking",
-  "model": "gpt-5.2-codex",
+  "model": "gpt-5.4",
   "reasoning_effort": "high"
 }
 ```
 
 **Use cases:**
 - High-reasoning analysis: `"reasoning_effort": "high"`
-- Fast iteration with mini: `"model": "gpt-5.1-codex-mini"`, `"reasoning_effort": "medium"`
+- Fast iteration with mini: `"model": "gpt-5.4-mini"`, `"reasoning_effort": "medium"`
 - Advanced CLI flags: `"cli_parameters": [...]` (only if user explicitly requests)

--- a/ductor_bot/_home_defaults/workspace/tools/cron_tools/RULES-all-clis.md
+++ b/ductor_bot/_home_defaults/workspace/tools/cron_tools/RULES-all-clis.md
@@ -17,11 +17,10 @@ Scripts for creating, editing, listing, and removing scheduled jobs.
      - `sonnet` - Balanced performance (recommended)
      - `opus` - Most capable, highest quality
    - **If Codex:**
-     - `gpt-5.2-codex` - Frontier agentic coding model (recommended)
-     - `gpt-5.3-codex` - Latest frontier agentic coding model
-     - `gpt-5.1-codex-max` - Optimized for deep and fast reasoning
-     - `gpt-5.2` - Latest frontier model
-     - `gpt-5.1-codex-mini` - Cheaper, faster (limited reasoning)
+     - `gpt-5.4` - Latest frontier agentic coding model (recommended)
+     - `gpt-5.4-mini` - Smaller, faster frontier coding model
+     - `gpt-5.3-codex` - Frontier Codex-optimized coding model
+     - `gpt-5.2` - Optimized for long-running agent work
    - **If Gemini:**
      - `gemini-2.5-pro` - Balanced, most capable (recommended)
      - `gemini-2.5-flash` - Fast and cost-effective
@@ -35,7 +34,7 @@ Scripts for creating, editing, listing, and removing scheduled jobs.
    - `medium` - Balanced (default)
    - `high` - Extended thinking
    - `xhigh` - Maximum reasoning depth
-   - Note: `gpt-5.1-codex-mini` only supports `medium` and `high`
+   - Most current Codex models support `low`, `medium`, `high`, `xhigh`
 
 4. **Should this job respect quiet hours?**
    - Ask: "Should this job skip execution during specific hours (e.g., at night)?"
@@ -93,7 +92,7 @@ python3 tools/cron_tools/cron_add.py \
   --description "What this job does" \
   --schedule "0 9 * * *" \
   --provider codex \
-  --model gpt-5.2-codex \
+  --model gpt-5.4 \
   --reasoning-effort high
 
 # Gemini example:

--- a/ductor_bot/_home_defaults/workspace/tools/cron_tools/RULES-codex-only.md
+++ b/ductor_bot/_home_defaults/workspace/tools/cron_tools/RULES-codex-only.md
@@ -7,18 +7,17 @@ Scripts for creating, editing, listing, and removing scheduled jobs.
 **When the user requests a new cron job, you MUST ask:**
 
 1. **Which model?**
-   - `gpt-5.2-codex` - Frontier agentic coding model (recommended)
-   - `gpt-5.3-codex` - Latest frontier agentic coding model
-   - `gpt-5.1-codex-max` - Optimized for deep and fast reasoning
-   - `gpt-5.2` - Latest frontier model
-   - `gpt-5.1-codex-mini` - Cheaper, faster (limited reasoning)
+   - `gpt-5.4` - Latest frontier agentic coding model (recommended)
+   - `gpt-5.4-mini` - Smaller, faster frontier coding model
+   - `gpt-5.3-codex` - Frontier Codex-optimized coding model
+   - `gpt-5.2` - Optimized for long-running agent work
 
 2. **Which thinking level?**
    - `low` - Fast, surface-level reasoning
    - `medium` - Balanced (default)
    - `high` - Extended thinking
    - `xhigh` - Maximum reasoning depth
-   - Note: `gpt-5.1-codex-mini` only supports `medium` and `high`
+   - Most current Codex models support `low`, `medium`, `high`, `xhigh`
 
 3. **Should this job respect quiet hours?**
    - Ask: "Should this job skip execution during specific hours (e.g., at night)?"
@@ -66,7 +65,7 @@ python3 tools/cron_tools/cron_add.py \
   --title "Job Title" \
   --description "What this job does" \
   --schedule "0 9 * * *" \
-  --model gpt-5.2-codex \
+  --model gpt-5.4 \
   --reasoning-effort high
 ```
 
@@ -86,7 +85,7 @@ python3 tools/cron_tools/cron_list.py
 ```bash
 python3 tools/cron_tools/cron_edit.py "exact-job-id" --schedule "30 8 * * *"
 python3 tools/cron_tools/cron_edit.py "exact-job-id" --timezone "Europe/Berlin"
-python3 tools/cron_tools/cron_edit.py "exact-job-id" --model gpt-5.3-codex
+python3 tools/cron_tools/cron_edit.py "exact-job-id" --model gpt-5.4
 python3 tools/cron_tools/cron_edit.py "exact-job-id" --reasoning-effort xhigh
 python3 tools/cron_tools/cron_edit.py "exact-job-id" --enable
 python3 tools/cron_tools/cron_edit.py "exact-job-id" --disable

--- a/ductor_bot/_home_defaults/workspace/tools/cron_tools/cron_add.py
+++ b/ductor_bot/_home_defaults/workspace/tools/cron_tools/cron_add.py
@@ -57,7 +57,7 @@ OPTIONAL:
 
 EXECUTION OVERRIDES (optional, override global config for this specific job):
   --provider          CLI provider: 'claude', 'codex', or 'gemini' (defaults to global config)
-  --model             Model name (e.g. 'opus', 'sonnet', 'gpt-5.2-codex')
+  --model             Model name (e.g. 'opus', 'sonnet', 'gpt-5.4')
   --reasoning-effort  Thinking level for Codex: 'low', 'medium', 'high', 'xhigh'
   --cli-parameters    Additional CLI flags as JSON array (e.g. '["--chrome"]' for Claude only)
 
@@ -115,7 +115,7 @@ Codex job with high reasoning:
       --description "Analyze data with extended thinking" \\
       --schedule "0 9 * * *" \\
       --provider codex \\
-      --model gpt-5.2-codex \\
+      --model gpt-5.4 \\
       --reasoning-effort high
 
 Claude job with browser automation:
@@ -215,7 +215,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--model",
-        help="Model name for this job (e.g. 'opus', 'sonnet', 'gpt-5.2-codex'). "
+        help="Model name for this job (e.g. 'opus', 'sonnet', 'gpt-5.4'). "
         "If omitted, uses global config.",
     )
     parser.add_argument(

--- a/ductor_bot/_home_defaults/workspace/tools/cron_tools/cron_edit.py
+++ b/ductor_bot/_home_defaults/workspace/tools/cron_tools/cron_edit.py
@@ -43,9 +43,17 @@ CHANGES:
   --description "<text>"     Update metadata description
   --schedule "<cron-expr>"   Update execution schedule
   --timezone "<iana>"        Set per-job timezone override (e.g. 'Europe/Berlin')
+  --provider "<name>"        Set provider override ('claude', 'codex', 'gemini')
+  --model "<model-id>"       Set model override (e.g. 'opus', 'gpt-5.4')
+  --reasoning-effort <lvl>   Set Codex thinking level (low, medium, high, xhigh)
+  --cli-parameters "<json>"  Set extra CLI flags as JSON array
   --quiet-start <hour>       Start of quiet hours (0-23, job won't run during this time)
   --quiet-end <hour>         End of quiet hours (0-23, exclusive)
   --dependency "<name>"      Resource dependency for sequential execution (e.g. 'chrome_browser')
+  --clear-provider           Remove provider override (use global config)
+  --clear-model              Remove model override (use global config)
+  --clear-reasoning-effort   Remove reasoning override (use global config/model default)
+  --clear-cli-parameters     Remove job-specific CLI parameters
   --clear-quiet-hours        Remove quiet hour settings (use global config)
   --clear-dependency         Remove dependency (allow parallel execution)
   --enable                   Set enabled=true
@@ -56,6 +64,9 @@ EXAMPLES:
   python tools/cron_tools/cron_edit.py "weather-check" --title "Weather 08:30"
   python tools/cron_tools/cron_edit.py "weather-check" --name "weather-morning"
   python tools/cron_tools/cron_edit.py "weather-check" --disable
+  python tools/cron_tools/cron_edit.py "analysis-job" --provider codex --model gpt-5.4
+  python tools/cron_tools/cron_edit.py "analysis-job" --reasoning-effort xhigh
+  python tools/cron_tools/cron_edit.py "analysis-job" --cli-parameters '["--search"]'
   python tools/cron_tools/cron_edit.py "web-scraper" --quiet-start 22 --quiet-end 7
   python tools/cron_tools/cron_edit.py "web-scraper" --dependency chrome_browser
   python tools/cron_tools/cron_edit.py "web-scraper" --clear-quiet-hours
@@ -74,6 +85,24 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--description", help="New description text")
     parser.add_argument("--schedule", help="New cron expression")
     parser.add_argument("--timezone", help="IANA timezone for this job (e.g. 'Europe/Berlin')")
+    parser.add_argument(
+        "--provider",
+        choices=["claude", "codex", "gemini"],
+        help="Provider override for this job.",
+    )
+    parser.add_argument(
+        "--model",
+        help="Model override for this job (e.g. 'opus', 'gpt-5.4').",
+    )
+    parser.add_argument(
+        "--reasoning-effort",
+        choices=["low", "medium", "high", "xhigh"],
+        help="Codex thinking level override.",
+    )
+    parser.add_argument(
+        "--cli-parameters",
+        help="Additional CLI flags as JSON array (e.g. '[\"--search\"]').",
+    )
     parser.add_argument(
         "--quiet-start",
         type=int,
@@ -96,6 +125,26 @@ def _parse_args() -> argparse.Namespace:
         "--clear-quiet-hours",
         action="store_true",
         help="Remove quiet hour settings (use global config).",
+    )
+    parser.add_argument(
+        "--clear-provider",
+        action="store_true",
+        help="Remove provider override (use global config).",
+    )
+    parser.add_argument(
+        "--clear-model",
+        action="store_true",
+        help="Remove model override (use global config).",
+    )
+    parser.add_argument(
+        "--clear-reasoning-effort",
+        action="store_true",
+        help="Remove reasoning effort override (use global config/model default).",
+    )
+    parser.add_argument(
+        "--clear-cli-parameters",
+        action="store_true",
+        help="Remove job-specific CLI parameters.",
     )
     parser.add_argument(
         "--clear-dependency",
@@ -186,6 +235,36 @@ def _apply_updates(args: argparse.Namespace, job: dict[str, Any]) -> tuple[list[
             job["timezone"] = tz_val
             updated_fields.append("timezone")
 
+    if args.provider is not None and job.get("provider") != args.provider:
+        job["provider"] = args.provider
+        updated_fields.append("provider")
+
+    if args.model is not None:
+        model = args.model.strip()
+        if not model:
+            msg = "Model must not be empty"
+            raise ValueError(msg)
+        if job.get("model") != model:
+            job["model"] = model
+            updated_fields.append("model")
+
+    if args.reasoning_effort is not None and job.get("reasoning_effort") != args.reasoning_effort:
+        job["reasoning_effort"] = args.reasoning_effort
+        updated_fields.append("reasoning_effort")
+
+    if args.cli_parameters is not None:
+        try:
+            cli_params = json.loads(args.cli_parameters)
+        except json.JSONDecodeError as exc:
+            msg = f"Invalid --cli-parameters JSON: {exc}"
+            raise ValueError(msg) from exc
+        if not isinstance(cli_params, list):
+            msg = "--cli-parameters must be a JSON array"
+            raise ValueError(msg)
+        if job.get("cli_parameters") != cli_params:
+            job["cli_parameters"] = cli_params
+            updated_fields.append("cli_parameters")
+
     if args.quiet_start is not None:
         if job.get("quiet_start") != args.quiet_start:
             job["quiet_start"] = args.quiet_start
@@ -207,6 +286,22 @@ def _apply_updates(args: argparse.Namespace, job: dict[str, Any]) -> tuple[list[
             job.pop("quiet_start", None)
             job.pop("quiet_end", None)
             updated_fields.append("quiet_hours (cleared)")
+
+    if args.clear_provider and "provider" in job:
+        job.pop("provider", None)
+        updated_fields.append("provider (cleared)")
+
+    if args.clear_model and "model" in job:
+        job.pop("model", None)
+        updated_fields.append("model (cleared)")
+
+    if args.clear_reasoning_effort and "reasoning_effort" in job:
+        job.pop("reasoning_effort", None)
+        updated_fields.append("reasoning_effort (cleared)")
+
+    if args.clear_cli_parameters and "cli_parameters" in job:
+        job.pop("cli_parameters", None)
+        updated_fields.append("cli_parameters (cleared)")
 
     if args.clear_dependency:
         if "dependency" in job:
@@ -241,10 +336,18 @@ def main() -> None:
             args.description is not None,
             args.schedule is not None,
             args.timezone is not None,
+            args.provider is not None,
+            args.model is not None,
+            args.reasoning_effort is not None,
+            args.cli_parameters is not None,
             args.quiet_start is not None,
             args.quiet_end is not None,
             args.dependency is not None,
             args.clear_quiet_hours,
+            args.clear_provider,
+            args.clear_model,
+            args.clear_reasoning_effort,
+            args.clear_cli_parameters,
             args.clear_dependency,
             args.enable,
             args.disable,

--- a/ductor_bot/heartbeat/observer.py
+++ b/ductor_bot/heartbeat/observer.py
@@ -134,9 +134,7 @@ class HeartbeatObserver(BaseObserver):
                     continue
                 if not await self._validate_target(target.chat_id):
                     continue
-                prompt, ack_token, quiet_start, quiet_end = self._resolve_target_settings(
-                    target
-                )
+                prompt, ack_token, quiet_start, quiet_end = self._resolve_target_settings(target)
                 if self._is_target_quiet(target.chat_id, quiet_start, quiet_end):
                     continue
                 await self._run_for_chat(

--- a/tests/cron/test_cron_edit_tool.py
+++ b/tests/cron/test_cron_edit_tool.py
@@ -131,6 +131,92 @@ def test_cron_edit_disable_then_enable(tmp_path: Path) -> None:
     assert _job(tmp_path, "toggle-job")["enabled"] is True
 
 
+def test_cron_edit_updates_provider_model_effort_and_cli_parameters(tmp_path: Path) -> None:
+    _add_job(tmp_path, "codex-job")
+
+    result = _run(
+        tmp_path,
+        TOOL_EDIT,
+        [
+            "codex-job",
+            "--provider",
+            "codex",
+            "--model",
+            "gpt-5.4",
+            "--reasoning-effort",
+            "xhigh",
+            "--cli-parameters",
+            '["--search","--skip-git-repo-check"]',
+        ],
+    )
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    assert output["updated"] is True
+    assert "provider" in output["updated_fields"]
+    assert "model" in output["updated_fields"]
+    assert "reasoning_effort" in output["updated_fields"]
+    assert "cli_parameters" in output["updated_fields"]
+
+    job = _job(tmp_path, "codex-job")
+    assert job["provider"] == "codex"
+    assert job["model"] == "gpt-5.4"
+    assert job["reasoning_effort"] == "xhigh"
+    assert job["cli_parameters"] == ["--search", "--skip-git-repo-check"]
+
+
+def test_cron_edit_can_clear_execution_overrides(tmp_path: Path) -> None:
+    _add_job(tmp_path, "clear-job")
+    seeded = _run(
+        tmp_path,
+        TOOL_EDIT,
+        [
+            "clear-job",
+            "--provider",
+            "codex",
+            "--model",
+            "gpt-5.4",
+            "--reasoning-effort",
+            "high",
+            "--cli-parameters",
+            '["--search"]',
+        ],
+    )
+    assert seeded.returncode == 0
+
+    cleared = _run(
+        tmp_path,
+        TOOL_EDIT,
+        [
+            "clear-job",
+            "--clear-provider",
+            "--clear-model",
+            "--clear-reasoning-effort",
+            "--clear-cli-parameters",
+        ],
+    )
+    assert cleared.returncode == 0
+    output = json.loads(cleared.stdout)
+    assert "provider (cleared)" in output["updated_fields"]
+    assert "model (cleared)" in output["updated_fields"]
+    assert "reasoning_effort (cleared)" in output["updated_fields"]
+    assert "cli_parameters (cleared)" in output["updated_fields"]
+
+    job = _job(tmp_path, "clear-job")
+    assert "provider" not in job
+    assert "model" not in job
+    assert "reasoning_effort" not in job
+    assert "cli_parameters" not in job
+
+
+def test_cron_edit_rejects_invalid_cli_parameters_json(tmp_path: Path) -> None:
+    _add_job(tmp_path, "bad-json")
+
+    result = _run(tmp_path, TOOL_EDIT, ["bad-json", "--cli-parameters", '{"oops":true}'])
+    assert result.returncode == 1
+    output = json.loads(result.stdout)
+    assert "JSON array" in output["error"]
+
+
 def test_cron_edit_no_change_flags_exits_1(tmp_path: Path) -> None:
     _add_job(tmp_path, "no-change")
     result = _run(tmp_path, TOOL_EDIT, ["no-change"])


### PR DESCRIPTION
Hello, I'm Vic! **An Apache Software Foundation Contributor in apache/airflow & apache/mahout.** 🙌
I think this project is pretty cool! So I made this feature patch haha.

## Summary

This PR aligns cron job tooling and cron setup guidance with the existing Codex runtime capability for modern models, especially `gpt-5.4`.

The runtime already supports Codex cron execution through the shared task runner and model validation pipeline, but the user-facing cron tools and rule files were still biased toward older Codex model names and incomplete edit flows.

This change makes cron support for `gpt-5.4` explicit and usable end-to-end.

## What changed

### 1. Added missing cron edit functionality

`tools/cron_tools/cron_edit.py` now supports in-place execution override updates:

- `--provider`
- `--model`
- `--reasoning-effort`
- `--cli-parameters`

It also supports clearing those fields with:

- `--clear-provider`
- `--clear-model`
- `--clear-reasoning-effort`
- `--clear-cli-parameters`

This closes the gap between the tool’s documented behavior and its actual
capabilities.

### 2. Updated cron examples to use modern Codex defaults

Cron help text and examples now use `gpt-5.4` as the primary Codex example,
instead of older `gpt-5.2-codex` guidance.

### 3. Updated cron rule files for agent guidance

The cron-related rule files now recommend current Codex model choices such as:

- `gpt-5.4`
- `gpt-5.4-mini`
- `gpt-5.3-codex`
- `gpt-5.2`

This ensures agents creating or editing cron jobs stop steering users toward
stale model recommendations.

### 4. Added tests

Added coverage for:

- editing provider/model/reasoning/CLI overrides in place
- clearing those overrides
- rejecting invalid `--cli-parameters` input

## Why this is needed

Before this PR:

- cron runtime support for Codex `gpt-5.4` already existed
- cron UX made that support look missing
- `cron_edit.py` could not actually perform several edits that its own docs and
  surrounding rules implied should be possible

After this PR:

- cron jobs can be updated to `gpt-5.4` through supported tooling
- cron guidance matches runtime behavior
- users no longer need manual `cron_jobs.json` edits for normal model updates

Screenshot:

<img width="300" height="350" alt="image" src="https://github.com/user-attachments/assets/c0c0b7b3-e2af-4ba0-b8dd-e783c9db1941" />
