### PR TITLE
feat(models): add "fable" to the Claude model selector

### DIFF
--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -559,6 +559,9 @@ CLAUDE_MODELS_ORDERED: tuple[str, ...] = (
     "sonnet[1m]",
     "opus",
     "opus[1m]",
+    # Claude Code >= 2.1.172 resolves the "fable" alias to the latest Fable
+    # model (same auto-tracking as the opus/sonnet aliases).
+    "fable",
 )
 CLAUDE_MODELS: frozenset[str] = frozenset(CLAUDE_MODELS_ORDERED)
 

--- a/tests/orchestrator/test_core_provider_info.py
+++ b/tests/orchestrator/test_core_provider_info.py
@@ -44,6 +44,7 @@ class TestBuildProviderInfo:
         assert info[0]["name"] == "Claude Code"
         assert info[0]["color"] == "#F97316"
         assert sorted(info[0]["models"]) == [
+            "fable",
             "haiku",
             "opus",
             "opus[1m]",


### PR DESCRIPTION
Adds the `fable` alias to `CLAUDE_MODELS_ORDERED` so it is selectable in the Claude model picker.

Claude Code >= 2.1.172 exposes `fable` in its model union (`sdk-tools.d.ts`) and resolves it to the latest Fable model, the same way the `opus` / `sonnet` aliases auto-track their latest release. Using the alias rather than pinning a full model id keeps it tracking future releases automatically.

The model selector builds its buttons directly from `CLAUDE_MODELS_ORDERED`, and `CLAUDE_MODELS` is derived from the same tuple, so no other change is needed.