### PR TITLE
fix: discover Gemini models from prebundled CLI chunks

### DIFF
--- a/ductor_bot/cli/gemini_utils.py
+++ b/ductor_bot/cli/gemini_utils.py
@@ -71,11 +71,21 @@ def find_gemini_cli_js() -> str | None:
 def discover_gemini_models() -> frozenset[str]:
     """Discover Gemini models from the installed Gemini CLI config files.
 
-    The canonical source is ``gemini-cli-core/dist/src/config/models.js``,
-    generated from upstream ``models.ts`` in the Gemini CLI project.
+    Two layouts are supported:
+
+    1. Older releases ship ``gemini-cli-core/dist/src/config/models.js`` as
+       a separate ESM module that re-exports ``VALID_GEMINI_MODELS``.
+    2. ``@google/gemini-cli`` ≥ 0.37 ships everything as a pre-bundled
+       ``bundle/*.js`` set; the model list lives inside one of the hashed
+       chunks as ``VALID_GEMINI_MODELS = new Set([...])`` referencing
+       ``const`` identifiers defined in the same file.
     """
     for models_js in _gemini_models_js_candidates():
         models = _discover_models_from_models_js(models_js)
+        if models:
+            return models
+    for bundle_js in _gemini_bundle_candidates():
+        models = _discover_models_from_bundle(bundle_js)
         if models:
             return models
     return frozenset()
@@ -354,6 +364,106 @@ def _find_node_binary() -> str | None:
 def _extract_models_from_text(content: str) -> set[str]:
     pattern = re.compile(r"""['"]((?:auto-)?gemini-[\w.\-]+)['"]""")
     return set(pattern.findall(content))
+
+
+# Matches `VALID_GEMINI_MODELS = new Set([...])`, tolerating an optional
+# `/* @__PURE__ */` annotation inserted by esbuild.
+_VALID_GEMINI_SET_RE = re.compile(
+    r"VALID_GEMINI_MODELS\s*=\s*(?:/\*[^*]*\*/\s*)?new\s+Set\s*\(\s*\[(.*?)\]\s*\)",
+    re.DOTALL,
+)
+_UPPER_IDENT_RE = re.compile(r"\b([A-Z][A-Z0-9_]*)\b")
+
+
+def _extract_models_from_valid_set(content: str) -> set[str]:
+    """Resolve identifiers listed inside ``VALID_GEMINI_MODELS = new Set([...])``.
+
+    Each identifier is looked up in *content* via
+    ``IDENT = "gemini-..."`` (with or without ``const``/``var``).
+    Identifiers that cannot be resolved are silently skipped.
+    """
+    set_block = _VALID_GEMINI_SET_RE.search(content)
+    if not set_block:
+        return set()
+    idents = _UPPER_IDENT_RE.findall(set_block.group(1))
+    if not idents:
+        return set()
+
+    found: set[str] = set()
+    for ident in dict.fromkeys(idents):
+        ident_re = re.compile(
+            r"\b" + re.escape(ident) + r"""\s*=\s*['"]((?:auto-)?gemini-[\w.\-]+)['"]"""
+        )
+        match = ident_re.search(content)
+        if match:
+            found.add(match.group(1))
+    return found
+
+
+def _gemini_bundle_candidates() -> tuple[Path, ...]:
+    """Return ``bundle/*.js`` files of an installed ``@google/gemini-cli``.
+
+    Newer releases ship the model list inside one of the hashed chunks
+    instead of a stable ``models.js`` location.
+    """
+    candidates: list[Path] = []
+    for bundle_root in _gemini_bundle_roots():
+        try:
+            candidates.extend(p for p in sorted(bundle_root.glob("*.js")) if p.is_file())
+        except OSError:
+            continue
+
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        deduped.append(path)
+    return tuple(deduped)
+
+
+def _gemini_bundle_roots() -> list[Path]:
+    roots: list[Path] = []
+
+    npm_root = _npm_global_root()
+    if npm_root is not None:
+        roots.append(npm_root / "@google" / "gemini-cli" / "bundle")
+
+    try:
+        cli_path = Path(find_gemini_cli()).resolve()
+    except (FileNotFoundError, OSError):
+        cli_path = None
+
+    if cli_path is not None:
+        pkg_root = _find_gemini_cli_package_root(cli_path)
+        if pkg_root is not None:
+            roots.append(pkg_root / "bundle")
+
+        node_version_dir = cli_path.parent.parent
+        roots.append(
+            node_version_dir / "lib" / "node_modules" / "@google" / "gemini-cli" / "bundle"
+        )
+        roots.append(cli_path.parent / "node_modules" / "@google" / "gemini-cli" / "bundle")
+
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for root in roots:
+        if root in seen:
+            continue
+        seen.add(root)
+        deduped.append(root)
+    return deduped
+
+
+def _discover_models_from_bundle(bundle_js: Path) -> frozenset[str]:
+    try:
+        content = bundle_js.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return frozenset()
+    if "VALID_GEMINI_MODELS" not in content:
+        return frozenset()
+    return frozenset(sorted(_extract_models_from_valid_set(content)))
 
 
 def _extract_models_from_source_map(models_js: Path) -> set[str]:

--- a/tests/cli/test_gemini_utils.py
+++ b/tests/cli/test_gemini_utils.py
@@ -186,6 +186,51 @@ class TestDiscoverGeminiModels:
             result = discover_gemini_models()
             assert result == frozenset()
 
+    def test_from_prebundled_chunk(self, tmp_path: Path) -> None:
+        """Newer @google/gemini-cli ships a bundle/*.js chunk instead of models.js."""
+        bundle_dir = tmp_path / "@google" / "gemini-cli" / "bundle"
+        bundle_dir.mkdir(parents=True)
+
+        # Mimic the real chunk layout from @google/gemini-cli 0.37.x:
+        # const-style identifiers defined first, then a Set referencing them.
+        chunk = bundle_dir / "chunk-ABC123.js"
+        chunk.write_text(
+            'var DEFAULT_GEMINI_MODEL = "gemini-2.5-pro";\n'
+            'var DEFAULT_GEMINI_FLASH_MODEL = "gemini-2.5-flash";\n'
+            'var DEFAULT_GEMINI_FLASH_LITE_MODEL = "gemini-2.5-flash-lite";\n'
+            'var PREVIEW_GEMINI_MODEL = "gemini-3-pro-preview";\n'
+            'var PREVIEW_GEMINI_FLASH_MODEL = "gemini-3-flash-preview";\n'
+            "var VALID_GEMINI_MODELS = /* @__PURE__ */ new Set([\n"
+            "  PREVIEW_GEMINI_MODEL,\n"
+            "  PREVIEW_GEMINI_FLASH_MODEL,\n"
+            "  DEFAULT_GEMINI_MODEL,\n"
+            "  DEFAULT_GEMINI_FLASH_MODEL,\n"
+            "  DEFAULT_GEMINI_FLASH_LITE_MODEL\n"
+            "]);\n"
+            'var DEFAULT_GEMINI_MODEL_AUTO = "auto-gemini-2.5";\n'  # not in Set
+            'var IRRELEVANT = "gemini-1.0-legacy";\n'  # not referenced
+        )
+        # Distractor file in the same bundle dir without the marker.
+        (bundle_dir / "chunk-OTHER.js").write_text("// nothing relevant here\n")
+
+        with (
+            patch("ductor_bot.cli.gemini_utils.which", return_value="/usr/bin/npm"),
+            patch(
+                "ductor_bot.cli.gemini_utils.subprocess.check_output",
+                return_value=str(tmp_path),
+            ),
+        ):
+            result = discover_gemini_models()
+
+        assert "gemini-2.5-pro" in result
+        assert "gemini-2.5-flash" in result
+        assert "gemini-2.5-flash-lite" in result
+        assert "gemini-3-pro-preview" in result
+        assert "gemini-3-flash-preview" in result
+        # Strings outside the Set are intentionally excluded.
+        assert "auto-gemini-2.5" not in result
+        assert "gemini-1.0-legacy" not in result
+
 
 class TestTrustWorkspace:
     def test_creates_file(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Starting with `@google/gemini-cli@0.37`, the CLI is shipped as a single pre-bundled `bundle/*.js` directory inside the npm package. The file `@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/config/models.js` that `discover_gemini_models()` looks for no longer exists, so discovery returns an empty set and `GeminiModelCache` falls back to the hardcoded trio (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`).

As a result `/model` only shows those three even though the installed CLI itself knows about `gemini-3-pro-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview` and others.

In the new bundle, `VALID_GEMINI_MODELS` lives inside one of the hashed chunks (e.g. `bundle/chunk-XXXXXXXX.js`) as:

```js
var DEFAULT_GEMINI_MODEL = "gemini-2.5-pro";
var DEFAULT_GEMINI_FLASH_MODEL = "gemini-2.5-flash";
// ...
var VALID_GEMINI_MODELS = /* @__PURE__ */ new Set([
  PREVIEW_GEMINI_MODEL,
  PREVIEW_GEMINI_FLASH_MODEL,
  DEFAULT_GEMINI_MODEL,
  // ...
]);
```

## Fix

Adds a bundle-aware discovery path to `ductor_bot/cli/gemini_utils.py`:

- `_gemini_bundle_candidates()` enumerates `bundle/*.js` files of the installed `@google/gemini-cli`, using the same npm/NVM/package-root resolution as the existing `models.js` lookup.
- `_extract_models_from_valid_set()` finds the `VALID_GEMINI_MODELS = new Set([...])` block (tolerating the `/* @__PURE__ */` esbuild annotation), pulls out the identifiers inside the `Set` and resolves each against `IDENT = "gemini-..."` in the same chunk. This avoids the false-positive problem of a wide text scan, which would also pick up unrelated strings like `auto-gemini-2.5` or legacy compatibility models that are referenced but **not** in `VALID_GEMINI_MODELS`.
- `_discover_models_from_bundle()` cheaply pre-filters chunks by the presence of the `VALID_GEMINI_MODELS` marker before parsing.
- `discover_gemini_models()` first tries the legacy `models.js` layout (so older releases continue to work), then falls back to the bundle scan.

## How to reproduce / verify

```sh
npm install -g @google/gemini-cli@0.37.2
ls "$(npm root -g)/@google/gemini-cli/"          # → bundle/  node_modules/  ...
ls "$(npm root -g)/@google/gemini-cli/bundle/" | head
grep -l VALID_GEMINI_MODELS \
   "$(npm root -g)/@google/gemini-cli/bundle/"*.js
```

Before this patch: `discover_gemini_models()` returns `frozenset()`, the cache file is empty and `/model` shows the fallback trio. After this patch it returns all eight identifiers from `VALID_GEMINI_MODELS`, including the 3.x preview models.

## Tests

`tests/cli/test_gemini_utils.py::TestDiscoverGeminiModels::test_from_prebundled_chunk` builds a synthetic chunk that mirrors the real bundle layout (`var IDENT = "gemini-..."` constants + `new Set([...])`) and asserts:

- All Set members are returned.
- Strings outside the Set (`auto-gemini-2.5`, an unreferenced `gemini-1.0-legacy`) are intentionally excluded.

The existing `test_from_file` covering the legacy `models.js` layout is unchanged and still passes.