### PR TITLE
feat(telegram): channel whitelist + auto-leave with message

### DIFF
--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -313,6 +313,7 @@ class AgentConfig(BaseModel):
     telegram_token: str = ""
     allowed_user_ids: list[int] = Field(default_factory=list)
     allowed_group_ids: list[int] = Field(default_factory=list)
+    allowed_channel_ids: list[int] = Field(default_factory=list)
     matrix: MatrixConfig = Field(default_factory=MatrixConfig)
 
     @field_validator("gemini_api_key", mode="before")

--- a/ductor_bot/i18n/en/chat.toml
+++ b/ductor_bot/i18n/en/chat.toml
@@ -368,6 +368,7 @@ topic_reset = "New session for **{name}** ({provider})."
 
 [telegram]
 group_rejected = "This bot is not authorized for this group."
+channel_not_whitelisted = "This channel is not whitelisted, I am out."
 where_header = "**Where**"
 where_no_tracker = "Chat tracker not available."
 where_empty = "No chat activity recorded yet."

--- a/ductor_bot/messenger/telegram/app.py
+++ b/ductor_bot/messenger/telegram/app.py
@@ -203,8 +203,10 @@ class TelegramBot:
 
         allowed = set(config.allowed_user_ids)
         allowed_groups = set(config.allowed_group_ids)
+        allowed_channels = set(config.allowed_channel_ids)
         self._allowed_users = allowed
         self._allowed_groups = allowed_groups
+        self._allowed_channels = allowed_channels
         self._chat_tracker: ChatTracker | None = None  # set in _on_startup
         self._topic_names = TopicNameCache()
         self._lock_pool = lock_pool or LockPool()
@@ -367,6 +369,10 @@ class TelegramBot:
             self._allowed_groups.update(config.allowed_group_ids)
             logger.info("Auth hot-reloaded: allowed_group_ids (%d)", len(self._allowed_groups))
             self._group_audit_task = asyncio.create_task(self._fire_audit())
+        if "allowed_channel_ids" in hot:
+            self._allowed_channels.clear()
+            self._allowed_channels.update(config.allowed_channel_ids)
+            logger.info("Auth hot-reloaded: allowed_channel_ids (%d)", len(self._allowed_channels))
         if "language" in hot:
             _rebuild_commands()
             self._lang_sync_task = asyncio.create_task(self._sync_commands())
@@ -380,9 +386,17 @@ class TelegramBot:
             self._chat_tracker.record_rejected(chat_id, chat_type, title)
 
     async def _on_bot_added(self, event: ChatMemberUpdated) -> None:
-        """Bot was added to a group."""
+        """Bot was added to a group or channel."""
         chat = event.chat
-        allowed = chat.id in self._allowed_groups
+        is_channel = chat.type == "channel"
+        if is_channel:
+            allowed = chat.id in self._allowed_channels
+            reject_key = "telegram.channel_not_whitelisted"
+            chat_kind = "channel"
+        else:
+            allowed = chat.id in self._allowed_groups
+            reject_key = "telegram.group_rejected"
+            chat_kind = "group"
         if self._chat_tracker:
             self._chat_tracker.record_join(
                 chat.id,
@@ -394,13 +408,18 @@ class TelegramBot:
             with contextlib.suppress(TelegramAPIError):
                 await self._bot.send_message(
                     chat.id,
-                    t("telegram.group_rejected"),
+                    t(reject_key),
                 )
             with contextlib.suppress(TelegramAPIError):
                 await self._bot.leave_chat(chat.id)
             if self._chat_tracker:
                 self._chat_tracker.record_leave(chat.id, "auto_left")
-            logger.info("Auto-left unauthorized group chat_id=%d title=%s", chat.id, chat.title)
+            logger.info(
+                "Auto-left unauthorized %s chat_id=%d title=%s",
+                chat_kind,
+                chat.id,
+                chat.title,
+            )
             return
         await self._send_join_notification(chat.id)
 
@@ -459,7 +478,10 @@ class TelegramBot:
         for rec in self._chat_tracker.get_all():
             if rec.status != "active":
                 continue
-            if rec.chat_id in self._allowed_groups:
+            if rec.chat_type == "channel":
+                if rec.chat_id in self._allowed_channels:
+                    continue
+            elif rec.chat_id in self._allowed_groups:
                 continue
             # Not allowed — try to leave.
             try:

--- a/tests/messenger/telegram/test_channel_whitelist.py
+++ b/tests/messenger/telegram/test_channel_whitelist.py
@@ -1,0 +1,295 @@
+"""Tests for channel whitelist and auto-leave feature.
+
+Covers:
+- _on_bot_added: auto-leave non-whitelisted channels with the correct message
+- _on_bot_added: allow whitelisted channels (no leave)
+- _on_bot_added: group behaviour unchanged by channel whitelist
+- audit_groups: whitelisted channels are not evicted
+- audit_groups: non-whitelisted active channels are left
+- Config: allowed_channel_ids field defaults to empty list
+- Hot-reload: allowed_channel_ids updated in-place
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiogram.exceptions import TelegramAPIError
+from aiogram.types import ChatMemberUpdated
+
+from ductor_bot.config import AgentConfig, StreamingConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    *,
+    group_ids: list[int] | None = None,
+    channel_ids: list[int] | None = None,
+) -> AgentConfig:
+    return AgentConfig(
+        telegram_token="test:token",
+        allowed_user_ids=[100],
+        allowed_group_ids=group_ids or [],
+        allowed_channel_ids=channel_ids or [],
+        streaming=StreamingConfig(enabled=False),
+    )
+
+
+def _make_tg_bot(config: AgentConfig) -> tuple[MagicMock, MagicMock]:
+    """Return (tg_bot, mock_bot_instance)."""
+    from ductor_bot.messenger.telegram.app import TelegramBot
+
+    bot_instance = MagicMock()
+    bot_instance.send_message = AsyncMock()
+    bot_instance.leave_chat = AsyncMock()
+    bot_instance.edit_message_reply_markup = AsyncMock()
+    bot_instance.edit_message_text = AsyncMock()
+    bot_instance.send_photo = AsyncMock()
+    bot_instance.send_chat_action = AsyncMock()
+    bot_instance.delete_webhook = AsyncMock()
+
+    with patch("ductor_bot.messenger.telegram.app.Bot", return_value=bot_instance):
+        tg_bot = TelegramBot(config)
+
+    return tg_bot, bot_instance
+
+
+def _make_member_event(chat_id: int, chat_type: str, title: str = "Test Chat") -> MagicMock:
+    """Create a mock ChatMemberUpdated event."""
+    event = MagicMock(spec=ChatMemberUpdated)
+    event.chat = MagicMock()
+    event.chat.id = chat_id
+    event.chat.type = chat_type
+    event.chat.title = title
+    event.new_chat_member = MagicMock()
+    event.new_chat_member.status = "member"
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Config field
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedChannelIdsConfig:
+    def test_defaults_to_empty(self) -> None:
+        cfg = AgentConfig(telegram_token="t:x", allowed_user_ids=[1])
+        assert cfg.allowed_channel_ids == []
+
+    def test_accepts_channel_ids(self) -> None:
+        cfg = AgentConfig(
+            telegram_token="t:x",
+            allowed_user_ids=[1],
+            allowed_channel_ids=[-1001234567890],
+        )
+        assert cfg.allowed_channel_ids == [-1001234567890]
+
+
+# ---------------------------------------------------------------------------
+# _on_bot_added — channel handling
+# ---------------------------------------------------------------------------
+
+
+class TestOnBotAddedChannel:
+    async def test_non_whitelisted_channel_sends_message_and_leaves(self) -> None:
+        cfg = _make_config(channel_ids=[])  # no channels whitelisted
+        tg_bot, bot = _make_tg_bot(cfg)
+        event = _make_member_event(chat_id=-1001111111111, chat_type="channel")
+
+        await tg_bot._on_bot_added(event)
+
+        bot.send_message.assert_awaited_once()
+        call_args = bot.send_message.call_args
+        assert call_args.args[0] == -1001111111111
+        # Message must mention "channel" and "whitelisted"
+        sent_text: str = call_args.args[1]
+        assert "channel" in sent_text.lower()
+        assert "whitelisted" in sent_text.lower()
+
+        bot.leave_chat.assert_awaited_once_with(-1001111111111)
+
+    async def test_non_whitelisted_channel_leave_message_exact(self) -> None:
+        """The exact i18n string must be used."""
+        from ductor_bot.i18n import t
+
+        cfg = _make_config(channel_ids=[])
+        tg_bot, bot = _make_tg_bot(cfg)
+        event = _make_member_event(chat_id=-1001111111111, chat_type="channel")
+
+        await tg_bot._on_bot_added(event)
+
+        sent_text = bot.send_message.call_args.args[1]
+        assert sent_text == t("telegram.channel_not_whitelisted")
+
+    async def test_whitelisted_channel_does_not_leave(self) -> None:
+        channel_id = -1001111111111
+        cfg = _make_config(channel_ids=[channel_id])
+        tg_bot, bot = _make_tg_bot(cfg)
+        # _send_join_notification reads a file; patch it out
+        tg_bot._send_join_notification = AsyncMock()
+        event = _make_member_event(chat_id=channel_id, chat_type="channel")
+
+        await tg_bot._on_bot_added(event)
+
+        bot.send_message.assert_not_awaited()
+        bot.leave_chat.assert_not_awaited()
+        tg_bot._send_join_notification.assert_awaited_once_with(channel_id)
+
+    async def test_leave_chat_api_error_is_suppressed(self) -> None:
+        """TelegramAPIError during leave_chat must not propagate."""
+        cfg = _make_config(channel_ids=[])
+        tg_bot, bot = _make_tg_bot(cfg)
+        bot.leave_chat.side_effect = TelegramAPIError(method=MagicMock(), message="forbidden")
+        event = _make_member_event(chat_id=-1001111111111, chat_type="channel")
+
+        # Should not raise
+        await tg_bot._on_bot_added(event)
+
+    async def test_send_message_api_error_is_suppressed(self) -> None:
+        """TelegramAPIError during send_message must not propagate."""
+        cfg = _make_config(channel_ids=[])
+        tg_bot, bot = _make_tg_bot(cfg)
+        bot.send_message.side_effect = TelegramAPIError(method=MagicMock(), message="forbidden")
+        event = _make_member_event(chat_id=-1001111111111, chat_type="channel")
+
+        await tg_bot._on_bot_added(event)
+
+        # leave_chat is still called even when send_message fails
+        bot.leave_chat.assert_awaited_once_with(-1001111111111)
+
+
+# ---------------------------------------------------------------------------
+# _on_bot_added — group behaviour unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestOnBotAddedGroupUnchanged:
+    async def test_non_whitelisted_group_still_uses_group_message(self) -> None:
+        from ductor_bot.i18n import t
+
+        cfg = _make_config(group_ids=[], channel_ids=[])
+        tg_bot, bot = _make_tg_bot(cfg)
+        event = _make_member_event(chat_id=-100222222222, chat_type="supergroup")
+
+        await tg_bot._on_bot_added(event)
+
+        sent_text = bot.send_message.call_args.args[1]
+        assert sent_text == t("telegram.group_rejected")
+        bot.leave_chat.assert_awaited_once_with(-100222222222)
+
+    async def test_whitelisted_group_is_not_affected_by_channel_ids(self) -> None:
+        group_id = -100222222222
+        cfg = _make_config(group_ids=[group_id], channel_ids=[-1001111111111])
+        tg_bot, bot = _make_tg_bot(cfg)
+        tg_bot._send_join_notification = AsyncMock()
+        event = _make_member_event(chat_id=group_id, chat_type="supergroup")
+
+        await tg_bot._on_bot_added(event)
+
+        bot.send_message.assert_not_awaited()
+        bot.leave_chat.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# audit_groups — channel awareness
+# ---------------------------------------------------------------------------
+
+
+class TestAuditGroupsChannelAwareness:
+    def _make_chat_record(
+        self,
+        chat_id: int,
+        chat_type: str,
+        status: str = "active",
+    ) -> MagicMock:
+        rec = MagicMock()
+        rec.chat_id = chat_id
+        rec.chat_type = chat_type
+        rec.status = status
+        rec.title = "Test"
+        return rec
+
+    async def test_whitelisted_channel_is_not_left_during_audit(self) -> None:
+        channel_id = -1001111111111
+        cfg = _make_config(channel_ids=[channel_id])
+        tg_bot, bot = _make_tg_bot(cfg)
+
+        tracker = MagicMock()
+        tracker.get_all.return_value = [
+            self._make_chat_record(channel_id, "channel"),
+        ]
+        tracker.record_leave = MagicMock()
+        tg_bot._chat_tracker = tracker
+
+        left = await tg_bot.audit_groups()
+
+        assert left == 0
+        bot.leave_chat.assert_not_awaited()
+
+    async def test_non_whitelisted_active_channel_is_left_during_audit(self) -> None:
+        channel_id = -1001111111111
+        cfg = _make_config(channel_ids=[])  # not whitelisted
+        tg_bot, bot = _make_tg_bot(cfg)
+
+        tracker = MagicMock()
+        tracker.get_all.return_value = [
+            self._make_chat_record(channel_id, "channel"),
+        ]
+        tracker.record_leave = MagicMock()
+        tg_bot._chat_tracker = tracker
+
+        left = await tg_bot.audit_groups()
+
+        assert left == 1
+        bot.leave_chat.assert_awaited_once_with(channel_id)
+        tracker.record_leave.assert_called_once_with(channel_id, "auto_left")
+
+    async def test_whitelisted_group_still_safe_during_audit(self) -> None:
+        group_id = -100222222222
+        cfg = _make_config(group_ids=[group_id])
+        tg_bot, bot = _make_tg_bot(cfg)
+
+        tracker = MagicMock()
+        tracker.get_all.return_value = [
+            self._make_chat_record(group_id, "supergroup"),
+        ]
+        tracker.record_leave = MagicMock()
+        tg_bot._chat_tracker = tracker
+
+        left = await tg_bot.audit_groups()
+
+        assert left == 0
+        bot.leave_chat.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Hot-reload
+# ---------------------------------------------------------------------------
+
+
+class TestHotReloadChannelIds:
+    async def test_allowed_channel_ids_updated_on_hot_reload(self) -> None:
+        channel_id = -1001111111111
+        cfg = _make_config(channel_ids=[])
+        tg_bot, _ = _make_tg_bot(cfg)
+
+        assert channel_id not in tg_bot._allowed_channels
+
+        new_cfg = _make_config(channel_ids=[channel_id])
+        tg_bot._on_auth_hot_reload(new_cfg, {"allowed_channel_ids": [channel_id]})
+
+        assert channel_id in tg_bot._allowed_channels
+
+    async def test_unrelated_hot_reload_does_not_touch_channels(self) -> None:
+        channel_id = -1001111111111
+        cfg = _make_config(channel_ids=[channel_id])
+        tg_bot, _ = _make_tg_bot(cfg)
+
+        new_cfg = _make_config(channel_ids=[channel_id])
+        # Only language changed — channels must be untouched
+        tg_bot._on_auth_hot_reload(new_cfg, {"language": "de"})
+
+        assert channel_id in tg_bot._allowed_channels


### PR DESCRIPTION
## Summary

- Adds `allowed_channel_ids: list[int]` config field so Telegram **channels** can be explicitly whitelisted, separate from `allowed_group_ids` (which covers groups/supergroups)
- When the bot is added to a non-whitelisted channel it sends **"This channel is not whitelisted, I am out."** before leaving — instead of reusing the group rejection message or leaving silently
- `audit_groups` now correctly exempts whitelisted channels from periodic eviction
- `allowed_channel_ids` is hot-reloadable (edit `config.json`, takes effect within seconds, no restart needed)

## Changed files

| File | Change |
|---|---|
| `ductor_bot/config.py` | Add `allowed_channel_ids` field |
| `ductor_bot/messenger/telegram/app.py` | Branch `_on_bot_added` on `chat.type == "channel"`; fix `audit_groups`; hot-reload |
| `ductor_bot/i18n/en/chat.toml` | Add `telegram.channel_not_whitelisted` string |
| `tests/messenger/telegram/test_channel_whitelist.py` | 14 new tests (config, _on_bot_added, audit_groups, hot-reload) |

## Test plan

- [x] `pytest tests/messenger/telegram/test_channel_whitelist.py` — 14/14 pass
- [x] `pytest tests/messenger/` — 780/780 pass, no regressions
- [x] `ruff format` + `ruff check` — clean
- [ ] Manual: add bot to a non-whitelisted channel → bot sends message and leaves
- [ ] Manual: add channel ID to `allowed_channel_ids` → bot stays and sends join notification

## Config example

```json
{
  "allowed_group_ids": [-100123456789],
  "allowed_channel_ids": [-100987654321]
}
```

> **Note:** Other language strings (`de`, `fr`, `es`, `ru`, `pt`, `nl`) still use the English fallback for `channel_not_whitelisted`. Native translations welcome in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)