### PR TITLE
feat(config): inject configurable files into the system prompt

### DIFF
--- a/ductor_bot/_home_defaults/config/RULES-all-clis.md
+++ b/ductor_bot/_home_defaults/config/RULES-all-clis.md
@@ -78,6 +78,13 @@ For user-facing schedules, set `user_timezone` explicitly.
 - `cleanup.output_to_user_days`
 - `cleanup.check_hour`
 
+### System Prompt
+
+- `append_system_prompt_files`: list of workspace-relative filenames whose
+  contents are appended to the system prompt on every agent-driven turn
+  (e.g. `["GLOSSARY.md", "STYLE_GUIDE.md"]`). Empty (default) injects nothing.
+  Each agent reads its own workspace copy; missing files are skipped.
+
 ### File Sending Scope
 
 - `file_access` controls what can be sent via `<file:...>`:

--- a/ductor_bot/background/observer.py
+++ b/ductor_bot/background/observer.py
@@ -13,10 +13,12 @@ from typing import TYPE_CHECKING
 from ductor_bot.background.models import BackgroundResult, BackgroundSubmit, BackgroundTask
 from ductor_bot.i18n import t
 from ductor_bot.infra.task_runner import TaskRunOptions, run_oneshot_task
+from ductor_bot.workspace.loader import build_appended_files_block
 
 if TYPE_CHECKING:
     from ductor_bot.cli.param_resolver import TaskExecutionConfig
     from ductor_bot.cli.service import CLIService
+    from ductor_bot.config import AgentConfig
     from ductor_bot.workspace.paths import DuctorPaths
 
 logger = logging.getLogger(__name__)
@@ -35,10 +37,12 @@ class BackgroundObserver:
         *,
         timeout_seconds: float,
         cli_service: CLIService | None = None,
+        config: AgentConfig,
     ) -> None:
         self._paths = paths
         self._timeout_seconds = timeout_seconds
         self._cli_service = cli_service
+        self._config = config
         self._on_result: BgResultCallback | None = None
         self._tasks: dict[str, BackgroundTask] = {}
 
@@ -197,8 +201,12 @@ class BackgroundObserver:
         t0 = time.monotonic()
         process_label = f"ns:{bg_task.session_name}"
         try:
+            files_block = await build_appended_files_block(
+                self._paths, self._config.append_system_prompt_files
+            )
             request = AgentRequest(
                 prompt=bg_task.prompt,
+                append_system_prompt=files_block,
                 model_override=bg_task.model or None,
                 provider_override=bg_task.provider or None,
                 chat_id=bg_task.chat_id,

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -436,6 +436,7 @@ class AgentConfig(BaseModel):
     cli_timeout: float = 1800.0
     reasoning_effort: str = "medium"
     file_access: str = "all"
+    append_system_prompt_files: list[str] = Field(default_factory=list)
     gemini_api_key: str | None = None
     streaming: StreamingConfig = Field(default_factory=StreamingConfig)
     docker: DockerConfig = Field(default_factory=DockerConfig)

--- a/ductor_bot/multiagent/supervisor.py
+++ b/ductor_bot/multiagent/supervisor.py
@@ -141,6 +141,7 @@ class AgentSupervisor:
                 self._main_paths,
                 cli_service=None,  # Set per-agent in _post_startup
                 config=self._main_config.tasks,
+                append_system_prompt_files=self._main_config.append_system_prompt_files,
                 process_registry=self._task_process_registry,
             )
             self._internal_api.set_task_hub(self._task_hub)

--- a/ductor_bot/orchestrator/flows.py
+++ b/ductor_bot/orchestrator/flows.py
@@ -22,7 +22,7 @@ from ductor_bot.orchestrator.hooks import HookContext
 from ductor_bot.orchestrator.registry import OrchestratorResult
 from ductor_bot.session import SessionData, SessionKey
 from ductor_bot.text.response_format import session_error_text, timeout_error_text
-from ductor_bot.workspace.loader import read_mainmemory
+from ductor_bot.workspace.loader import build_appended_files_block, read_mainmemory
 
 if TYPE_CHECKING:
     from ductor_bot.orchestrator.core import Orchestrator
@@ -126,6 +126,12 @@ async def _prepare_normal(
         roster = _build_agent_roster(orch)
         if roster:
             append_prompt = f"{append_prompt}\n\n{roster}" if append_prompt else roster
+
+    files_block = await build_appended_files_block(
+        orch.paths, orch._config.append_system_prompt_files
+    )
+    if files_block:
+        append_prompt = f"{append_prompt}\n\n{files_block}" if append_prompt else files_block
 
     hook_ctx = HookContext(
         chat_id=key.chat_id,
@@ -729,8 +735,12 @@ async def named_session_flow(
 
     tag = f"**[{session_name} | {ns.provider}]**\n"
     orch._named_sessions.mark_running(key.chat_id, session_name, text)
+    files_block = await build_appended_files_block(
+        orch.paths, orch._config.append_system_prompt_files
+    )
     request = AgentRequest(
         prompt=text,
+        append_system_prompt=files_block,
         model_override=ns.model,
         provider_override=ns.provider,
         chat_id=key.chat_id,
@@ -780,8 +790,12 @@ async def named_session_streaming(
     cb = cbs or StreamingCallbacks()
     tag = f"**[{session_name} | {ns.provider}]**\n"
     orch._named_sessions.mark_running(key.chat_id, session_name, text)
+    files_block = await build_appended_files_block(
+        orch.paths, orch._config.append_system_prompt_files
+    )
     request = AgentRequest(
         prompt=text,
+        append_system_prompt=files_block,
         model_override=ns.model,
         provider_override=ns.provider,
         chat_id=key.chat_id,

--- a/ductor_bot/orchestrator/injection.py
+++ b/ductor_bot/orchestrator/injection.py
@@ -16,6 +16,7 @@ from ductor_bot.cli.types import AgentRequest
 from ductor_bot.orchestrator.flows import _is_invalid_session, _update_session
 from ductor_bot.session.key import SessionKey
 from ductor_bot.session.named import NamedSession
+from ductor_bot.workspace.loader import build_appended_files_block
 
 if TYPE_CHECKING:
     from ductor_bot.multiagent.bus import AsyncInterAgentResult
@@ -54,8 +55,12 @@ async def _inject_prompt(  # noqa: PLR0913
     active = await orch._sessions.get_active(key)
     resume_id = active.session_id if active else None
 
+    files_block = await build_appended_files_block(
+        orch.paths, orch._config.append_system_prompt_files
+    )
     request = AgentRequest(
         prompt=prompt,
+        append_system_prompt=files_block,
         chat_id=chat_id,
         topic_id=topic_id,
         transport=transport,
@@ -193,8 +198,12 @@ async def handle_interagent_message(
     )
 
     ns.status = "running"
+    files_block = await build_appended_files_block(
+        orch.paths, orch._config.append_system_prompt_files
+    )
     request = AgentRequest(
         prompt=prompt,
+        append_system_prompt=files_block,
         chat_id=chat_id,
         transport=transport,
         process_label=f"interagent:{sender}",
@@ -230,8 +239,12 @@ async def handle_interagent_message(
         orch._named_sessions.end_session(chat_id, ns.name)
         ns, _, _ = _get_or_create_interagent_session(orch, sender, new_session=True)
         ns.status = "running"
+        files_block = await build_appended_files_block(
+            orch.paths, orch._config.append_system_prompt_files
+        )
         retry_request = AgentRequest(
             prompt=prompt,
+            append_system_prompt=files_block,
             chat_id=chat_id,
             transport=transport,
             process_label=f"interagent:{sender}",

--- a/ductor_bot/orchestrator/observers.py
+++ b/ductor_bot/orchestrator/observers.py
@@ -114,7 +114,10 @@ class ObserverManager:
         config, paths = self._config, self._paths
         self.codex_cache = codex_cache
         self.background = BackgroundObserver(
-            paths, timeout_seconds=config.timeouts.background, cli_service=cli_service
+            paths,
+            timeout_seconds=config.timeouts.background,
+            cli_service=cli_service,
+            config=config,
         )
         self.cron = CronObserver(paths, cron_manager, config=config, codex_cache=codex_cache)
         self.webhook = WebhookObserver(

--- a/ductor_bot/tasks/hub.py
+++ b/ductor_bot/tasks/hub.py
@@ -16,6 +16,7 @@ from ductor_bot.tasks.models import (
     TaskSubmit,
     normalise_priority,
 )
+from ductor_bot.workspace.loader import build_appended_files_block
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -71,13 +72,14 @@ class TaskHub:
     question handling → result delivery.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         registry: TaskRegistry,
         paths: DuctorPaths,
         *,
         cli_service: CLIService | None = None,
         config: TasksConfig,
+        append_system_prompt_files: list[str] | None = None,
         process_registry: ProcessRegistry | None = None,
     ) -> None:
         self._registry = registry
@@ -85,6 +87,8 @@ class TaskHub:
         self._cli_service = cli_service
         self._cli_services: dict[str, CLIService] = {}
         self._agent_tasks_dirs: dict[str, Path] = {}
+        self._agent_paths: dict[str, DuctorPaths] = {}
+        self._append_system_prompt_files = append_system_prompt_files or []
         self._config = config
         self._in_flight: dict[str, TaskInFlight] = {}
         self._result_handlers: dict[str, TaskResultCallback] = {}
@@ -145,6 +149,7 @@ class TaskHub:
     def set_agent_paths(self, agent_name: str, paths: DuctorPaths) -> None:
         """Register per-agent paths for task folder isolation."""
         self._agent_tasks_dirs[agent_name] = paths.tasks_dir
+        self._agent_paths[agent_name] = paths
 
     def set_agent_chat_id(self, agent_name: str, chat_id: int) -> None:
         """Register the primary chat_id for an agent (for resolving CLI-submitted tasks)."""
@@ -446,9 +451,14 @@ class TaskHub:
         t0 = time.monotonic()
         try:
             timeout = self._config.timeout_seconds
+            agent_paths = self._agent_paths.get(entry.parent_agent, self._paths)
+            files_block = await build_appended_files_block(
+                agent_paths, self._append_system_prompt_files
+            )
 
             request = AgentRequest(
                 prompt=prompt,
+                append_system_prompt=files_block,
                 model_override=entry.model or None,
                 provider_override=entry.provider or None,
                 chat_id=entry.chat_id,

--- a/ductor_bot/workspace/loader.py
+++ b/ductor_bot/workspace/loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -24,3 +25,25 @@ def read_file(path: Path) -> str | None:
 def read_mainmemory(paths: DuctorPaths) -> str:
     """Read MAINMEMORY.md, returning empty string if missing."""
     return read_file(paths.mainmemory_path) or ""
+
+
+async def build_appended_files_block(paths: DuctorPaths, filenames: list[str]) -> str | None:
+    """Concatenate the given *filenames* from the agent's workspace.
+
+    Each name is resolved relative to ``paths.workspace`` and must stay inside
+    it (absolute paths, ``..`` and symlinks escaping the workspace are skipped).
+    Missing/empty files are skipped. Returns ``None`` when nothing remains so
+    callers can leave ``append_system_prompt`` unchanged.
+    """
+    parts: list[str] = []
+    ws = paths.workspace.resolve()
+    for fname in filenames:
+        if not fname:
+            continue
+        target = (paths.workspace / fname).resolve()
+        if not target.is_relative_to(ws):
+            continue
+        content = await asyncio.to_thread(read_file, target)
+        if content and content.strip():
+            parts.append(content.strip())
+    return "\n\n".join(parts) if parts else None

--- a/tests/background/test_observer.py
+++ b/tests/background/test_observer.py
@@ -6,13 +6,15 @@ import asyncio
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from ductor_bot.background.models import BackgroundResult, BackgroundSubmit
 from ductor_bot.background.observer import MAX_TASKS_PER_CHAT, BackgroundObserver
 from ductor_bot.cli.param_resolver import TaskExecutionConfig
+from ductor_bot.cli.types import AgentResponse
+from ductor_bot.config import AgentConfig
 from ductor_bot.cron.execution import OneShotExecutionResult
 from ductor_bot.infra.task_runner import TaskResult
 from ductor_bot.workspace.paths import DuctorPaths
@@ -45,8 +47,12 @@ def _make_exec_config(**overrides: Any) -> TaskExecutionConfig:
     return TaskExecutionConfig(**defaults)
 
 
-def _make_observer(paths: DuctorPaths, timeout: float = 300.0) -> BackgroundObserver:
-    return BackgroundObserver(paths, timeout_seconds=timeout)
+def _make_observer(
+    paths: DuctorPaths, timeout: float = 300.0, config: AgentConfig | None = None
+) -> BackgroundObserver:
+    return BackgroundObserver(
+        paths, timeout_seconds=timeout, config=config or AgentConfig()
+    )
 
 
 def _success_task_result(text: str = "") -> TaskResult:
@@ -268,3 +274,45 @@ class TestCleanup:
             await asyncio.sleep(0.05)
 
         assert len(observer.active_tasks(123)) == 0
+
+
+class TestAppendSystemPromptFiles:
+    async def test_named_session_injects_configured_files(self, tmp_path: Path) -> None:
+        """_run_with_session injects append_system_prompt_files from the workspace."""
+        paths = _make_paths(tmp_path)
+        (paths.workspace / "PERSONA.md").write_text("Bg persona.")
+        config = AgentConfig(append_system_prompt_files=["PERSONA.md"])
+        cli = MagicMock()
+        cli.execute = AsyncMock(return_value=AgentResponse(result="ok", session_id="s1"))
+        obs = _make_observer(paths, config=config)
+        object.__setattr__(obs, "_cli_service", cli)
+        obs.set_result_handler(AsyncMock())
+
+        sub = BackgroundSubmit(
+            chat_id=1, prompt="hi", message_id=1, thread_id=None, session_name="work"
+        )
+        obs.submit(sub, _make_exec_config())
+        await asyncio.sleep(0.05)
+        await obs.shutdown()
+
+        request = cli.execute.await_args.args[0]
+        assert request.append_system_prompt is not None
+        assert "Bg persona." in request.append_system_prompt
+
+    async def test_named_session_no_files_leaves_append_none(self, tmp_path: Path) -> None:
+        paths = _make_paths(tmp_path)
+        cli = MagicMock()
+        cli.execute = AsyncMock(return_value=AgentResponse(result="ok", session_id="s1"))
+        obs = _make_observer(paths, config=AgentConfig())
+        object.__setattr__(obs, "_cli_service", cli)
+        obs.set_result_handler(AsyncMock())
+
+        sub = BackgroundSubmit(
+            chat_id=1, prompt="hi", message_id=1, thread_id=None, session_name="work"
+        )
+        obs.submit(sub, _make_exec_config())
+        await asyncio.sleep(0.05)
+        await obs.shutdown()
+
+        request = cli.execute.await_args.args[0]
+        assert request.append_system_prompt is None

--- a/tests/orchestrator/test_flows.py
+++ b/tests/orchestrator/test_flows.py
@@ -14,6 +14,7 @@ from ductor_bot.orchestrator.flows import (
     _finish_normal,
     _strip_ack_token,
     _update_session,
+    heartbeat_flow,
     named_session_flow,
     normal,
     normal_streaming,
@@ -862,3 +863,51 @@ def test_finish_normal_non_empty_success_unchanged() -> None:
     response = AgentResponse(result="Hello world", is_error=False)
     result = _finish_normal(response)
     assert result.text == "Hello world"
+
+
+# -- append_system_prompt_files injection --
+
+
+async def test_normal_injects_appended_files_every_turn(orch: Orchestrator) -> None:
+    orch._config.append_system_prompt_files = ["PERSONA.md"]
+    (orch.paths.workspace / "PERSONA.md").write_text("You are helpful.")
+    captured: list[object] = []
+
+    async def mock_execute(req: object) -> AgentResponse:
+        captured.append(req)
+        return _mock_response()
+
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+    await normal(orch, SessionKey(chat_id=1), "Hello")  # new session
+    await normal(orch, SessionKey(chat_id=1), "Again")  # resume session
+
+    assert len(captured) == 2
+    for req in captured:
+        assert req.append_system_prompt is not None  # type: ignore[attr-defined]
+        assert "You are helpful." in req.append_system_prompt  # type: ignore[attr-defined]
+
+
+async def test_normal_no_files_configured_leaves_resume_append_none(orch: Orchestrator) -> None:
+    # Default config (empty list) -> behavior unchanged: resume turn has no append.
+    mock_execute = AsyncMock(return_value=_mock_response())
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+    await normal(orch, SessionKey(chat_id=1), "Hello")
+    await normal(orch, SessionKey(chat_id=1), "Again")
+    request = mock_execute.call_args[0][0]
+    assert request.append_system_prompt is None
+
+
+async def test_heartbeat_excludes_appended_files(orch: Orchestrator) -> None:
+    """Regression: the heartbeat path must NOT inject append_system_prompt_files."""
+    orch._config.append_system_prompt_files = ["PERSONA.md"]
+    (orch.paths.workspace / "PERSONA.md").write_text("You are helpful.")
+    orch._config.heartbeat.cooldown_minutes = 0
+    await _establish_session(orch)
+
+    mock_execute = AsyncMock(return_value=_mock_response(result="HEARTBEAT_OK"))
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+    await heartbeat_flow(orch, SessionKey(chat_id=1))
+
+    assert mock_execute.await_count == 1
+    request = mock_execute.await_args[0][0]
+    assert request.append_system_prompt is None

--- a/tests/orchestrator/test_injection.py
+++ b/tests/orchestrator/test_injection.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from ductor_bot.cli.types import AgentRequest, AgentResponse
 from ductor_bot.orchestrator.injection import _inject_prompt
+from ductor_bot.workspace.paths import DuctorPaths
 
 
 def _make_orch(active: Any) -> MagicMock:
@@ -59,3 +61,38 @@ class TestInjectPromptProviderOverride:
         req = _captured_request(orch)
         assert req.provider_override == "claude"
         assert req.model_override == "opus"
+
+
+async def test_inject_prompt_appends_configured_files(tmp_path: Path) -> None:
+    """_inject_prompt injects append_system_prompt_files from the agent workspace."""
+    paths = DuctorPaths(ductor_home=tmp_path)
+    paths.workspace.mkdir(parents=True, exist_ok=True)
+    (paths.workspace / "PERSONA.md").write_text("You are helpful.")
+
+    active = MagicMock(session_id="sid", provider="claude", model="opus")
+    orch = _make_orch(active)
+    orch.paths = paths
+    orch._config.append_system_prompt_files = ["PERSONA.md"]
+
+    with patch("ductor_bot.orchestrator.injection._update_session", new=AsyncMock()):
+        await _inject_prompt(orch, "hi", chat_id=1, process_label="task_result:x")
+
+    req = _captured_request(orch)
+    assert req.append_system_prompt is not None
+    assert "You are helpful." in req.append_system_prompt
+
+
+async def test_inject_prompt_no_files_leaves_append_none(tmp_path: Path) -> None:
+    """Empty append_system_prompt_files -> append_system_prompt stays None."""
+    paths = DuctorPaths(ductor_home=tmp_path)
+    paths.workspace.mkdir(parents=True, exist_ok=True)
+
+    orch = _make_orch(MagicMock(session_id="sid", provider="claude", model="opus"))
+    orch.paths = paths
+    orch._config.append_system_prompt_files = []
+
+    with patch("ductor_bot.orchestrator.injection._update_session", new=AsyncMock()):
+        await _inject_prompt(orch, "hi", chat_id=1, process_label="task_result:x")
+
+    req = _captured_request(orch)
+    assert req.append_system_prompt is None

--- a/tests/orchestrator/test_memory_flush.py
+++ b/tests/orchestrator/test_memory_flush.py
@@ -280,3 +280,28 @@ async def test_memory_flusher_runs_unlocked_without_lock_pool(tmp_path: Path) ->
     await flusher.maybe_flush(key, session)
 
     assert cli.execute.await_count == 1
+
+
+async def test_flush_excludes_appended_system_prompt(tmp_path: Path) -> None:
+    """Regression: memory flush must NOT inject append_system_prompt_files."""
+    flusher, cli = _make_flusher(tmp_path, compact_cfg=MemoryCompactionConfig(enabled=False))
+    key = SessionKey(chat_id=101)
+    session = _session_with_id("sess-abc")
+    flusher.mark_boundary(key)
+    await flusher.maybe_flush(key, session)
+
+    assert cli.execute.await_count == 1
+    request = cli.execute.await_args[0][0]
+    assert request.append_system_prompt is None
+
+
+async def test_compact_excludes_appended_system_prompt(tmp_path: Path) -> None:
+    """Regression: memory compaction must NOT inject append_system_prompt_files."""
+    flusher, cli = _make_flusher(tmp_path, mainmemory_lines=100)
+    key = SessionKey(chat_id=101)
+    session = _session_with_id("sess-abc")
+    await flusher.compact(key, session)
+
+    assert cli.execute.await_count == 1
+    request = cli.execute.await_args[0][0]
+    assert request.append_system_prompt is None

--- a/tests/tasks/test_hub.py
+++ b/tests/tasks/test_hub.py
@@ -12,6 +12,7 @@ from ductor_bot.cli.process_registry import ProcessRegistry
 from ductor_bot.tasks.hub import TaskHub
 from ductor_bot.tasks.models import TaskResult, TaskSubmit
 from ductor_bot.tasks.registry import TaskRegistry
+from ductor_bot.workspace.paths import DuctorPaths
 
 
 @pytest.fixture
@@ -963,3 +964,53 @@ class TestAppendTaskmemory:
         assert not any("TASKMEMORY truncated" in rec.message for rec in caplog.records)
         assert "truncated" not in result.lower()
         assert "short content" in result
+
+
+class TestAppendSystemPromptFiles:
+    async def test_uses_parent_agent_workspace_files(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        """_run reads append_system_prompt_files from the parent agent's workspace."""
+        cli = _make_cli_service("task output")
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path / "main_ws"),
+            cli_service=cli,
+            config=_make_config(),
+            append_system_prompt_files=["PERSONA.md"],
+        )
+        # Parent agent "dev" has its own workspace + persona file.
+        dev_paths = DuctorPaths(ductor_home=tmp_path / "dev_home")
+        dev_paths.workspace.mkdir(parents=True, exist_ok=True)
+        (dev_paths.workspace / "PERSONA.md").write_text("Dev persona.")
+        hub.set_agent_paths("dev", dev_paths)
+        hub.set_result_handler("dev", AsyncMock())
+
+        submit = TaskSubmit(
+            chat_id=42, prompt="go", message_id=1, thread_id=None, parent_agent="dev", name="T"
+        )
+        hub.submit(submit)
+        await asyncio.sleep(0.1)
+
+        await hub.shutdown()
+        request = cli.execute.await_args.args[0]
+        assert request.append_system_prompt is not None
+        assert "Dev persona." in request.append_system_prompt
+
+    async def test_no_files_leaves_append_none(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        cli = _make_cli_service("task output")
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=cli,
+            config=_make_config(),
+        )
+        hub.set_result_handler("main", AsyncMock())
+        hub.submit(_submit())
+        await asyncio.sleep(0.1)
+
+        await hub.shutdown()
+        request = cli.execute.await_args.args[0]
+        assert request.append_system_prompt is None

--- a/tests/workspace/test_loader.py
+++ b/tests/workspace/test_loader.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ductor_bot.workspace.loader import read_file, read_mainmemory
+from ductor_bot.workspace.loader import (
+    build_appended_files_block,
+    read_file,
+    read_mainmemory,
+)
 from ductor_bot.workspace.paths import DuctorPaths
 
 
@@ -48,3 +52,70 @@ def test_read_mainmemory_exists(tmp_path: Path) -> None:
 def test_read_mainmemory_missing(tmp_path: Path) -> None:
     paths = _make_paths(tmp_path)
     assert read_mainmemory(paths) == ""
+
+
+# -- build_appended_files_block --
+
+
+def _ws(tmp_path: Path) -> DuctorPaths:
+    paths = _make_paths(tmp_path)
+    paths.workspace.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+async def test_appended_block_concatenates_existing(tmp_path: Path) -> None:
+    paths = _ws(tmp_path)
+    (paths.workspace / "A.md").write_text("alpha")
+    (paths.workspace / "B.md").write_text("beta")
+    block = await build_appended_files_block(paths, ["A.md", "B.md"])
+    assert block == "alpha\n\nbeta"
+
+
+async def test_appended_block_empty_list_is_none(tmp_path: Path) -> None:
+    paths = _ws(tmp_path)
+    assert await build_appended_files_block(paths, []) is None
+
+
+async def test_appended_block_all_missing_is_none(tmp_path: Path) -> None:
+    paths = _ws(tmp_path)
+    assert await build_appended_files_block(paths, ["nope.md", "gone.md"]) is None
+
+
+async def test_appended_block_skips_missing_without_error(tmp_path: Path) -> None:
+    paths = _ws(tmp_path)
+    (paths.workspace / "A.md").write_text("alpha")
+    block = await build_appended_files_block(paths, ["A.md", "missing.md"])
+    assert block == "alpha"
+
+
+async def test_appended_block_skips_blank_files(tmp_path: Path) -> None:
+    paths = _ws(tmp_path)
+    (paths.workspace / "A.md").write_text("   \n  ")
+    (paths.workspace / "B.md").write_text("beta")
+    block = await build_appended_files_block(paths, ["A.md", "B.md"])
+    assert block == "beta"
+
+
+async def test_appended_block_blocks_absolute_path(tmp_path: Path) -> None:
+    paths = _ws(tmp_path)
+    secret = tmp_path / "secret.md"
+    secret.write_text("top secret")
+    block = await build_appended_files_block(paths, [str(secret)])
+    assert block is None
+
+
+async def test_appended_block_blocks_dotdot_escape(tmp_path: Path) -> None:
+    paths = _ws(tmp_path)
+    (paths.ductor_home / "outside.md").write_text("outside")
+    block = await build_appended_files_block(paths, ["../outside.md"])
+    assert block is None
+
+
+async def test_appended_block_blocks_symlink_escape(tmp_path: Path) -> None:
+    paths = _ws(tmp_path)
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside")
+    link = paths.workspace / "link.md"
+    link.symlink_to(outside)
+    block = await build_appended_files_block(paths, ["link.md"])
+    assert block is None


### PR DESCRIPTION
## Motivation
Ductor already auto-appends `MAINMEMORY.md` to the system prompt (on new sessions), but there's no way to inject *additional* files — extra context or reference documents — that you want present on **every** turn. This adds a small config option to do exactly that.

## What it adds
- New config key **`append_system_prompt_files: list[str]`** (default `[]`): a list of workspace-relative filenames whose contents are appended to the agent's `--append-system-prompt` for agent-driven turns.
  - List multiple files to inject several — they're concatenated in the listed order, e.g. `"append_system_prompt_files": ["GLOSSARY.md", "STYLE_GUIDE.md"]`.
- Each agent reads the files from its **own** workspace, so the main agent and each sub-agent can carry different content under the same filenames. Sub-agents inherit the list from the main config.
- Injected on **every turn** (not just new sessions), so it survives compaction — like the existing `MAINMEMORY.md` mechanism, but always-on.

## Where it injects (and where it doesn't)
Wired into the agent-driven request paths: normal chat, named sessions (sync + streaming), inter-agent messages (incl. retry), tasks, and background named sessions. Intentionally **excluded** from system-maintenance turns — heartbeat, memory flush, and compaction.

## Safety
- Default `[]` → no change to current behavior.
- Missing files are silently skipped (no error).
- Filenames are confined to the workspace: absolute paths, `..`, and symlink escapes are ignored (resolved and checked against the workspace root).

## Tests
Coverage for the helper (concat / empty / missing / path-escape guards), every-turn injection (including resume), per-agent workspace resolution, and the maintenance-flow exclusions.
