### PR TITLE
fix(task_runner): forward ~/.ductor/.env secrets to one-shot subprocess

### DIFF
--- a/ductor_bot/infra/task_runner.py
+++ b/ductor_bot/infra/task_runner.py
@@ -58,6 +58,13 @@ async def run_oneshot_task(
 
     if options.ductor_home is not None:
         one_shot.env_overrides["DUCTOR_HOME"] = str(options.ductor_home)
+        import os
+
+        from ductor_bot.infra.env_secrets import load_env_secrets
+
+        for k, v in load_env_secrets(options.ductor_home / ".env").items():
+            if k not in os.environ and k not in one_shot.env_overrides:
+                one_shot.env_overrides[k] = v
     execution = await execute_one_shot(
         one_shot,
         cwd=options.cwd,

--- a/tests/infra/test_task_runner.py
+++ b/tests/infra/test_task_runner.py
@@ -1,0 +1,116 @@
+"""Tests for run_oneshot_task .env forwarding into one_shot.env_overrides."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from ductor_bot.cli.param_resolver import TaskExecutionConfig
+from ductor_bot.cron.execution import OneShotCommand, OneShotExecutionResult
+from ductor_bot.infra.env_secrets import clear_cache
+from ductor_bot.infra.task_runner import TaskRunOptions, run_oneshot_task
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _exec_config() -> TaskExecutionConfig:
+    return TaskExecutionConfig(
+        provider="claude",
+        model="opus",
+        reasoning_effort="",
+        cli_parameters=[],
+        permission_mode="bypassPermissions",
+        working_dir="/tmp",
+        file_access="all",
+    )
+
+
+def _exec_result() -> OneShotExecutionResult:
+    return OneShotExecutionResult(
+        status="success",
+        result_text="ok",
+        stdout=b"",
+        stderr=b"",
+        returncode=0,
+        timed_out=False,
+    )
+
+
+async def _run_and_capture(
+    tmp_path: Path,
+) -> dict[str, str]:
+    """Drive run_oneshot_task with a fixed OneShotCommand and capture env_overrides."""
+    captured: list[dict[str, str]] = []
+    cmd = OneShotCommand(cmd=["/usr/bin/claude", "-p", "--", "hi"])
+
+    async def fake_exec(one_shot: OneShotCommand, **_: object) -> OneShotExecutionResult:
+        captured.append(dict(one_shot.env_overrides))
+        return _exec_result()
+
+    with (
+        patch("ductor_bot.cron.execution.build_cmd", return_value=cmd),
+        patch(
+            "ductor_bot.cron.execution.execute_one_shot",
+            new=AsyncMock(side_effect=fake_exec),
+        ),
+    ):
+        await run_oneshot_task(
+            _exec_config(),
+            "hi",
+            TaskRunOptions(
+                cwd=tmp_path,
+                timeout_seconds=60,
+                timeout_label="test",
+                ductor_home=tmp_path,
+            ),
+        )
+
+    assert len(captured) == 1
+    return captured[0]
+
+
+class TestDotenvForwarding:
+    """run_oneshot_task merges ~/.ductor/.env into one_shot.env_overrides."""
+
+    async def test_forwards_keys_not_in_environ(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / ".env").write_text("DUCTOR_PR_TEST_DOTENV_KEY=from-file\n")
+        monkeypatch.delenv("DUCTOR_PR_TEST_DOTENV_KEY", raising=False)
+        clear_cache()
+
+        overrides = await _run_and_capture(tmp_path)
+
+        assert overrides["DUCTOR_PR_TEST_DOTENV_KEY"] == "from-file"
+        assert overrides["DUCTOR_HOME"] == str(tmp_path)
+
+    async def test_existing_environ_key_not_overridden(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / ".env").write_text("PRESET=from-file\n")
+        monkeypatch.setenv("PRESET", "from-process")
+        clear_cache()
+
+        overrides = await _run_and_capture(tmp_path)
+
+        assert "PRESET" not in overrides
+        assert overrides["DUCTOR_HOME"] == str(tmp_path)
+
+    async def test_ductor_home_not_overridden_by_dotenv(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / ".env").write_text("DUCTOR_HOME=/wrong\n")
+        monkeypatch.delenv("DUCTOR_HOME", raising=False)
+        clear_cache()
+
+        overrides = await _run_and_capture(tmp_path)
+
+        assert overrides["DUCTOR_HOME"] == str(tmp_path)


### PR DESCRIPTION
## Background

When I edit `~/.ductor/.env` while ductor is running (e.g. adding a new API key for a new skill, or rotating a secret), interactive chat picks up the change on the very next message — `cli/executor.py:_build_env` re-reads the file each turn via `env_secrets.load_env_secrets` (mtime-cached, no override of existing process env).

Cron, webhook, and background one-shots don't see the edit until I fully restart the bot, because they only receive `DUCTOR_HOME` injected into `OneShotCommand.env_overrides` (added by rr#19 / #121).  Any newly added key in `.env` is invisible to them until restart.

It would be more convenient if those one-shots also re-read `.env` so a freshly added key is usable on the next cron tick / background task without bouncing the bot.

## Proposed change

In `infra/task_runner.run_oneshot_task`, when `ductor_home` is provided, also merge `load_env_secrets(ductor_home / ".env")` into `one_shot.env_overrides`, skipping keys already set in `os.environ` or already present in `env_overrides` (so the existing `DUCTOR_HOME` injection stays authoritative).  Same low-priority merge policy as `cli/executor.py:_build_env` — keys already in the process environment are never overridden.

When `ductor_home` is `None`, behavior is unchanged.

## Test plan

- [x] `pytest tests/infra/test_task_runner.py tests/infra/test_env_secrets.py tests/cron tests/background tests/webhook` — 317 passed
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy` clean

Added `tests/infra/test_task_runner.py` with 3 regression gates for the new merge policy:
- `.env` keys absent from `os.environ` are forwarded into `env_overrides`
- pre-existing process env wins over `.env`
- `DUCTOR_HOME` set above the merge is never overridden by a stray `DUCTOR_HOME=` line in `.env`
