### PR TITLE
fix(orchestrator): use active session's provider/model when injecting prompts

### DIFF
--- a/ductor_bot/orchestrator/injection.py
+++ b/ductor_bot/orchestrator/injection.py
@@ -60,6 +60,8 @@ async def _inject_prompt(  # noqa: PLR0913
         topic_id=topic_id,
         transport=transport,
         process_label=process_label,
+        provider_override=active.provider if active else None,
+        model_override=active.model if active else None,
         resume_session=resume_id,
         timeout_seconds=orch._config.cli_timeout,
     )

--- a/tests/orchestrator/test_injection.py
+++ b/tests/orchestrator/test_injection.py
@@ -1,0 +1,61 @@
+"""Tests for _inject_prompt provider/model resolution from the active session."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ductor_bot.cli.types import AgentRequest, AgentResponse
+from ductor_bot.orchestrator.injection import _inject_prompt
+
+
+def _make_orch(active: Any) -> MagicMock:
+    orch = MagicMock()
+    orch._sessions.get_active = AsyncMock(return_value=active)
+    orch._cli_service.execute = AsyncMock(
+        return_value=AgentResponse(result="ok", session_id="any", is_error=False)
+    )
+    orch._config.cli_timeout = 60
+    return orch
+
+
+def _captured_request(orch: MagicMock) -> AgentRequest:
+    return cast("AgentRequest", orch._cli_service.execute.await_args.args[0])
+
+
+class TestInjectPromptProviderOverride:
+    """`_inject_prompt` passes the active session's provider/model into AgentRequest."""
+
+    async def test_uses_active_session_provider_model(self) -> None:
+        active = MagicMock(session_id="sid", provider="codex", model="gpt-5.5")
+        orch = _make_orch(active)
+
+        with patch("ductor_bot.orchestrator.injection._update_session", new=AsyncMock()):
+            await _inject_prompt(orch, "hi", chat_id=1, process_label="task_result:x")
+
+        req = _captured_request(orch)
+        assert req.provider_override == "codex"
+        assert req.model_override == "gpt-5.5"
+        assert req.resume_session == "sid"
+
+    async def test_falls_back_to_none_when_no_active_session(self) -> None:
+        orch = _make_orch(None)
+
+        with patch("ductor_bot.orchestrator.injection._update_session", new=AsyncMock()):
+            await _inject_prompt(orch, "hi", chat_id=1, process_label="task_result:x")
+
+        req = _captured_request(orch)
+        assert req.provider_override is None
+        assert req.model_override is None
+        assert req.resume_session is None
+
+    async def test_claude_active_session(self) -> None:
+        active = MagicMock(session_id="sid", provider="claude", model="opus")
+        orch = _make_orch(active)
+
+        with patch("ductor_bot.orchestrator.injection._update_session", new=AsyncMock()):
+            await _inject_prompt(orch, "hi", chat_id=1, process_label="task_result:x")
+
+        req = _captured_request(orch)
+        assert req.provider_override == "claude"
+        assert req.model_override == "opus"


### PR DESCRIPTION
## Background

`_inject_prompt` in `orchestrator/injection.py` builds the `AgentRequest`
without `provider_override` or `model_override`, so `CLIService` falls
back to the bot's default provider/model.

Sessions are per-topic (`SessionKey(transport, chat_id, topic_id)`), so a
single chat can have one topic on Codex and another on Claude even when
the bot default is `claude`. When the default disagrees with the topic's
active session provider, `--resume <sid>` hits the wrong CLI:

```
CLI stderr: No conversation found with session ID: <sid>
CLI returned empty output (exit=1)
```

The empty result becomes the envelope's `result_text` and surfaces in
the user chat as the visible reply, even though the task completed
normally (`status=done` or `failed`). The same path covers async
inter-agent result injection, so sub-agent results into a
different-provider topic hit it too.

Same family as #82/#81 (d38d738e), which added a stale-session marker
and retry to `handle_interagent_message`. The `_inject_prompt` path was
not covered.

## Proposed change

Reuse the already-resolved active session and pass its provider/model:

```python
provider_override=active.provider if active else None,
model_override=active.model if active else None,
```

When `active is None`, both stay `None` and behavior is unchanged.

## Consistency

Other resume sites already pass per-session provider/model — e.g.
`flows.named_session_flow` uses `provider_override=ns.provider,
model_override=ns.model`. The inject path was the odd one out.

## Test plan

- [x] Added `tests/orchestrator/test_injection.py` mocking `get_active`
      and asserting the captured `AgentRequest` uses the active
      session's provider/model (and falls back to `None` when no active
      session).
- [x] `ruff check`, `ruff format --check`, `mypy` clean.
- [x] Manual repro on a Codex-active topic with Claude default,
      `status=done` task. Before: `No conversation found …` in user
      chat. After: result delivered cleanly.
