### PR TITLE
fix(telegram): drop unaddressed group messages before queue indicator

### DIFF
--- a/ductor_bot/messenger/telegram/app.py
+++ b/ductor_bot/messenger/telegram/app.py
@@ -51,9 +51,9 @@ from ductor_bot.messenger.telegram.handlers import (
 from ductor_bot.messenger.telegram.media import (
     has_media,
     is_command_for_others,
-    is_media_addressed,
     is_message_addressed,
     resolve_media_text,
+    should_drop_in_group,
 )
 from ductor_bot.messenger.telegram.message_dispatch import (
     NonStreamingDispatch,
@@ -216,7 +216,9 @@ class TelegramBot:
 
         self._bus.register_transport(TelegramTransport(self))
         self._sequential = SequentialMiddleware(
-            lock_pool=self._lock_pool, topic_names=self._topic_names
+            lock_pool=self._lock_pool,
+            topic_names=self._topic_names,
+            group_mention_only=config.group_mention_only,
         )
         self._sequential.set_bot(self._bot)
         self._sequential.set_interrupt_handler(self._on_interrupt)
@@ -378,6 +380,7 @@ class TelegramBot:
 
         await run_startup(self)
         self._sequential.set_bot_username(self._bot_username)
+        self._sequential.set_bot_id(self._bot_id)
 
     def _register_handlers(self) -> None:
         r = self._router
@@ -1389,28 +1392,21 @@ class TelegramBot:
 
     async def _resolve_text(self, message: Message) -> str | None:
         """Extract processable text from *message* (plain text or media prompt)."""
-        is_group = message.chat.type in ("group", "supergroup")
+        if should_drop_in_group(
+            message,
+            bot_id=self._bot_id,
+            bot_username=self._bot_username,
+            group_mention_only=self._config.group_mention_only,
+        ):
+            return None
 
         if has_media(message):
-            if is_group and (
-                self._is_for_others(message)
-                or (
-                    self._config.group_mention_only
-                    and not is_media_addressed(message, self._bot_id, self._bot_username)
-                )
-            ):
-                return None
             paths = self._orch.paths
             return await resolve_media_text(
                 self._bot, message, paths.telegram_files_dir, paths.workspace
             )
         if not message.text:
             return None
-        if is_group:
-            if self._is_for_others(message):
-                return None
-            if self._config.group_mention_only and not self._is_addressed(message):
-                return None
         return strip_mention(message.text, self._bot_username)
 
     async def _handle_streaming(

--- a/ductor_bot/messenger/telegram/media.py
+++ b/ductor_bot/messenger/telegram/media.py
@@ -109,6 +109,27 @@ def is_media_addressed(
     return is_message_addressed(message, bot_id, bot_username)
 
 
+def should_drop_in_group(
+    message: Message,
+    *,
+    bot_id: int | None,
+    bot_username: str | None,
+    group_mention_only: bool,
+) -> bool:
+    """True if a group/supergroup message should be silently dropped.
+
+    Drops ``/cmd@other_bot`` commands always, and — when *group_mention_only*
+    is True — any message not addressed to this bot via reply / @mention /
+    ``/cmd@us``. Returns False for non-group chats; the caller can rely on
+    this to skip the check in private DMs.
+    """
+    if message.chat.type not in ("group", "supergroup"):
+        return False
+    if is_command_for_others(message, bot_username):
+        return True
+    return group_mention_only and not is_message_addressed(message, bot_id, bot_username)
+
+
 async def resolve_media_text(
     bot: Bot,
     message: Message,

--- a/ductor_bot/messenger/telegram/middleware.py
+++ b/ductor_bot/messenger/telegram/middleware.py
@@ -28,6 +28,7 @@ from ductor_bot.messenger.telegram.abort import (
     is_interrupt_message,
 )
 from ductor_bot.messenger.telegram.dedup import DedupeCache, build_dedup_key
+from ductor_bot.messenger.telegram.media import should_drop_in_group
 from ductor_bot.messenger.telegram.topic import (
     TopicNameCache,
     get_session_key,
@@ -166,6 +167,8 @@ class SequentialMiddleware(BaseMiddleware):
         self,
         lock_pool: LockPool | None = None,
         topic_names: TopicNameCache | None = None,
+        *,
+        group_mention_only: bool = False,
     ) -> None:
         self._lock_pool = lock_pool if lock_pool is not None else LockPool()
         self._topic_names = topic_names
@@ -177,7 +180,9 @@ class SequentialMiddleware(BaseMiddleware):
         self._pending: dict[int, list[_QueueEntry]] = {}
         self._entry_counter = 0
         self._bot: Bot | None = None
+        self._bot_id: int | None = None
         self._bot_username: str | None = None
+        self._group_mention_only = group_mention_only
 
     @property
     def lock_pool(self) -> LockPool:
@@ -191,6 +196,10 @@ class SequentialMiddleware(BaseMiddleware):
     def set_bot_username(self, bot_username: str | None) -> None:
         """Set the bot username for command mention filtering."""
         self._bot_username = bot_username
+
+    def set_bot_id(self, bot_id: int | None) -> None:
+        """Set the bot user id for reply-to-self detection in group filtering."""
+        self._bot_id = bot_id
 
     def set_interrupt_handler(self, handler: AbortHandler) -> None:
         """Register a callback invoked for interrupt triggers *before* the lock."""
@@ -290,6 +299,26 @@ class SequentialMiddleware(BaseMiddleware):
 
         return False
 
+    def _is_unaddressed_group(self, event: Message) -> bool:
+        """True if this group message is not addressed to us and must be dropped.
+
+        Centralised so the queue indicator (``_send_indicator``) is never
+        rendered for messages the bot would silently discard later.
+        """
+        drop = should_drop_in_group(
+            event,
+            bot_id=self._bot_id,
+            bot_username=self._bot_username,
+            group_mention_only=self._group_mention_only,
+        )
+        if drop:
+            logger.debug(
+                "Unaddressed group message dropped chat=%d msg_id=%d",
+                event.chat.id,
+                event.message_id,
+            )
+        return drop
+
     async def __call__(
         self,
         handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
@@ -298,6 +327,8 @@ class SequentialMiddleware(BaseMiddleware):
     ) -> Any:
         if not isinstance(event, Message) or not event.chat:
             return await handler(event, data)
+        if self._is_unaddressed_group(event):
+            return None
 
         topic_label: str | None = None
         if event.is_topic_message and event.message_thread_id and self._topic_names:
@@ -327,6 +358,19 @@ class SequentialMiddleware(BaseMiddleware):
             return None
 
         session_key = get_session_key(event)
+        return await self._run_under_lock(handler, event, data, chat_id, session_key)
+
+    # -- Internal helpers ------------------------------------------------------
+
+    async def _run_under_lock(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: Message,
+        data: dict[str, Any],
+        chat_id: int,
+        session_key: Any,
+    ) -> Any:
+        """Acquire the per-session lock; queue with indicator if it was busy."""
         lock = self.get_lock(session_key.lock_key)
         entry: _QueueEntry | None = None
 
@@ -343,8 +387,6 @@ class SequentialMiddleware(BaseMiddleware):
                     return None
                 await self._delete_indicator(chat_id, entry)
             return await handler(event, data)
-
-    # -- Internal helpers ------------------------------------------------------
 
     def _create_entry(self, chat_id: int, event: Message) -> _QueueEntry:
         self._entry_counter += 1

--- a/tests/messenger/telegram/test_app.py
+++ b/tests/messenger/telegram/test_app.py
@@ -551,10 +551,10 @@ class TestResolveText:
         result = await tg_bot._resolve_text(msg)
         assert result == "[MEDIA PROMPT]"
 
-    @patch("ductor_bot.messenger.telegram.app.is_media_addressed", return_value=False)
+    @patch("ductor_bot.messenger.telegram.app.should_drop_in_group", return_value=True)
     @patch("ductor_bot.messenger.telegram.app.has_media", return_value=True)
     async def test_media_in_group_not_addressed_mention_only(
-        self, _mock_has: MagicMock, _mock_addr: MagicMock
+        self, _mock_has: MagicMock, _mock_drop: MagicMock
     ) -> None:
         cfg = _make_config(group_mention_only=True)
         tg_bot, _ = _make_tg_bot(cfg)
@@ -578,10 +578,10 @@ class TestResolveText:
         assert result == "[MEDIA]"
 
     @patch("ductor_bot.messenger.telegram.app.resolve_media_text", new_callable=AsyncMock)
-    @patch("ductor_bot.messenger.telegram.app.is_media_addressed", return_value=True)
+    @patch("ductor_bot.messenger.telegram.app.should_drop_in_group", return_value=False)
     @patch("ductor_bot.messenger.telegram.app.has_media", return_value=True)
     async def test_media_in_group_addressed(
-        self, _mock_has: MagicMock, _mock_addr: MagicMock, mock_resolve: AsyncMock
+        self, _mock_has: MagicMock, _mock_drop: MagicMock, mock_resolve: AsyncMock
     ) -> None:
         tg_bot, _ = _make_tg_bot()
         tg_bot._orchestrator = _make_orchestrator()

--- a/tests/messenger/telegram/test_middleware.py
+++ b/tests/messenger/telegram/test_middleware.py
@@ -248,6 +248,64 @@ class TestAuthMiddleware:
 class TestSequentialMiddleware:
     """Test dedup + per-chat sequential lock."""
 
+    async def test_unaddressed_group_message_dropped_before_queue(self) -> None:
+        """In mention_only mode, an unaddressed group message must be dropped
+        before the queue indicator is sent — otherwise users see a misleading
+        '[Message in queue...]' for a bot that will never reply.
+        """
+        from ductor_bot.messenger.telegram.middleware import SequentialMiddleware
+
+        mw = SequentialMiddleware(group_mention_only=True)
+        mw.set_bot_username("mybot")
+        mw.set_bot_id(1)
+        bot = AsyncMock()
+        bot.send_message = AsyncMock(return_value=MagicMock(message_id=999))
+        mw.set_bot(bot)
+
+        # Pre-occupy the lock so an indicator would otherwise be emitted.
+        chat_id = 100
+        held = mw.get_lock((chat_id, None))
+        await held.acquire()
+        try:
+            handler = AsyncMock()
+            msg = _make_message(chat_id=chat_id, text="hi", chat_type="supergroup")
+            msg.entities = []
+            msg.caption = None
+            msg.caption_entities = []
+            msg.reply_to_message = None
+
+            result = await mw(handler, msg, {})
+
+            handler.assert_not_called()
+            bot.send_message.assert_not_called()
+            assert not mw.has_pending(chat_id)
+            assert result is None
+        finally:
+            held.release()
+
+    async def test_addressed_group_message_passes(self) -> None:
+        """A group message with the bot's @mention reaches the handler."""
+        from ductor_bot.messenger.telegram.middleware import SequentialMiddleware
+
+        mw = SequentialMiddleware(group_mention_only=True)
+        mw.set_bot_username("mybot")
+        mw.set_bot_id(1)
+
+        handler = AsyncMock(return_value="ok")
+        msg = _make_message(chat_id=100, text="@mybot hi", chat_type="supergroup")
+        mention = MagicMock()
+        mention.type = "mention"
+        mention.offset = 0
+        mention.length = len("@mybot")
+        msg.entities = [mention]
+        msg.caption = None
+        msg.caption_entities = []
+        msg.reply_to_message = None
+
+        result = await mw(handler, msg, {})
+        handler.assert_called_once()
+        assert result == "ok"
+
     async def test_sequential_processing(self) -> None:
         from ductor_bot.messenger.telegram.middleware import SequentialMiddleware
 


### PR DESCRIPTION
## Problem

In multi-bot groups with `group_mention_only` enabled, every bot in the chat receives every message (Telegram privacy mode is required to be off for mention filtering to work at all).

The addressed-check used to run inside `TelegramBot._resolve_text` — i.e. *after* `SequentialMiddleware` had already enqueued the message and posted a `[Message in queue...]` indicator with a Cancel button. The handler then silently dropped the message, but:

- the misleading indicator stayed visible to users until the lock freed,
- every silently-dropped message cost two extra Telegram API calls (`sendMessage` for the indicator, `deleteMessage` after the drop),
- in chats with several bots the chat fills up with phantom queue notifications from bots that were never going to answer.

Repro: a group with bots A, B, C (privacy mode off, `group_mention_only=true`). User replies to bot A's message and writes `@B …`. Bot C — not addressed in any way — still flashes a `[Message in queue...]` notification while its session lock is busy.

## Fix

Move the filter into `SequentialMiddleware` so unaddressed group messages are short-circuited *before* the queue indicator is rendered.

- New shared helper `should_drop_in_group` in `media.py` consolidates the two drop reasons (`/cmd@other_bot` always, and — in mention-only mode — missing reply / @mention / `cmd@us`).
- `SequentialMiddleware` accepts `group_mention_only` in its constructor and gains a `set_bot_id(...)` setter (called after `getMe`, alongside the existing `set_bot_username`).
- `_resolve_text` is simplified to use the same helper, so middleware and handler no longer carry duplicated branches.
- The lock/queue body is extracted into `_run_under_lock` (no behaviour change; needed to keep `__call__` within ruff's `C901` / `PLR0911` budget after the new early-return).

## Tests

Two new tests in `tests/messenger/telegram/test_middleware.py` cover the queue-indicator path explicitly: an unaddressed group message arriving while the lock is held must produce no handler call, no `bot.send_message`, and no pending entry; an addressed message with `@bot` still reaches the handler.

Existing `test_app.py` cases for `_resolve_text` were re-targeted to patch `should_drop_in_group` (the underlying logic and behaviour are unchanged).

- `pytest tests/messenger/telegram/` — 591 passed.
- `ruff check` / `mypy` — clean.