### PR TITLE
test: exercise PR Guardian live agent

### DIFF
--- a/ductor_bot/pr_guardian_live_smoke.py
+++ b/ductor_bot/pr_guardian_live_smoke.py
@@ -1,0 +1,12 @@
+"""Small PR Guardian live-agent smoke helper.
+
+This module exists only on the synthetic PR branch used to exercise the
+external PR Guardian reviewer with a real Claude Code agent.
+"""
+
+from __future__ import annotations
+
+
+def normalize_live_agent_marker(value: str) -> str:
+    """Normalize a marker used by live PR Guardian smoke tests."""
+    return "-".join(value.strip().lower().split())

--- a/tests/e2e/test_pr_guardian_live_smoke.py
+++ b/tests/e2e/test_pr_guardian_live_smoke.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from ductor_bot.pr_guardian_live_smoke import normalize_live_agent_marker
+
+
+def test_normalize_live_agent_marker() -> None:
+    assert normalize_live_agent_marker("  PR Guardian   Live  Agent  ") == "pr-guardian-live-agent"


### PR DESCRIPTION
Synthetic PR used to exercise the external PR Guardian reviewer agent against Ductor.\n\nThis adds a tiny branch-only helper plus a focused E2E test so Guardian can infer intent, select checks, execute them, and report evidence. This PR is not intended to be merged into production.