### PR TITLE
Fix Antigravity host state and model discovery

### DIFF
--- a/ductor_bot/cli/antigravity_cache.py
+++ b/ductor_bot/cli/antigravity_cache.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Self
 
 from ductor_bot.cli.antigravity_discovery import discover_antigravity_models
+from ductor_bot.cli.antigravity_runtime import configured_antigravity_models
 from ductor_bot.cli.model_cache import BaseModelCache
 
 # Hardcoded fallback when discovery and disk cache both fail. Mirrors the
@@ -35,6 +36,13 @@ class AntigravityModelCache(BaseModelCache):
 
     @classmethod
     async def _discover(cls) -> tuple[str, ...]:
+        configured = configured_antigravity_models()
+        if configured:
+            # agy 1.0.x can hang or return empty stdout outside a TTY. Official
+            # settings prove the CLI is configured and identify the selected
+            # model, so avoid a redundant network probe for every agent home.
+            return tuple(dict.fromkeys((*_FALLBACK_ANTIGRAVITY_MODELS, *configured)))
+
         return await discover_antigravity_models()
 
     @classmethod

--- a/ductor_bot/cli/antigravity_discovery.py
+++ b/ductor_bot/cli/antigravity_discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from ductor_bot.cli.antigravity_runtime import antigravity_process_env
 from ductor_bot.infra.platform import CREATION_FLAGS as _CREATION_FLAGS
 from ductor_bot.infra.process_tree import force_kill_process_tree
 
@@ -27,6 +28,7 @@ async def discover_antigravity_models() -> tuple[str, ...]:
             "models",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=antigravity_process_env(),
             creationflags=_CREATION_FLAGS,
         )
     except (OSError, ValueError):

--- a/ductor_bot/cli/antigravity_provider.py
+++ b/ductor_bot/cli/antigravity_provider.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ductor_bot.cli.antigravity_events import parse_antigravity_json
+from ductor_bot.cli.antigravity_runtime import antigravity_process_env
 from ductor_bot.cli.base import BaseCLI, CLIConfig
 from ductor_bot.cli.executor import build_subprocess_env
 from ductor_bot.cli.process_registry import ProcessRegistry, TrackedProcess
@@ -185,7 +186,7 @@ class AntigravityCLI(BaseCLI):
         safe_cmd = _safe_command_for_logging(cmd)
         logger.debug("Antigravity send: %s", safe_cmd)
 
-        env = build_subprocess_env(self._config)
+        env = antigravity_process_env(build_subprocess_env(self._config))
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdin=asyncio.subprocess.PIPE,

--- a/ductor_bot/cli/antigravity_runtime.py
+++ b/ductor_bot/cli/antigravity_runtime.py
@@ -1,0 +1,39 @@
+"""Shared host runtime helpers for the Antigravity CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_SANDBOX_ENV_KEYS = frozenset({"CODEX_SANDBOX_NETWORK_DISABLED"})
+
+
+def antigravity_process_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Return a host environment suitable for the official ``agy`` CLI."""
+    env = dict(os.environ if base_env is None else base_env)
+    for key in _SANDBOX_ENV_KEYS:
+        env.pop(key, None)
+    return env
+
+
+def configured_antigravity_models(home: Path | None = None) -> tuple[str, ...]:
+    """Return the model selected in the official Antigravity settings."""
+    root = home or Path.home()
+    settings = root / ".gemini" / "antigravity-cli" / "settings.json"
+    data = _read_json(settings)
+    model = data.get("model")
+    if not isinstance(model, str) or not model.strip():
+        return ()
+    return (model.strip(),)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}

--- a/ductor_bot/cli/auth.py
+++ b/ductor_bot/cli/auth.py
@@ -13,6 +13,7 @@ from enum import StrEnum, unique
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ductor_bot.cli.antigravity_runtime import antigravity_process_env
 from ductor_bot.cli.gemini_utils import find_gemini_cli
 from ductor_bot.config import NULLISH_TEXT_VALUES
 from ductor_bot.infra.platform import CREATION_FLAGS as _CREATION_FLAGS
@@ -419,6 +420,7 @@ def _antigravity_cli_logged_in() -> bool:
             text=True,
             timeout=10,
             check=False,
+            env=antigravity_process_env(),
             creationflags=_CREATION_FLAGS,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:

--- a/tests/cli/test_antigravity_discovery.py
+++ b/tests/cli/test_antigravity_discovery.py
@@ -11,6 +11,10 @@ import pytest
 
 from ductor_bot.cli.antigravity_cache import _FALLBACK_ANTIGRAVITY_MODELS, AntigravityModelCache
 from ductor_bot.cli.antigravity_discovery import _parse_models, discover_antigravity_models
+from ductor_bot.cli.antigravity_runtime import (
+    antigravity_process_env,
+    configured_antigravity_models,
+)
 from ductor_bot.config import (
     ModelRegistry,
     reset_antigravity_models,
@@ -52,14 +56,21 @@ def _mock_proc(stdout: bytes, returncode: int = 0) -> AsyncMock:
 
 
 async def test_discover_returns_models_on_success() -> None:
-    with patch(
-        "ductor_bot.cli.antigravity_discovery.asyncio.create_subprocess_exec",
-        return_value=_mock_proc(_SAMPLE_OUTPUT.encode()),
+    with (
+        patch(
+            "ductor_bot.cli.antigravity_discovery.asyncio.create_subprocess_exec",
+            return_value=_mock_proc(_SAMPLE_OUTPUT.encode()),
+        ) as create_process,
+        patch(
+            "ductor_bot.cli.antigravity_discovery.antigravity_process_env",
+            return_value={"HOME": "host"},
+        ),
     ):
         models = await discover_antigravity_models()
 
     assert models[0] == "Gemini 3.5 Flash (Medium)"
     assert len(models) == 3
+    assert create_process.call_args.kwargs["env"] == {"HOME": "host"}
 
 
 async def test_discover_returns_empty_on_nonzero_exit() -> None:
@@ -87,6 +98,48 @@ async def test_cache_falls_back_when_discovery_empty(tmp_path: Path) -> None:
         cache = await AntigravityModelCache.load_or_refresh(cache_path, force_refresh=True)
 
     assert cache.models == _FALLBACK_ANTIGRAVITY_MODELS
+
+
+async def test_cache_persists_models_from_official_settings(tmp_path: Path) -> None:
+    cache_path = tmp_path / "antigravity_models.json"
+    configured = "Future Antigravity Model"
+    with (
+        patch(
+            "ductor_bot.cli.antigravity_cache.discover_antigravity_models",
+            AsyncMock(return_value=()),
+        ) as cli_discovery,
+        patch(
+            "ductor_bot.cli.antigravity_cache.configured_antigravity_models",
+            return_value=(configured,),
+        ),
+    ):
+        cache = await AntigravityModelCache.load_or_refresh(cache_path, force_refresh=True)
+
+    assert cache.models == (*_FALLBACK_ANTIGRAVITY_MODELS, configured)
+    assert cache_path.is_file()
+    cli_discovery.assert_not_awaited()
+
+
+def test_discovers_model_from_official_settings(tmp_path: Path) -> None:
+    settings_dir = tmp_path / ".gemini" / "antigravity-cli"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.json").write_text(
+        '{"model": "Claude Opus 4.6 (Thinking)"}',
+        encoding="utf-8",
+    )
+
+    assert configured_antigravity_models(tmp_path) == ("Claude Opus 4.6 (Thinking)",)
+
+
+def test_process_env_removes_codex_sandbox_flag() -> None:
+    env = antigravity_process_env(
+        {
+            "HOME": "host",
+            "CODEX_SANDBOX_NETWORK_DISABLED": "1",
+        }
+    )
+
+    assert env == {"HOME": "host"}
 
 
 def test_runtime_display_name_routes_to_antigravity() -> None:


### PR DESCRIPTION
## Summary
- reuse the official `~/.gemini/antigravity-cli/settings.json` model when `agy models` cannot produce a non-TTY model list
- persist the known Antigravity model set without blocking every agent home on a redundant CLI probe
- run Antigravity provider, discovery, and auth probes with a clean host environment so Codex sandbox flags do not disable host network access

## Notes
- `agy 1.0.x` can return success with empty stdout or hang when `models` runs without a TTY. The official settings model provides a deterministic authenticated-host fallback while preserving CLI discovery when no settings exist.
- Antigravity continues to run on the host when Docker sandboxing is enabled and continues to use the existing transcript fallback for `--print` responses.

## Tests
- `pytest tests/cli/test_antigravity_discovery.py tests/cli/test_antigravity_provider.py tests/cli/test_auth.py -q` (80 passed)
- `ruff check ductor_bot/cli/antigravity_runtime.py ductor_bot/cli/antigravity_cache.py ductor_bot/cli/antigravity_discovery.py ductor_bot/cli/antigravity_provider.py ductor_bot/cli/auth.py tests/cli/test_antigravity_discovery.py`
- runtime smoke: fresh Antigravity cache persisted 8 models in 0.01s; `AntigravityCLI.send_streaming()` returned the expected text delta and successful result event