### PR TITLE
fix: cron double-execution, wall-clock drift, and @gpt-5.4 directive routing

### DIFF
--- a/ductor_bot/cron/observer.py
+++ b/ductor_bot/cron/observer.py
@@ -7,7 +7,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from cronsim import CronSim, CronSimError
@@ -244,6 +244,10 @@ class CronObserver(BaseTaskObserver):
         """Wait for delay, execute the job, then reschedule for next occurrence."""
         try:
             await asyncio.sleep(delay)
+            # Clock-skew guard: verify wall clock reached the cron slot.
+            # Protects against asyncio.sleep waking early after a clock jump
+            # (WSL2/VM suspend/resume, NTP corrections, etc.).
+            await self._ensure_cron_slot_reached(scheduled_job)
             await self._execute_job(
                 scheduled_job.id,
                 scheduled_job.instruction,
@@ -264,6 +268,41 @@ class CronObserver(BaseTaskObserver):
                     scheduled_job.task_folder,
                     scheduled_job.timezone,
                 )
+
+    async def _ensure_cron_slot_reached(self, scheduled_job: _ScheduledJob) -> None:
+        """Re-sleep if wall clock shows we woke before the cron slot.
+
+        ``asyncio.sleep`` relies on the event-loop monotonic clock, which can
+        jump forward (relative to wall time) when the host suspends and
+        resumes (WSL2, VMs, hibernation) or after NTP corrections. When that
+        happens the sleep completes before the intended cron slot and the job
+        fires early.  This helper re-checks wall clock against the next cron
+        match and sleeps the deficit.  Iterations are bounded to avoid an
+        infinite loop on misconfigured expressions.
+        """
+        tz = resolve_user_timezone(
+            scheduled_job.timezone or self._config.user_timezone,
+        )
+        for _ in range(5):
+            now_aware = datetime.now(tz)
+            try:
+                it = CronSim(
+                    scheduled_job.schedule,
+                    now_aware.replace(tzinfo=None) - timedelta(minutes=1),
+                )
+                next_naive = next(it)
+            except (CronSimError, StopIteration):
+                return
+            next_aware = next_naive.replace(tzinfo=tz)
+            deficit = (next_aware - now_aware).total_seconds()
+            if deficit <= 30:
+                return
+            logger.warning(
+                "Cron job %s woke %.0fs early (wall clock), re-sleeping",
+                scheduled_job.id,
+                deficit,
+            )
+            await asyncio.sleep(deficit)
 
     # -- Execution --
 

--- a/ductor_bot/cron/observer.py
+++ b/ductor_bot/cron/observer.py
@@ -216,6 +216,14 @@ class CronObserver(BaseTaskObserver):
                 task_folder=task_folder,
                 timezone=job_timezone,
             )
+            existing = self._scheduled.get(job_id)
+            if (
+                existing is not None
+                and not existing.done()
+                and job_id not in self._executing
+            ):
+                existing.cancel()
+                logger.debug("Cancelled prior idle task for %s", job_id)
             task = asyncio.create_task(
                 self._run_at(delay, scheduled_job),
             )

--- a/ductor_bot/orchestrator/core.py
+++ b/ductor_bot/orchestrator/core.py
@@ -328,7 +328,19 @@ class Orchestrator:
 
         await self._ensure_docker()
 
-        directives = parse_directives(dispatch.text, self._providers._known_model_ids)
+        # _known_model_ids only covers Claude + Gemini IDs (refreshed on Gemini
+        # cache updates).  Codex model IDs live in a separate dynamic cache, so
+        # merge them in here before parsing so that directives like @gpt-5.4
+        # route to the Codex provider instead of falling through to the default.
+        known_ids = self._providers._known_model_ids
+        codex_cache = (
+            self._providers._codex_cache_fn()
+            if self._providers._codex_cache_fn
+            else None
+        )
+        if codex_cache is not None:
+            known_ids = known_ids | frozenset(m.id for m in codex_cache.models)
+        directives = parse_directives(dispatch.text, known_ids)
 
         # Check if a leading @directive matches a named session
         if directives.raw_directives:

--- a/ductor_bot/orchestrator/directives.py
+++ b/ductor_bot/orchestrator/directives.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
-_DIRECTIVE_RE = re.compile(r"@([a-zA-Z][a-zA-Z0-9_-]*)(?:=(\S+))?")
+_DIRECTIVE_RE = re.compile(r"@([a-zA-Z][a-zA-Z0-9_.-]*)(?:=(\S+))?")
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary

Four related fixes found while diagnosing duplicate Telegram notifications
from an in-process cron job and broken `@<model>` routing for Codex.

1. **`fix(cron): cancel orphaned Task in _schedule_job`** — fixes #75.
   Reschedule events (file-watcher on `cron_jobs.json` or
   `request_reschedule()`) can fire close to the scheduled time, creating a
   new Task while the previous one is still pending.  The overwrite in
   `self._scheduled[job_id]` leaves the old Task orphaned but alive, and it
   fires at its original time.  Cancel it (respecting the `_executing`
   guard already used by `_reschedule_all`) before overwriting.

2. **`fix(cron): guard against early wake after wall-clock jumps`** — new
   helper `_ensure_cron_slot_reached()` that re-sleeps if `asyncio.sleep`
   completes before the cron slot according to wall clock.  Reproducible on
   WSL2 where the guest monotonic clock jumps forward on host
   suspend/resume.  Also protects against NTP corrections and hibernation.

3. **`fix(directives): allow '.' in directive key`** — `_DIRECTIVE_RE`
   stopped at the first `.`, so `@gpt-5.4 hello` was parsed as `@gpt-5`
   with `.4 hello` returned as the message body.  All Codex model IDs
   contain dots; Claude and Gemini aliases are unaffected.

4. **`fix(directives): include Codex models in known_ids for directive
   parsing`** — `Orchestrator.process()` passed only
   `self._providers._known_model_ids` (Claude + Gemini) to
   `parse_directives()`.  Codex IDs live in a separate dynamic cache, so
   `@gpt-5.4` fell through to `raw_directives`, `directives.model` stayed
   `None`, and the message was dispatched to the default provider.

Each fix is a standalone commit so they can be cherry-picked individually
if preferred.

## Verification

All four fixes validated in production (ductor v0.15.0, systemd user
service, WSL2 host, Telegram transport).

After fixes:
- Cron jobs fire once per slot (prior: 2-3 times per day, sometimes minutes
  early).
- `@gpt-5.4 <msg>` logs `Directive parsed model=gpt-5.4` →
  `CLI factory creating provider=codex` → real Codex subprocess.
- No regression in `@sonnet` / `@opus` / `@haiku` / `@pro` / `@flash`.

## Test plan

- [ ] Run existing test suite (`pytest`).
- [ ] Add regression test for orphan-Task scenario in
      `tests/cron/test_observer.py` (schedule same job twice, assert only
      one runs).
- [ ] Add regression test for `parse_directives("@gpt-5.4 hi", known)` with
      the Codex ID in `known`.
- [ ] Add parser test for dot handling.
- [ ] Manual: trigger host suspend mid-sleep and confirm the warning log
      appears and the job fires on time.

I can add the tests in a follow-up commit on this branch once maintainers
agree on the approach.

Refs: #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)