### PR TITLE
fix(codex): pass prompts via stdin

### DIFF
--- a/ductor_bot/cli/base.py
+++ b/ductor_bot/cli/base.py
@@ -42,7 +42,7 @@ async def _feed_stdin_and_close(
     if windows_only and not _IS_WINDOWS:
         return
 
-    writer = process.stdin
+    writer = getattr(process, "stdin", None)
     if writer is None:
         return
 

--- a/ductor_bot/cli/codex_provider.py
+++ b/ductor_bot/cli/codex_provider.py
@@ -10,7 +10,6 @@ from shutil import which
 from typing import TYPE_CHECKING
 
 from ductor_bot.cli.base import (
-    _IS_WINDOWS,
     BaseCLI,
     CLIConfig,
     docker_wrap,
@@ -108,16 +107,14 @@ class CodexCLI(BaseCLI):
             return ["--full-auto"]
         return ["--sandbox", cfg.sandbox_mode]
 
-    def _build_resume_command(
-        self, final_prompt: str, session_id: str, *, json_output: bool
-    ) -> list[str]:
+    def _build_resume_command(self, session_id: str, *, json_output: bool) -> list[str]:
         """Build command to resume an existing Codex session."""
         cmd = [self._cli, "exec", "resume"]
         if json_output:
             cmd.append("--json")
         cmd += self._sandbox_flags()
         cmd += ["--", session_id]
-        cmd.append("-" if _IS_WINDOWS else final_prompt)
+        cmd.append("-")
         return cmd
 
     def _build_command(
@@ -128,10 +125,9 @@ class CodexCLI(BaseCLI):
         json_output: bool = True,
     ) -> list[str]:
         cfg = self._config
-        final_prompt = self._compose_prompt(prompt)
 
         if resume_session:
-            return self._build_resume_command(final_prompt, resume_session, json_output=json_output)
+            return self._build_resume_command(resume_session, json_output=json_output)
 
         cmd = [self._cli, "exec"]
         if json_output:
@@ -154,18 +150,17 @@ class CodexCLI(BaseCLI):
             cmd.extend(cfg.cli_parameters)
 
         cmd.append("--")
-        # On Windows, .CMD wrappers mangle arguments with special characters.
-        # Use "-" so Codex reads stdin without emitting the "Reading prompt..."
-        # notice as a stdout prelude before JSONL.
-        cmd.append("-" if _IS_WINDOWS else final_prompt)
+        # Keep large composed prompts out of argv; Linux enforces per-arg and
+        # total argv/env limits before Codex can even start.
+        cmd.append("-")
         return cmd
 
     def _docker_wrap(self, cmd: list[str]) -> tuple[list[str], str | None]:
-        """Keep stdin open for Dockerized Codex on Windows so prompts reach the CLI."""
+        """Keep stdin open for Dockerized Codex so piped prompts reach the CLI."""
         return docker_wrap(
             cmd,
             self._config,
-            interactive=_IS_WINDOWS,
+            interactive=True,
         )
 
     async def send(
@@ -179,12 +174,20 @@ class CodexCLI(BaseCLI):
         """Send a prompt and return the final result."""
         if continue_session:
             logger.debug("continue_session is not supported by Codex CLI, ignoring")
+        final_prompt = self._compose_prompt(prompt)
         cmd = self._build_command(prompt, resume_session, json_output=True)
         exec_cmd, use_cwd = self._docker_wrap(cmd)
         _log_cmd(exec_cmd)
         return await run_oneshot_subprocess(
             config=self._config,
-            spec=SubprocessSpec(exec_cmd, use_cwd, prompt, timeout_seconds, timeout_controller),
+            spec=SubprocessSpec(
+                exec_cmd,
+                use_cwd,
+                prompt,
+                timeout_seconds,
+                timeout_controller,
+                stdin_text=final_prompt,
+            ),
             parse_output=self._parse_output,
             provider_label="Codex",
         )
@@ -198,6 +201,7 @@ class CodexCLI(BaseCLI):
         timeout_controller: TimeoutController | None = None,
     ) -> AsyncGenerator[StreamEvent, None]:
         """Send a prompt and yield stream events as they arrive."""
+        final_prompt = self._compose_prompt(prompt)
         cmd = self._build_command(prompt, resume_session, json_output=True)
         exec_cmd, use_cwd = self._docker_wrap(cmd)
         _log_cmd(exec_cmd, streaming=True)
@@ -226,7 +230,14 @@ class CodexCLI(BaseCLI):
 
         async for event in run_streaming_subprocess(
             config=self._config,
-            spec=SubprocessSpec(exec_cmd, use_cwd, prompt, timeout_seconds, timeout_controller),
+            spec=SubprocessSpec(
+                exec_cmd,
+                use_cwd,
+                prompt,
+                timeout_seconds,
+                timeout_controller,
+                stdin_text=final_prompt,
+            ),
             line_handler=line_handler,
             provider_label="Codex",
             post_handler=post_handler,

--- a/ductor_bot/cli/executor.py
+++ b/ductor_bot/cli/executor.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from ductor_bot.cli.base import (
     _IS_WINDOWS,
     CLIConfig,
+    _feed_stdin_and_close,
     _win_feed_stdin,
 )
 from ductor_bot.cli.stream_events import ResultEvent, StreamEvent
@@ -78,13 +79,14 @@ def build_subprocess_env(config: CLIConfig) -> dict[str, str] | None:
 
 @dataclass(slots=True)
 class SubprocessSpec:
-    """What to run: command, working directory, prompt, and timeout."""
+    """What to run: command, working directory, prompt, timeout, and stdin."""
 
     exec_cmd: list[str]
     use_cwd: str | None
     prompt: str
     timeout_seconds: float | None = None
     timeout_controller: TimeoutController | None = None
+    stdin_text: str | None = None
 
 
 @dataclass(slots=True)
@@ -132,7 +134,7 @@ async def run_streaming_subprocess(
 
     Lifecycle:
     1. Create subprocess with stdout/stderr pipes
-    2. Feed stdin on Windows (prompt via pipe)
+    2. Feed stdin when requested (or on Windows legacy prompt pipe)
     3. Register in process registry
     4. Drain stderr in background task
     5. Stream stdout lines through *line_handler* with timeout
@@ -143,7 +145,7 @@ async def run_streaming_subprocess(
     subprocess_env = build_subprocess_env(config) if spec.use_cwd else None
     process = await asyncio.create_subprocess_exec(
         *spec.exec_cmd,
-        stdin=_win_stdin_pipe(),
+        stdin=_stdin_pipe(spec),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=spec.use_cwd,
@@ -154,7 +156,7 @@ async def run_streaming_subprocess(
     if process.stdout is None or process.stderr is None:
         msg = "Subprocess created without stdout/stderr pipes"
         raise RuntimeError(msg)
-    _win_feed_stdin(process, spec.prompt)
+    await _feed_streaming_stdin(process, spec)
     logger.info("%s subprocess starting pid=%s", provider_label, process.pid)
 
     reg = config.process_registry
@@ -279,7 +281,7 @@ async def run_oneshot_subprocess(
 
     Lifecycle:
     1. Create subprocess with pipes
-    2. Communicate (stdin on Windows + wait)
+    2. Communicate (optional stdin + wait)
     3. Register/unregister in process registry
     4. Handle timeout
     5. Parse output via *parse_output* callback
@@ -287,7 +289,7 @@ async def run_oneshot_subprocess(
     oneshot_env = build_subprocess_env(config) if spec.use_cwd else None
     process = await asyncio.create_subprocess_exec(
         *spec.exec_cmd,
-        stdin=_win_stdin_pipe(),
+        stdin=_stdin_pipe(spec),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=spec.use_cwd,
@@ -303,7 +305,7 @@ async def run_oneshot_subprocess(
         else None
     )
     try:
-        stdin_data = spec.prompt.encode() if _IS_WINDOWS else None
+        stdin_data = _stdin_bytes(spec)
         if spec.timeout_controller:
             communicate_coro = process.communicate(input=stdin_data)
             stdout, stderr = await spec.timeout_controller.run_with_timeout(communicate_coro)
@@ -327,9 +329,27 @@ async def run_oneshot_subprocess(
 # ---------------------------------------------------------------------------
 
 
-def _win_stdin_pipe() -> int | None:
-    """Return ``asyncio.subprocess.PIPE`` on Windows, else ``None``."""
-    return asyncio.subprocess.PIPE if _IS_WINDOWS else None
+def _stdin_pipe(spec: SubprocessSpec) -> int | None:
+    """Return a stdin pipe when the provider supplies stdin or Windows needs it."""
+    return asyncio.subprocess.PIPE if spec.stdin_text is not None or _IS_WINDOWS else None
+
+
+def _stdin_bytes(spec: SubprocessSpec) -> bytes | None:
+    """Return bytes to feed to communicate(), preserving Windows legacy behavior."""
+    if spec.stdin_text is not None:
+        return spec.stdin_text.encode()
+    return spec.prompt.encode() if _IS_WINDOWS else None
+
+
+async def _feed_streaming_stdin(
+    process: asyncio.subprocess.Process,
+    spec: SubprocessSpec,
+) -> None:
+    """Feed stdin for streaming processes, using the old Windows fallback when needed."""
+    if spec.stdin_text is not None:
+        await _feed_stdin_and_close(process, spec.stdin_text)
+        return
+    _win_feed_stdin(process, spec.prompt)
 
 
 async def _cancel_drain(drain: asyncio.Task[bytes]) -> None:

--- a/tests/cli/test_codex_provider.py
+++ b/tests/cli/test_codex_provider.py
@@ -35,7 +35,6 @@ def _default_non_windows_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep platform-sensitive command tests stable on Windows hosts."""
     monkeypatch.setattr("ductor_bot.cli.base._IS_WINDOWS", False)
     monkeypatch.setattr("ductor_bot.cli.executor._IS_WINDOWS", False)
-    monkeypatch.setattr("ductor_bot.cli.codex_provider._IS_WINDOWS", False)
 
 
 def _make_cli(monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> CodexCLI:
@@ -88,6 +87,9 @@ def _make_streaming_process(
     stderr_mock = AsyncMock()
     stderr_mock.read = AsyncMock(return_value=stderr)
     proc.stderr = stderr_mock
+    proc.stdin = MagicMock()
+    proc.stdin.drain = MagicMock(return_value=None)
+    proc.stdin.close = MagicMock()
 
     return proc
 
@@ -196,7 +198,8 @@ class TestBuildCommand:
         assert "--model" in cmd
         idx_model = cmd.index("--model")
         assert cmd[idx_model + 1] == "gpt-5.2-codex"
-        assert cmd[-1] == "hello"
+        assert cmd[-2:] == ["--", "-"]
+        assert "hello" not in cmd
 
     def test_json_output_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cli = _make_cli(monkeypatch)
@@ -208,9 +211,8 @@ class TestBuildCommand:
         cmd = cli._build_command("hello")
         assert "--model" not in cmd
 
-    def test_windows_exec_uses_dash_prompt_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Windows sends prompts via stdin without Codex's stdout stdin notice."""
-        monkeypatch.setattr("ductor_bot.cli.codex_provider._IS_WINDOWS", True)
+    def test_exec_uses_dash_prompt_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Codex reads prompts via stdin to avoid argv size limits."""
         cli = _make_cli(monkeypatch)
 
         cmd = cli._build_command("hello")
@@ -218,9 +220,8 @@ class TestBuildCommand:
         assert cmd[-2:] == ["--", "-"]
         assert "hello" not in cmd
 
-    def test_windows_resume_uses_dash_prompt_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Resume on Windows must explicitly read the prompt from stdin."""
-        monkeypatch.setattr("ductor_bot.cli.codex_provider._IS_WINDOWS", True)
+    def test_resume_uses_dash_prompt_marker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Resume must explicitly read the prompt from stdin."""
         cli = _make_cli(monkeypatch)
 
         cmd = cli._build_command("hello", resume_session="thread-abc")
@@ -293,17 +294,17 @@ class TestBuildCommand:
     def test_prompt_composed_in_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cli = _make_cli(monkeypatch, system_prompt="SYS", append_system_prompt="APPEND")
         cmd = cli._build_command("user msg")
-        final_arg = cmd[-1]
-        assert "SYS" in final_arg
-        assert "user msg" in final_arg
-        assert "APPEND" in final_arg
+        assert cmd[-2:] == ["--", "-"]
+        assert "SYS" not in cmd
+        assert "user msg" not in cmd
+        assert "APPEND" not in cmd
 
     def test_resume_prompt_also_composed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cli = _make_cli(monkeypatch, system_prompt="SYS")
         cmd = cli._build_command("user msg", resume_session="th-1")
-        final_arg = cmd[-1]
-        assert "SYS" in final_arg
-        assert "user msg" in final_arg
+        assert cmd[-3:] == ["--", "th-1", "-"]
+        assert "SYS" not in cmd
+        assert "user msg" not in cmd
 
 
 # ---------------------------------------------------------------------------
@@ -560,6 +561,56 @@ class TestSend:
 
         assert "Resumed" in resp.result
 
+    async def test_send_passes_composed_prompt_via_stdin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cli = _make_cli(monkeypatch, system_prompt="SYS", append_system_prompt="APPEND")
+        jsonl = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "OK"},
+            }
+        )
+        proc = _make_process_mock(stdout=jsonl.encode(), returncode=0)
+
+        with patch("ductor_bot.cli.executor.asyncio") as mock_asyncio:
+            mock_asyncio.timeout = asyncio.timeout
+            mock_asyncio.subprocess = asyncio.subprocess
+            mock_asyncio.create_subprocess_exec = AsyncMock(return_value=proc)
+
+            await cli.send("hello")
+
+        call_args = mock_asyncio.create_subprocess_exec.call_args
+        assert call_args.args[-2:] == ("--", "-")
+        assert "hello" not in call_args.args
+        assert call_args.kwargs["stdin"] == asyncio.subprocess.PIPE
+        proc.communicate.assert_awaited_once_with(input=b"SYS\n\nhello\n\nAPPEND")
+
+    async def test_send_resume_passes_composed_prompt_via_stdin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cli = _make_cli(monkeypatch, system_prompt="SYS")
+        jsonl = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "OK"},
+            }
+        )
+        proc = _make_process_mock(stdout=jsonl.encode(), returncode=0)
+
+        with patch("ductor_bot.cli.executor.asyncio") as mock_asyncio:
+            mock_asyncio.timeout = asyncio.timeout
+            mock_asyncio.subprocess = asyncio.subprocess
+            mock_asyncio.create_subprocess_exec = AsyncMock(return_value=proc)
+
+            await cli.send("hello", resume_session="thread-xyz")
+
+        call_args = mock_asyncio.create_subprocess_exec.call_args
+        assert call_args.args[-3:] == ("--", "thread-xyz", "-")
+        assert "hello" not in call_args.args
+        assert call_args.kwargs["stdin"] == asyncio.subprocess.PIPE
+        proc.communicate.assert_awaited_once_with(input=b"SYS\n\nhello")
+
     async def test_send_registry_unregisters_on_timeout(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -588,6 +639,40 @@ class TestSend:
 
 
 class TestSendStreaming:
+    async def test_streaming_passes_composed_prompt_via_stdin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cli = _make_cli(monkeypatch, system_prompt="SYS")
+        proc = _make_streaming_process(
+            [
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "agent_message", "text": "OK"},
+                    }
+                )
+            ],
+            returncode=0,
+        )
+        proc.stdin = MagicMock()
+        proc.stdin.drain = MagicMock(return_value=None)
+        proc.stdin.close = MagicMock()
+
+        with patch("ductor_bot.cli.executor.asyncio") as mock_asyncio:
+            mock_asyncio.timeout = asyncio.timeout
+            mock_asyncio.subprocess = asyncio.subprocess
+            mock_asyncio.create_subprocess_exec = AsyncMock(return_value=proc)
+            mock_asyncio.create_task = asyncio.ensure_future
+
+            await _collect_events(cli.send_streaming("hello"))
+
+        call_args = mock_asyncio.create_subprocess_exec.call_args
+        assert call_args.args[-2:] == ("--", "-")
+        assert "hello" not in call_args.args
+        assert call_args.kwargs["stdin"] == asyncio.subprocess.PIPE
+        proc.stdin.write.assert_called_once_with(b"SYS\n\nhello")
+        proc.stdin.close.assert_called_once()
+
     async def test_streaming_full_sequence(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cli = _make_cli(monkeypatch)
         lines = [
@@ -1104,11 +1189,10 @@ class TestDockerIntegration:
         assert call_args.kwargs.get("cwd") is None
         assert resp.result == "docker OK"
 
-    async def test_send_with_docker_container_keeps_stdin_open_on_windows(
+    async def test_send_with_docker_container_keeps_stdin_open(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Windows Codex-in-Docker must use ``docker exec -i`` so stdin prompts arrive."""
-        monkeypatch.setattr("ductor_bot.cli.codex_provider._IS_WINDOWS", True)
+        """Dockerized Codex must use ``docker exec -i`` so stdin prompts arrive."""
         cli = CodexCLI(
             CLIConfig(
                 provider="codex",
@@ -1245,12 +1329,13 @@ class TestSendWithoutRegistry:
 
 class TestResumeCommandArgOrder:
     def test_resume_session_id_before_prompt(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The resume command must have: ... thread_id prompt (in that order)."""
+        """The resume command must have: ... thread_id - (stdin marker)."""
         cli = _make_cli(monkeypatch, system_prompt=None, append_system_prompt=None)
         cmd = cli._build_command("my prompt", resume_session="th-abc")
-        # thread_id and prompt should be the last two args
+        # thread_id and stdin marker should be the last two args
         assert cmd[-2] == "th-abc"
-        assert cmd[-1] == "my prompt"
+        assert cmd[-1] == "-"
+        assert "my prompt" not in cmd
 
     def test_resume_with_empty_images_no_crash(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Resume path ignores images even if set (they're not in the resume branch)."""

--- a/tests/integration/test_cli_parameter_flow.py
+++ b/tests/integration/test_cli_parameter_flow.py
@@ -93,8 +93,9 @@ def test_main_agent_codex_parameters() -> None:
     assert "--codex-flag" in params_before_separator
     assert "codex-value" in params_before_separator
 
-    # Verify prompt comes after separator
-    assert cmd[separator_idx + 1] == "test prompt"
+    # Verify prompt is read from stdin after the separator.
+    assert cmd[separator_idx + 1] == "-"
+    assert "test prompt" not in cmd
 
 
 def test_parameter_isolation() -> None:


### PR DESCRIPTION
## Summary

Pass Codex prompts through stdin instead of argv on all platforms.

## Why

Ductor composes prompts with hooks, background task context, and memory. Passing the full prompt as a command-line argument can exceed Linux argv limits before the Codex CLI starts, raising `OSError: [Errno 7] Argument list too long`.

## Changes

- Use `-` as the Codex prompt marker for new and resumed `codex exec` calls.
- Add optional stdin payload support to the shared CLI subprocess executor.
- Keep Dockerized Codex stdin open with `docker exec -i` so piped prompts arrive.
- Cover non-streaming, resume, streaming, and CLI parameter command shape with tests.

## Validation

- `uv run pytest tests/cli/test_codex_provider.py tests/integration/test_cli_parameter_flow.py tests/cli/test_executor_timeout.py tests/cli/test_claude_provider.py tests/cli/test_docker_wrap.py -q`
- `uv run ruff check ductor_bot/cli/base.py ductor_bot/cli/executor.py ductor_bot/cli/codex_provider.py tests/cli/test_codex_provider.py tests/integration/test_cli_parameter_flow.py`
- `uv run mypy ductor_bot`
