### PR TITLE
fix(telegram): separate reasoning stream from thinking state

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Main chat:  "Ask codex-agent to write tests for the API"
 - **Multi-transport** — run Telegram and Matrix simultaneously, or pick one
 - **Multi-language** — UI in English, Deutsch, Nederlands, Français, Русский, Español, Português
 - **Real-time streaming** — live message edits (Telegram) or segment-based output (Matrix)
+- **Telegram reasoning + tool UX controls** — optional reasoning stream, live tool progress, and separate thinking indicator controls
 - **Provider switching** — `/model` to change provider/model (never blocks, even during active processes)
 - **Persistent memory** — plain Markdown files that survive across sessions
 - **Memory maintenance** — pre-compaction flush, optional reflection cadence, and LLM-driven compaction

--- a/config.example.json
+++ b/config.example.json
@@ -44,6 +44,9 @@
         "max_edit_failures": 3,
         "append_mode": false,
         "sentence_break": true,
+        "show_reasoning_stream": true,
+        "show_tool_progress": true,
+        "show_thinking_indicator": true,
     },
     "docker": {
         "enabled": true,

--- a/docs/config.md
+++ b/docs/config.md
@@ -232,6 +232,13 @@ Behavior notes:
 | `max_edit_failures` | `int` | `3` |
 | `append_mode` | `bool` | `false` |
 | `sentence_break` | `bool` | `true` |
+| `show_reasoning_stream` | `bool` | `false` |
+| `show_tool_progress` | `bool` | `true` |
+| `show_thinking_indicator` | `bool` | `true` |
+
+- `show_reasoning_stream`: when the provider exposes reasoning/thinking blocks, stream them as separate Telegram messages instead of degrading them to a plain status indicator.
+- `show_tool_progress`: show live Telegram tool activity messages during streaming turns.
+- `show_thinking_indicator`: keep the lighter Telegram `THINKING` status indicator when no reasoning stream is being shown.
 
 ## `DockerConfig`
 

--- a/ductor_bot/cli/param_resolver.py
+++ b/ductor_bot/cli/param_resolver.py
@@ -114,13 +114,15 @@ def resolve_cli_config(
         # Check if model supports reasoning and if effort is valid
         if codex_cache and requested_effort:
             model_info = codex_cache.get_model(model)
-            if (
-                model_info
-                and model_info.supported_efforts
-                and requested_effort in model_info.supported_efforts
-            ):
+            if model_info and model_info.supported_efforts and requested_effort in model_info.supported_efforts:
                 reasoning_effort = requested_effort
-            # Otherwise, fall back to empty (invalid effort or model doesn't support reasoning)
+            elif overrides.reasoning_effort is not None:
+                supported_display = ", ".join(model_info.supported_efforts) if model_info else "none"
+                msg = (
+                    f"Invalid reasoning effort '{requested_effort}' for Codex model {model}. "
+                    f"Supported: {supported_display}"
+                )
+                raise DuctorError(msg)
 
     # 5. Merge CLI parameters: base per-provider bucket first, task overrides second.
     #    argparse-style resolution — last flag wins at the CLI level.

--- a/ductor_bot/cli/service.py
+++ b/ductor_bot/cli/service.py
@@ -42,15 +42,17 @@ class _StreamCallbacks:
         on_text: Callable[[str], Awaitable[None]] | None,
         on_tool: Callable[[str], Awaitable[None]] | None,
         on_status: Callable[[str | None], Awaitable[None]] | None,
+        on_reasoning: Callable[[str], Awaitable[None]] | None = None,
         on_compact_boundary: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         self._on_text = on_text
         self._on_tool = on_tool
         self._on_status = on_status
+        self._on_reasoning = on_reasoning
         self._on_compact_boundary = on_compact_boundary
         self.init_session_id: str | None = None
 
-    async def dispatch(self, event: StreamEvent) -> tuple[str, ResultEvent | None]:
+    async def dispatch(self, event: StreamEvent) -> tuple[str, ResultEvent | None]:  # noqa: C901
         """Handle one event. Returns (accumulated_text_chunk, result_or_none)."""
         if isinstance(event, SystemInitEvent) and event.session_id:
             self.init_session_id = event.session_id
@@ -59,8 +61,11 @@ class _StreamCallbacks:
             if self._on_text is not None:
                 await self._on_text(event.text)
             return event.text, None
-        if isinstance(event, ThinkingEvent) and self._on_status is not None:
-            await self._on_status("thinking")
+        if isinstance(event, ThinkingEvent):
+            if self._on_reasoning is not None and event.text:
+                await self._on_reasoning(event.text)
+            elif self._on_status is not None:
+                await self._on_status("thinking")
         elif isinstance(event, ToolUseEvent) and self._on_tool is not None:
             await self._on_tool(event.tool_name)
         elif isinstance(event, SystemStatusEvent) and self._on_status is not None:
@@ -179,12 +184,13 @@ class CLIService:
         self._log_call(request, agent_resp, elapsed_ms)
         return agent_resp
 
-    async def execute_streaming(
+    async def execute_streaming(  # noqa: PLR0913
         self,
         request: AgentRequest,
         on_text_delta: Callable[[str], Awaitable[None]] | None = None,
         on_tool_activity: Callable[[str], Awaitable[None]] | None = None,
         on_system_status: Callable[[str | None], Awaitable[None]] | None = None,
+        on_reasoning_delta: Callable[[str], Awaitable[None]] | None = None,
         on_compact_boundary: Callable[[], Awaitable[None]] | None = None,
     ) -> AgentResponse:
         """Execute a streaming CLI call with automatic fallback to non-streaming."""
@@ -200,7 +206,11 @@ class CLIService:
         stream_error = False
 
         callbacks = _StreamCallbacks(
-            on_text_delta, on_tool_activity, on_system_status, on_compact_boundary
+            on_text_delta,
+            on_tool_activity,
+            on_system_status,
+            on_reasoning_delta,
+            on_compact_boundary,
         )
 
         try:

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -56,6 +56,9 @@ class StreamingConfig(BaseModel):
     max_edit_failures: int = 3
     append_mode: bool = False
     sentence_break: bool = True
+    show_reasoning_stream: bool = False
+    show_tool_progress: bool = True
+    show_thinking_indicator: bool = True
 
 
 class DockerConfig(BaseModel):

--- a/ductor_bot/messenger/telegram/message_dispatch.py
+++ b/ductor_bot/messenger/telegram/message_dispatch.py
@@ -13,7 +13,7 @@ from ductor_bot.messenger.telegram.sender import (
     send_files_from_text,
     send_rich,
 )
-from ductor_bot.messenger.telegram.streaming import create_stream_editor
+from ductor_bot.messenger.telegram.streaming import StreamEditor, create_stream_editor
 from ductor_bot.messenger.telegram.typing import TypingContext
 from ductor_bot.orchestrator.registry import OrchestratorResult
 from ductor_bot.session.key import SessionKey
@@ -143,6 +143,13 @@ def _status_reaction_enabled(scene: SceneConfig | None) -> bool:
     return bool(scene is not None and scene.status_reaction)
 
 
+def _format_reasoning_chunk(text: str) -> str:
+    normalized = text.strip()
+    if not normalized:
+        return ""
+    return f"**Thinking**\n\n{normalized}"
+
+
 @dataclass(slots=True)
 class NonStreamingDispatch:
     """Input payload for one non-streaming message turn.
@@ -220,7 +227,7 @@ async def run_non_streaming_message(
         await tracker.clear()
 
 
-async def run_streaming_message(
+async def run_streaming_message(  # noqa: C901, PLR0915
     dispatch: StreamingDispatch,
 ) -> str:
     """Execute one streaming turn and deliver text/files to Telegram."""
@@ -240,6 +247,14 @@ async def run_streaming_message(
         cfg=dispatch.streaming_cfg,
         thread_id=dispatch.thread_id,
     )
+    streamed_text_sent = False
+
+    async def _flush_text_chunk(chunk: str) -> None:
+        nonlocal streamed_text_sent
+        if chunk.strip():
+            streamed_text_sent = True
+        await editor.append_text(chunk)
+
     coalescer = StreamCoalescer(
         config=CoalesceConfig(
             min_chars=dispatch.streaming_cfg.min_chars,
@@ -247,8 +262,34 @@ async def run_streaming_message(
             idle_ms=dispatch.streaming_cfg.idle_ms,
             sentence_break=dispatch.streaming_cfg.sentence_break,
         ),
-        on_flush=editor.append_text,
+        on_flush=_flush_text_chunk,
     )
+
+    reasoning_coalescer: StreamCoalescer | None = None
+    if dispatch.streaming_cfg.show_reasoning_stream:
+        reasoning_editor = StreamEditor(
+            dispatch.bot,
+            dispatch.key.chat_id,
+            thread_id=dispatch.thread_id,
+        )
+
+        async def _flush_reasoning_chunk(chunk: str) -> None:
+            formatted = _format_reasoning_chunk(chunk)
+            if not formatted:
+                return
+            await reasoning_editor.append_text(formatted)
+
+        reasoning_coalescer = StreamCoalescer(
+            config=CoalesceConfig(
+                min_chars=dispatch.streaming_cfg.min_chars,
+                max_chars=dispatch.streaming_cfg.max_chars,
+                idle_ms=dispatch.streaming_cfg.idle_ms,
+                sentence_break=dispatch.streaming_cfg.sentence_break,
+            ),
+            on_flush=_flush_reasoning_chunk,
+        )
+
+    thinking_indicator_sent = False
 
     async def on_text(delta: str) -> None:
         await coalescer.feed(delta)
@@ -256,7 +297,10 @@ async def run_streaming_message(
     async def on_tool(tool_name: str) -> None:
         await tracker.set_tool(tool_name)
         await coalescer.flush(force=True)
-        await editor.append_tool(tool_name)
+        if reasoning_coalescer is not None:
+            await reasoning_coalescer.flush(force=True)
+        if dispatch.streaming_cfg.show_tool_progress:
+            await editor.append_tool(tool_name)
 
     async def on_system(status: str | None) -> None:
         system_map: dict[str, str] = {
@@ -269,9 +313,29 @@ async def run_streaming_message(
         label = system_map.get(status or "")
         if label is None:
             return
+        if status == "thinking":
+            if dispatch.streaming_cfg.show_reasoning_stream:
+                return
+            if not dispatch.streaming_cfg.show_thinking_indicator:
+                return
         await tracker.set_system()
         await coalescer.flush(force=True)
+        if reasoning_coalescer is not None:
+            await reasoning_coalescer.flush(force=True)
         await editor.append_system(label)
+
+    async def on_reasoning(delta: str) -> None:
+        nonlocal thinking_indicator_sent
+        if not delta.strip():
+            return
+        await tracker.set_thinking()
+        await coalescer.flush(force=True)
+        if reasoning_coalescer is not None:
+            await reasoning_coalescer.feed(delta)
+            return
+        if dispatch.streaming_cfg.show_thinking_indicator and not thinking_indicator_sent:
+            thinking_indicator_sent = True
+            await on_system("thinking")
 
     try:
         await tracker.set_thinking()
@@ -282,10 +346,14 @@ async def run_streaming_message(
                 on_text_delta=on_text,
                 on_tool_activity=on_tool,
                 on_system_status=on_system,
+                on_reasoning_delta=on_reasoning,
             )
 
         await coalescer.flush(force=True)
         coalescer.stop()
+        if reasoning_coalescer is not None:
+            await reasoning_coalescer.flush(force=True)
+            reasoning_coalescer.stop()
         footer = _build_footer(result, dispatch.scene_config)
         if footer:
             await editor.append_text(footer)
@@ -298,7 +366,7 @@ async def run_streaming_message(
             editor.has_content,
         )
 
-        if result.stream_fallback or not editor.has_content:
+        if result.stream_fallback or not streamed_text_sent or not editor.has_content:
             await send_rich(
                 dispatch.bot,
                 dispatch.key.chat_id,

--- a/ductor_bot/orchestrator/commands.py
+++ b/ductor_bot/orchestrator/commands.py
@@ -328,12 +328,22 @@ async def _build_status(orch: Orchestrator, key: SessionKey) -> str:
         auth_lines.append(f"  [{provider}] {result.status.value}{age_label}")
     auth_block = t("status.auth_header") + "\n" + "\n".join(auth_lines)
 
+    streaming_cfg = orch._config.streaming
+    streaming_block = "\n".join(
+        [
+            "Streaming visibility:",
+            f"  Reasoning stream: {'on' if streaming_cfg.show_reasoning_stream else 'off'}",
+            f"  Tool progress: {'on' if streaming_cfg.show_tool_progress else 'off'}",
+            f"  Thinking indicator: {'on' if streaming_cfg.show_thinking_indicator else 'off'}",
+        ]
+    )
+
     agent_block = _build_agent_health_block(orch)
 
     blocks = [t("status.header"), SEP, session_block]
     if bg_block:
         blocks += [SEP, bg_block]
-    blocks += [SEP, auth_block]
+    blocks += [SEP, auth_block, SEP, streaming_block]
     if agent_block:
         blocks += [SEP, agent_block]
     return fmt(*blocks)

--- a/ductor_bot/orchestrator/core.py
+++ b/ductor_bot/orchestrator/core.py
@@ -78,6 +78,7 @@ logger = logging.getLogger(__name__)
 
 _TextCallback = Callable[[str], Awaitable[None]]
 _SystemStatusCallback = Callable[[str | None], Awaitable[None]]
+_ReasoningCallback = Callable[[str], Awaitable[None]]
 
 
 @dataclass(slots=True)
@@ -101,6 +102,7 @@ class _MessageDispatch:
     on_text_delta: _TextCallback | None = None
     on_tool_activity: _TextCallback | None = None
     on_system_status: _SystemStatusCallback | None = None
+    on_reasoning_delta: _ReasoningCallback | None = None
 
     def streaming_callbacks(self) -> StreamingCallbacks:
         """Bundle the streaming callbacks into a StreamingCallbacks instance."""
@@ -108,6 +110,7 @@ class _MessageDispatch:
             on_text_delta=self.on_text_delta,
             on_tool_activity=self.on_tool_activity,
             on_system_status=self.on_system_status,
+            on_reasoning_delta=self.on_reasoning_delta,
         )
 
 
@@ -296,7 +299,7 @@ class Orchestrator:
         dispatch = _MessageDispatch(key=key, text=text, cmd=text.strip().lower())
         return await self._handle_message_impl(dispatch)
 
-    async def handle_message_streaming(
+    async def handle_message_streaming(  # noqa: PLR0913
         self,
         key: SessionKey,
         text: str,
@@ -304,6 +307,7 @@ class Orchestrator:
         on_text_delta: _TextCallback | None = None,
         on_tool_activity: _TextCallback | None = None,
         on_system_status: _SystemStatusCallback | None = None,
+        on_reasoning_delta: _ReasoningCallback | None = None,
     ) -> OrchestratorResult:
         """Main entry point with streaming support."""
         dispatch = _MessageDispatch(
@@ -314,6 +318,7 @@ class Orchestrator:
             on_text_delta=on_text_delta,
             on_tool_activity=on_tool_activity,
             on_system_status=on_system_status,
+            on_reasoning_delta=on_reasoning_delta,
         )
         return await self._handle_message_impl(dispatch)
 

--- a/ductor_bot/orchestrator/flows.py
+++ b/ductor_bot/orchestrator/flows.py
@@ -36,6 +36,7 @@ class StreamingCallbacks:
     on_text_delta: Callable[[str], Awaitable[None]] | None = field(default=None)
     on_tool_activity: Callable[[str], Awaitable[None]] | None = field(default=None)
     on_system_status: Callable[[str | None], Awaitable[None]] | None = field(default=None)
+    on_reasoning_delta: Callable[[str], Awaitable[None]] | None = field(default=None)
 
 
 def _make_timeout_controller(orch: Orchestrator, kind: str) -> TimeoutController | None:
@@ -496,6 +497,7 @@ async def normal_streaming(  # noqa: PLR0911
             on_text_delta=cb.on_text_delta,
             on_tool_activity=cb.on_tool_activity,
             on_system_status=cb.on_system_status,
+            on_reasoning_delta=cb.on_reasoning_delta,
             on_compact_boundary=_on_compact if orch._memory_flusher is not None else None,
         )
         outcome = await _maybe_recover_session(
@@ -738,6 +740,7 @@ async def named_session_streaming(
         on_text_delta=_tagged_text_delta,
         on_tool_activity=cb.on_tool_activity,
         on_system_status=cb.on_system_status,
+        on_reasoning_delta=cb.on_reasoning_delta,
     )
 
     _reg2 = orch._process_registry

--- a/ductor_bot/orchestrator/selectors/model_selector.py
+++ b/ductor_bot/orchestrator/selectors/model_selector.py
@@ -91,6 +91,34 @@ def _build_switch_summary(ctx: _SwitchSummaryContext) -> str:
     return "\n".join(parts)
 
 
+def _validate_codex_reasoning_effort(
+    orch: Orchestrator,
+    model_id: str,
+    reasoning_effort: str | None,
+) -> str | None:
+    """Return a user-facing error when Codex effort is unsupported."""
+    if not reasoning_effort or orch.models.provider_for(model_id) != "codex":
+        return None
+
+    codex_cache = orch._observers.codex_cache_obs.get_cache() if orch._observers.codex_cache_obs else None
+    if codex_cache is None:
+        return None
+
+    model_info = codex_cache.get_model(model_id)
+    if model_info is None:
+        return None
+
+    supported = tuple(model_info.supported_efforts)
+    if reasoning_effort in supported:
+        return None
+
+    supported_display = ", ".join(supported) if supported else "none"
+    return (
+        f"Invalid reasoning effort `{reasoning_effort}` for `{model_id}`. "
+        f"Supported: {supported_display}."
+    )
+
+
 def _gemini_models_for_selector() -> list[str]:
     """Return Gemini models discovered from local Gemini CLI files."""
     models = sorted(get_gemini_models())
@@ -210,7 +238,7 @@ async def handle_model_callback(
     return SelectorResponse(text=t("model.unknown_action"))
 
 
-async def switch_model(
+async def switch_model(  # noqa: C901
     orch: Orchestrator,
     key: SessionKey,
     model_id: str,
@@ -234,6 +262,11 @@ async def switch_model(
     old_provider = orch.models.provider_for(old)
     new_provider = orch.models.provider_for(model_id)
     provider_changed = old_provider != new_provider
+
+    validation_error = _validate_codex_reasoning_effort(orch, model_id, reasoning_effort)
+    if validation_error is not None:
+        return validation_error
+
     resume_session_id, resume_message_count = _resume_state_for_provider(
         active_session,
         new_provider,

--- a/tests/cli/test_param_resolver.py
+++ b/tests/cli/test_param_resolver.py
@@ -82,16 +82,15 @@ def test_resolve_with_task_overrides(
     """Should apply task overrides over global config."""
     overrides = TaskOverrides(
         provider="codex",
-        model="gpt-4o-mini",
+        model="gpt-4o",
         reasoning_effort="low",
     )
 
     result = resolve_cli_config(base_config, codex_cache, task_overrides=overrides)
 
     assert result.provider == "codex"
-    assert result.model == "gpt-4o-mini"
-    # gpt-4o-mini doesn't support reasoning, should be empty
-    assert result.reasoning_effort == ""
+    assert result.model == "gpt-4o"
+    assert result.reasoning_effort == "low"
     assert result.cli_parameters == []
 
 
@@ -150,17 +149,15 @@ def test_resolve_codex_reasoning_effort(
 def test_resolve_codex_effort_fallback(
     base_config: AgentConfig, codex_cache: CodexModelCache
 ) -> None:
-    """Should fall back to empty reasoning effort for non-reasoning models."""
+    """Explicit invalid reasoning override must fail loudly."""
     overrides = TaskOverrides(
         provider="codex",
         model="gpt-4o-mini",
         reasoning_effort="high",  # Attempt to set, but model doesn't support
     )
 
-    result = resolve_cli_config(base_config, codex_cache, task_overrides=overrides)
-
-    assert result.model == "gpt-4o-mini"
-    assert result.reasoning_effort == ""
+    with pytest.raises(DuctorError, match="Invalid reasoning effort"):
+        resolve_cli_config(base_config, codex_cache, task_overrides=overrides)
 
 
 def test_resolve_claude_ignores_reasoning(

--- a/tests/messenger/telegram/test_message_dispatch.py
+++ b/tests/messenger/telegram/test_message_dispatch.py
@@ -1,4 +1,4 @@
-"""Unit tests for ReactionTracker in telegram.message_dispatch (#63)."""
+"""Unit tests for Telegram message dispatch helpers."""
 
 from __future__ import annotations
 
@@ -13,8 +13,11 @@ from ductor_bot.messenger.telegram.message_dispatch import (
     _REACTION_THINKING,
     NonStreamingDispatch,
     ReactionTracker,
+    StreamingDispatch,
     run_non_streaming_message,
+    run_streaming_message,
 )
+from ductor_bot.orchestrator.registry import OrchestratorResult
 from ductor_bot.session.key import SessionKey
 
 
@@ -160,3 +163,121 @@ async def test_non_streaming_reacts_on_trigger_message_not_reply_to() -> None:
 
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+async def test_streaming_reasoning_only_still_sends_final_answer() -> None:
+    """Reasoning text must never suppress the final Telegram answer."""
+    from ductor_bot.config import StreamingConfig
+
+    bot = _make_bot()
+    bot.send_message = AsyncMock(return_value=MagicMock())
+    message = MagicMock()
+    message.message_id = 55
+
+    editor = MagicMock()
+    editor.has_content = False
+    editor.append_text = AsyncMock()
+    editor.append_tool = AsyncMock()
+    editor.append_system = AsyncMock()
+    editor.finalize = AsyncMock()
+
+    orch = MagicMock()
+
+    async def _handle_streaming(*_args, **kwargs):
+        await kwargs["on_reasoning_delta"]("I am thinking through the patch")
+        return OrchestratorResult(text="Final answer delivered")
+
+    orch.handle_message_streaming = AsyncMock(side_effect=_handle_streaming)
+
+    dispatch = StreamingDispatch(
+        bot=bot,
+        orchestrator=orch,
+        message=message,
+        key=SessionKey(chat_id=1),
+        text="hello",
+        streaming_cfg=StreamingConfig(
+            show_reasoning_stream=True,
+            show_tool_progress=True,
+            show_thinking_indicator=False,
+        ),
+        allowed_roots=[Path("/tmp")],
+    )
+
+    with (
+        patch(
+            "ductor_bot.messenger.telegram.message_dispatch.create_stream_editor",
+            return_value=editor,
+        ),
+        patch(
+            "ductor_bot.messenger.telegram.message_dispatch.send_rich",
+            new_callable=AsyncMock,
+        ) as send_rich_mock,
+        patch(
+            "ductor_bot.messenger.telegram.message_dispatch.send_files_from_text",
+            new_callable=AsyncMock,
+        ) as send_files_mock,
+        patch("ductor_bot.messenger.telegram.message_dispatch.TypingContext") as typing_ctx,
+    ):
+        typing_ctx.return_value.__aenter__ = AsyncMock()
+        typing_ctx.return_value.__aexit__ = AsyncMock()
+
+        result = await run_streaming_message(dispatch)
+
+    assert result == "Final answer delivered"
+    send_rich_mock.assert_awaited_once()
+    assert send_rich_mock.await_args.args[2] == "Final answer delivered"
+    send_files_mock.assert_not_awaited()
+
+
+async def test_streaming_tool_progress_can_be_disabled() -> None:
+    from ductor_bot.config import StreamingConfig
+
+    bot = _make_bot()
+    message = MagicMock()
+    message.message_id = 77
+
+    editor = MagicMock()
+    editor.has_content = False
+    editor.append_text = AsyncMock()
+    editor.append_tool = AsyncMock()
+    editor.append_system = AsyncMock()
+    editor.finalize = AsyncMock()
+
+    orch = MagicMock()
+
+    async def _handle_streaming(*_args, **kwargs):
+        await kwargs["on_tool_activity"]("Read")
+        return OrchestratorResult(text="done", stream_fallback=True)
+
+    orch.handle_message_streaming = AsyncMock(side_effect=_handle_streaming)
+
+    dispatch = StreamingDispatch(
+        bot=bot,
+        orchestrator=orch,
+        message=message,
+        key=SessionKey(chat_id=1),
+        text="hello",
+        streaming_cfg=StreamingConfig(show_tool_progress=False),
+        allowed_roots=[Path("/tmp")],
+    )
+
+    with (
+        patch(
+            "ductor_bot.messenger.telegram.message_dispatch.create_stream_editor",
+            return_value=editor,
+        ),
+        patch(
+            "ductor_bot.messenger.telegram.message_dispatch.send_rich",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "ductor_bot.messenger.telegram.message_dispatch.send_files_from_text",
+            new_callable=AsyncMock,
+        ),
+        patch("ductor_bot.messenger.telegram.message_dispatch.TypingContext") as typing_ctx,
+    ):
+        typing_ctx.return_value.__aenter__ = AsyncMock()
+        typing_ctx.return_value.__aexit__ = AsyncMock()
+        await run_streaming_message(dispatch)
+
+    editor.append_tool.assert_not_awaited()

--- a/tests/orchestrator/test_commands.py
+++ b/tests/orchestrator/test_commands.py
@@ -106,6 +106,19 @@ async def test_status_prefers_session_model_over_config(orch: Orchestrator) -> N
     assert "Model: gpt-5.2-codex (configured: opus)" in result.text
 
 
+async def test_status_shows_streaming_visibility_flags(orch: Orchestrator) -> None:
+    orch._config.streaming.show_reasoning_stream = True
+    orch._config.streaming.show_tool_progress = False
+    orch._config.streaming.show_thinking_indicator = False
+
+    with patch("ductor_bot.orchestrator.commands.check_all_auth", return_value={}):
+        result = await cmd_status(orch, SessionKey(chat_id=1), "/status")
+
+    assert "Reasoning stream: on" in result.text
+    assert "Tool progress: off" in result.text
+    assert "Thinking indicator: off" in result.text
+
+
 # -- cmd_memory --
 
 

--- a/tests/orchestrator/test_model_selector.py
+++ b/tests/orchestrator/test_model_selector.py
@@ -384,3 +384,39 @@ async def test_switch_reasoning_only(orch: Orchestrator) -> None:
     assert "Reasoning effort updated" in result
     mock_kill.assert_not_called()
     mock_reset.assert_not_called()
+
+
+async def test_switch_model_rejects_invalid_codex_reasoning_effort(orch: Orchestrator) -> None:
+    from unittest.mock import MagicMock
+
+    from ductor_bot.cli.codex_cache import CodexModelCache
+    from ductor_bot.cli.codex_discovery import CodexModelInfo
+
+    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    orch._observers.codex_cache_obs = MagicMock(
+        get_cache=MagicMock(
+            return_value=CodexModelCache(
+                last_updated="2026-04-23T12:00:00",
+                models=[
+                    CodexModelInfo(
+                        id="gpt-4o-mini",
+                        display_name="GPT-4o Mini",
+                        description="mini",
+                        supported_efforts=(),
+                        default_effort="",
+                        is_default=False,
+                    )
+                ],
+            )
+        )
+    )
+
+    result = await switch_model(
+        orch,
+        SessionKey(chat_id=1),
+        "gpt-4o-mini",
+        reasoning_effort="high",
+    )
+
+    assert "Invalid reasoning effort" in result
+    assert "gpt-4o-mini" in result


### PR DESCRIPTION
## Summary
- separate Telegram reasoning streaming from the lighter thinking indicator so providers that expose reasoning can show it without suppressing the final answer
- make streaming delivery more robust by always sending the final Telegram answer when only reasoning or tool activity was emitted during the turn
- add explicit streaming config flags, surface them in `/status`, document them, and reject unsupported explicit Codex reasoning-effort overrides

## Verification
- python -m ruff check ductor_bot/cli/service.py ductor_bot/cli/param_resolver.py ductor_bot/config.py ductor_bot/messenger/telegram/message_dispatch.py ductor_bot/orchestrator/commands.py ductor_bot/orchestrator/core.py ductor_bot/orchestrator/flows.py ductor_bot/orchestrator/selectors/model_selector.py tests/messenger/telegram/test_message_dispatch.py tests/orchestrator/test_commands.py tests/orchestrator/test_model_selector.py tests/cli/test_param_resolver.py
- pytest tests/messenger/telegram/test_message_dispatch.py tests/orchestrator/test_commands.py tests/orchestrator/test_model_selector.py tests/cli/test_param_resolver.py tests/messenger/telegram/test_streaming.py tests/messenger/telegram/test_edit_streaming.py tests/cli/test_service.py tests/orchestrator/test_flows.py -k "stream or reasoning or tool or status or model or dispatch or flow"
