### PR TITLE
fix(env): inject DUCTOR_HOME into CLI subprocesses for sub-agents (rr#19)

### DIFF
--- a/ductor_bot/background/observer.py
+++ b/ductor_bot/background/observer.py
@@ -131,6 +131,7 @@ class BackgroundObserver:
                 cwd=self._paths.workspace,
                 timeout_seconds=self._timeout_seconds,
                 timeout_label="Background task",
+                ductor_home=self._paths.ductor_home,
             )
 
             elapsed = time.monotonic() - t0

--- a/ductor_bot/cron/execution.py
+++ b/ductor_bot/cron/execution.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -213,12 +214,15 @@ async def execute_one_shot(
     provider: str,
     timeout_seconds: float,
     timeout_label: str,
+    extra_env: dict[str, str] | None = None,
 ) -> OneShotExecutionResult:
     """Run one provider CLI command with timeout and normalized status/result."""
     stdin_input = one_shot.stdin_input
+    env = {**os.environ, **extra_env} if extra_env else None
     proc = await asyncio.create_subprocess_exec(
         *one_shot.cmd,
         cwd=str(cwd),
+        env=env,
         stdin=asyncio.subprocess.PIPE if stdin_input is not None else asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/ductor_bot/infra/task_runner.py
+++ b/ductor_bot/infra/task_runner.py
@@ -32,6 +32,7 @@ async def run_oneshot_task(
     cwd: Path,
     timeout_seconds: float,
     timeout_label: str,
+    ductor_home: Path | None = None,
 ) -> TaskResult:
     """Build the CLI command and execute it, returning a normalized result.
 
@@ -49,12 +50,14 @@ async def run_oneshot_task(
             execution=None,
         )
 
+    extra_env = {"DUCTOR_HOME": str(ductor_home)} if ductor_home is not None else None
     execution = await execute_one_shot(
         one_shot,
         cwd=cwd,
         provider=exec_config.provider,
         timeout_seconds=timeout_seconds,
         timeout_label=timeout_label,
+        extra_env=extra_env,
     )
 
     return TaskResult(
@@ -122,6 +125,7 @@ async def execute_in_task_folder(  # noqa: PLR0913
             cwd=folder,
             timeout_seconds=timeout_seconds,
             timeout_label=task_label,
+            ductor_home=observer._paths.ductor_home,
         )
 
         if result.execution is not None:

--- a/tests/cron/test_observer_params.py
+++ b/tests/cron/test_observer_params.py
@@ -41,6 +41,7 @@ def observer(tmp_path: Path, mock_codex_cache: CodexModelCache) -> CronObserver:
 
     # Mock paths
     paths = MagicMock(spec=DuctorPaths)
+    paths.ductor_home = tmp_path
     paths.cron_jobs_path = tmp_path / "cron_jobs.json"
     paths.cron_tasks_dir = tmp_path / "cron_tasks"
     paths.cron_tasks_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Root cause

Sub-agents run as asyncio tasks inside the same Python process as Main — mutating `os.environ` per-agent would be a race condition. `DUCTOR_HOME` was therefore absent from the environment passed to `asyncio.create_subprocess_exec`, causing `_shared.py` in cron/webhook tool scripts to fall back to `~/.ductor` (Main's home) and write state to the wrong registry.

Docker execution was unaffected — `docker.py:319` already sets `DUCTOR_HOME` explicitly.

## Fix

Thread `ductor_home: Path` from each observer's `DuctorPaths` through:
- `execute_in_task_folder` → `run_oneshot_task` → `execute_one_shot` (cron + webhook)
- `BackgroundObserver._run_oneshot` → `run_oneshot_task` → `execute_one_shot`

`execute_one_shot` merges it into `{**os.environ, 'DUCTOR_HOME': str(ductor_home)}` before spawning, so every provider CLI (Claude/Gemini/Codex) and any Bash tool it calls resolves paths against the correct agent home.

## Test plan
- [x] `tests/cron/` + `tests/background/` — 159 passed
- [x] Updated `test_observer_params.py` fixture: added `paths.ductor_home = tmp_path`
- [x] Pre-existing failures confirmed unrelated: `test_docker.py/test_docker_mounts.py` (11) and `test_check_gemini_auth_ductor_config_key` (1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)