### PR TITLE
feat(gemini): expose CLI auto/pro/flash/flash-lite aliases in /model selector

### DIFF
--- a/ductor_bot/orchestrator/selectors/model_selector.py
+++ b/ductor_bot/orchestrator/selectors/model_selector.py
@@ -121,13 +121,19 @@ def _validate_codex_reasoning_effort(
     )
 
 
+# Built-in Gemini aliases accepted by the Gemini CLI as `--model` values.
+# `auto` lets the CLI pick the best model per request; `pro`/`flash`/`flash-lite`
+# select the latest model of that tier without pinning a specific version.
+_GEMINI_ALIAS_ORDER: tuple[str, ...] = ("auto", "pro", "flash", "flash-lite")
+
+
 def _gemini_models_for_selector() -> list[str]:
-    """Return Gemini models discovered from local Gemini CLI files."""
+    """Return Gemini built-in aliases, then models discovered from the CLI files."""
     models = sorted(get_gemini_models())
     # Prefer stable models before previews in the selector.
     stable = [model for model in models if "preview" not in model]
     preview = [model for model in models if "preview" in model]
-    return [*stable, *preview]
+    return [*_GEMINI_ALIAS_ORDER, *stable, *preview]
 
 
 def _button_label(model_id: str) -> str:

--- a/tests/orchestrator/test_model_selector.py
+++ b/tests/orchestrator/test_model_selector.py
@@ -191,6 +191,21 @@ async def test_start_one_provider_gemini_uses_discovered_models(orch: Orchestrat
     assert "3-pro-preview" in labels
 
 
+async def test_start_one_provider_gemini_includes_builtin_aliases(orch: Orchestrator) -> None:
+    set_gemini_models(frozenset({"gemini-2.5-pro", "gemini-2.5-flash"}))
+    with _patch_auth(
+        {"claude": _NOT_FOUND_CLAUDE, "codex": _NOT_FOUND_CODEX, "gemini": _AUTHED_GEMINI}
+    ):
+        resp = await model_selector_start(orch, SessionKey(chat_id=1))
+    assert resp.buttons is not None
+    labels = [btn.text for row in resp.buttons.rows for btn in row]
+    # Built-in CLI aliases come first so the user can pick auto-routing without
+    # pinning a specific model version.
+    for alias in ("auto", "pro", "flash", "flash-lite"):
+        assert alias in labels
+    assert labels.index("auto") < labels.index("2.5-pro")
+
+
 # -- handle_model_callback: provider selection --
 
 


### PR DESCRIPTION
## Summary

- Surface the four built-in Gemini CLI aliases (`auto`, `pro`, `flash`, `flash-lite`) at the top of the `/model` keyboard for the Gemini provider.
- `auto` lets the CLI pick the optimal model per request; the tier aliases track the latest stable version of that tier without pinning a specific version.
- Until now `/model` only exposed discovered model IDs (e.g. `gemini-2.5-flash`), so users were forced to pin a concrete version and could not opt into the CLI's built-in routing.
- The aliases were already recognised by the rest of the stack (`_GEMINI_ALIASES`, `provider_for`, param resolver) — only the selector UI was missing them.

## Test plan

- [x] `pytest tests/orchestrator/test_model_selector.py` (added `test_start_one_provider_gemini_includes_builtin_aliases`)
- [x] `ruff format` + `ruff check` clean on changed files
- [x] Verified all four aliases are accepted by Gemini CLI as `--model` values (`gemini -m auto -p ...`, `gemini -m flash -p ...`, etc.)

## Notes

Stable-before-preview ordering of discovered models is preserved underneath the aliases.