### PR TITLE
fix(telegram): preserve forum topic on inter-agent / webhook delivery

### DIFF
--- a/ductor_bot/messenger/telegram/transport.py
+++ b/ductor_bot/messenger/telegram/transport.py
@@ -151,7 +151,7 @@ class TelegramTransport:
 
     async def _deliver_interagent(self, env: Envelope) -> None:
         """Deliver inter-agent result (error notification or injected response)."""
-        roots = self._roots()
+        opts = self._opts(env)
 
         if env.is_error:
             session_info = f"\nSession: `{env.session_name}`" if env.session_name else ""
@@ -161,9 +161,7 @@ class TelegramTransport:
                 f"Error: {env.metadata.get('error', 'unknown')}\n"
                 f"Request: _{env.prompt_preview}_"
             )
-            await send_rich(
-                self._bot.bot_instance, env.chat_id, error_text, SendRichOpts(allowed_roots=roots)
-            )
+            await send_rich(self._bot.bot_instance, env.chat_id, error_text, opts)
             return
 
         # Provider switch notice (before result)
@@ -173,17 +171,12 @@ class TelegramTransport:
                 self._bot.bot_instance,
                 env.chat_id,
                 f"**Provider Switch Detected**\n\n{notice}",
-                SendRichOpts(allowed_roots=roots),
+                opts,
             )
 
         # Result text (filled by bus injection)
         if env.result_text:
-            await send_rich(
-                self._bot.bot_instance,
-                env.chat_id,
-                env.result_text,
-                SendRichOpts(allowed_roots=roots),
-            )
+            await send_rich(self._bot.bot_instance, env.chat_id, env.result_text, opts)
 
     async def _deliver_task_result(self, env: Envelope) -> None:
         """Deliver task result notification + injected response."""
@@ -225,12 +218,7 @@ class TelegramTransport:
     async def _deliver_webhook_wake(self, env: Envelope) -> None:
         """Deliver webhook wake result."""
         if env.result_text:
-            await send_rich(
-                self._bot.bot_instance,
-                env.chat_id,
-                env.result_text,
-                SendRichOpts(allowed_roots=self._roots()),
-            )
+            await send_rich(self._bot.bot_instance, env.chat_id, env.result_text, self._opts(env))
 
     async def _deliver_cron(self, env: Envelope) -> None:
         """Deliver cron result to a specific chat/topic (unicast).


### PR DESCRIPTION
## Summary

`_deliver_interagent` and `_deliver_webhook_wake` in
`ductor_bot/messenger/telegram/transport.py` built `SendRichOpts`
directly, dropping `thread_id` (and for inter-agent also
`reply_to_message_id`). Inter-agent replies from a forum topic chat
were always delivered to the chat group's general (no-thread) topic,
and reply-threading was lost in non-forum chats too.

The sister handlers `_deliver_task_result`, `_deliver_task_question`,
and `_deliver_background` already use `self._opts(env)`, which builds:

```python
SendRichOpts(
    reply_to_message_id=envelope.reply_to_message_id,
    allowed_roots=self._roots(),
    thread_id=envelope.topic_id or envelope.thread_id,
)
```

Routing the two outliers through the same helper restores both
topic-thread routing and reply-to handling, and removes the only two
direct `SendRichOpts(allowed_roots=...)` constructions in the file's
delivery paths.

## Symptom

In a Telegram forum chat, calling `ask_agent_async` from a topic
returned the result in the chat's general topic instead of the
originating topic. Same shape of bug for webhook-wake delivery on
forum chats.

## What changed

- `_deliver_interagent`: 3 `send_rich` call sites now share a single
  `opts = self._opts(env)`.
- `_deliver_webhook_wake`: single `send_rich` call now uses
  `self._opts(env)`.

`_deliver_heartbeat` and `_deliver_cron` already pass `thread_id` on
their primary path; their fallback branches deliver to the main
user's private chat, where omitting topic/thread is intentional.
They are unchanged.

## Behaviour outside forum chats

`topic_id` and `thread_id` are `None` on private / non-forum group
envelopes, so `_opts(env)` produces `thread_id=None` and the parameter
is omitted from the API call — the same path the sister handlers
already exercise on those chats. `reply_to_message_id` for
inter-agent / webhook envelopes is whatever the bus puts on them;
if set, the reply is now threaded as a reply, consistent with the
sister handlers.

## Tests

`tests/bus`, `tests/messenger/telegram`, `tests/webhook` — **845
tests pass**.

**Diff**: 1 file, +5 / -17.
