### PR TITLE
fix: scope model-switch/reset/error process kills to the invoking topic

### DIFF
--- a/ductor_bot/cli/process_registry.py
+++ b/ductor_bot/cli/process_registry.py
@@ -17,6 +17,8 @@ from ductor_bot.infra.process_tree import (
 logger = logging.getLogger(__name__)
 
 _SIGTERM_GRACE_SECONDS = 2.0
+_PRESERVED_LABEL_PREFIXES: tuple[str, ...] = ("task:", "task_result:", "ns:")
+# Lifecycle for these subprocesses is owned by /tasks, /sessions, or TaskHub.cancel().
 
 
 @dataclass(slots=True)
@@ -108,19 +110,23 @@ class ProcessRegistry:
 
         Used by ``/stop`` so a stop in one topic does not affect another
         topic in the same chat. ``topic_id=None`` matches processes
-        registered without a topic (e.g. private chats).
+        registered without a topic (e.g. private chats). Labels owned by
+        /tasks, /sessions, or TaskHub.cancel() are preserved.
         """
         async with self._kill_lock:
             entries = self._processes.get(chat_id, [])
             targets = [
-                t for t in entries if t.topic_id == topic_id and t.process.returncode is None
+                t
+                for t in entries
+                if t.topic_id == topic_id
+                and t.process.returncode is None
+                and not t.label.startswith(_PRESERVED_LABEL_PREFIXES)
             ]
             if not targets:
                 return 0
             self._aborted_topics.add((chat_id, topic_id))
-            remaining = [
-                t for t in entries if t.topic_id != topic_id or t.process.returncode is not None
-            ]
+            target_ids = {id(t) for t in targets}
+            remaining = [t for t in entries if id(t) not in target_ids]
             if remaining:
                 self._processes[chat_id] = remaining
             else:

--- a/ductor_bot/orchestrator/commands.py
+++ b/ductor_bot/orchestrator/commands.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 async def cmd_reset(orch: Orchestrator, key: SessionKey, _text: str) -> OrchestratorResult:
     """Handle /new: kill processes and reset only active provider session."""
     logger.info("Reset requested")
-    await orch._process_registry.kill_all(key.chat_id)
+    await orch._process_registry.kill_by_chat_topic(key.chat_id, key.topic_id)
     provider = await orch.reset_active_provider_session(key)
     return OrchestratorResult(text=new_session_text(provider))
 
@@ -40,7 +40,7 @@ async def cmd_reset(orch: Orchestrator, key: SessionKey, _text: str) -> Orchestr
 async def cmd_reset_current(orch: Orchestrator, key: SessionKey, _text: str) -> OrchestratorResult:
     """Handle /reset: kill processes and reset the *current* provider session."""
     logger.info("Reset (current) requested")
-    await orch._process_registry.kill_all(key.chat_id)
+    await orch._process_registry.kill_by_chat_topic(key.chat_id, key.topic_id)
     provider = await orch.reset_current_provider_session(key)
     return OrchestratorResult(text=new_session_text(provider))
 

--- a/ductor_bot/orchestrator/flows.py
+++ b/ductor_bot/orchestrator/flows.py
@@ -198,7 +198,7 @@ async def _reset_on_error(
     cli_detail: str = "",
 ) -> OrchestratorResult:
     """Kill processes, preserve session, return user-facing error."""
-    await orch._process_registry.kill_all(key.chat_id)
+    await orch._process_registry.kill_by_chat_topic(key.chat_id, key.topic_id)
     logger.warning("Session error preserved model=%s provider=%s", model_name, provider_name)
     return OrchestratorResult(
         text=session_error_text(model_name, cli_detail),
@@ -218,7 +218,7 @@ async def _handle_timeout(
     so that the next user message can ``--resume`` the timed-out session.
     """
     model_name, _provider_name = _request_target(orch, request)
-    await orch._process_registry.kill_all(key.chat_id)
+    await orch._process_registry.kill_by_chat_topic(key.chat_id, key.topic_id)
 
     # Persist the session_id captured from SystemInitEvent so resume works.
     if response.session_id and response.session_id != session.session_id:
@@ -382,8 +382,8 @@ async def _recover_session(
     logger.warning("recovery.%s chat=%s action=retry", ctx.reason, key.chat_id)
     model_name = ctx.model_override or orch._config.model
     provider_name = orch.models.provider_for(model_name)
-    await orch._process_registry.kill_all(key.chat_id)
-    orch._process_registry.clear_abort(key.chat_id)
+    await orch._process_registry.kill_by_chat_topic(key.chat_id, key.topic_id)
+    orch._process_registry.clear_topic_abort(key.chat_id, key.topic_id)
     await orch._sessions.reset_provider_session(key, provider=provider_name, model=model_name)
 
     cb = ctx.cbs

--- a/ductor_bot/orchestrator/selectors/model_selector.py
+++ b/ductor_bot/orchestrator/selectors/model_selector.py
@@ -268,7 +268,7 @@ async def switch_model(  # noqa: C901
     *,
     reasoning_effort: str | None = None,
 ) -> str:
-    """Execute model switch: kill processes, preserve sessions, persist config.
+    """Execute model switch: kill topic processes, preserve sessions, persist config.
 
     Shared by ``/model <name>`` text command and the wizard callbacks.
     """
@@ -296,7 +296,7 @@ async def switch_model(  # noqa: C901
     )
 
     if not same_model:
-        await orch._process_registry.kill_all(key.chat_id)
+        await orch._process_registry.kill_by_chat_topic(key.chat_id, key.topic_id)
         if active_session is not None:
             await orch._sessions.sync_session_target(
                 active_session,

--- a/tests/bus/test_bus.py
+++ b/tests/bus/test_bus.py
@@ -161,6 +161,32 @@ async def test_injection_updates_result_text() -> None:
     assert env.result_text == "Injected response"
     t.deliver.assert_awaited_once()
 
+async def test_task_result_injection_uses_task_result_label() -> None:
+    bus = MessageBus()
+    t = _mock_transport()
+    bus.register_transport(t)
+
+    injector = AsyncMock()
+    injector.inject_prompt = AsyncMock(return_value="Injected response")
+    bus.set_injector(injector)
+
+    env = _env(
+        origin=Origin.TASK_RESULT,
+        envelope_id="abc123",
+        needs_injection=True,
+        prompt="Task result",
+        chat_id=10,
+    )
+    await bus.submit(env)
+
+    injector.inject_prompt.assert_awaited_once_with(
+        "Task result",
+        10,
+        "task_result:abc123",
+        topic_id=None,
+        transport="tg",
+    )
+
 
 async def test_injection_skipped_without_prompt() -> None:
     bus = MessageBus()

--- a/tests/cli/test_process_registry.py
+++ b/tests/cli/test_process_registry.py
@@ -9,7 +9,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ductor_bot.cli.process_registry import ProcessRegistry, TrackedProcess
+from ductor_bot.cli.process_registry import (
+    _PRESERVED_LABEL_PREFIXES,
+    ProcessRegistry,
+    TrackedProcess,
+)
 
 
 def _mock_process(*, pid: int = 1, returncode: int | None = None) -> MagicMock:
@@ -235,6 +239,122 @@ class TestKillByChatTopicAbortMarker:
         assert reg.has_active(1, topic_id=10) is False
         assert reg.has_active(1, topic_id=20) is True
         assert proc_b.returncode is None
+
+    async def test_kill_by_chat_topic_preserves_protected_labels(self) -> None:
+        reg = ProcessRegistry()
+        task = reg.register(
+            chat_id=1, process=_mock_process(pid=84), label="task:AAAAAAAA", topic_id=10
+        )
+        task_result = reg.register(
+            chat_id=1, process=_mock_process(pid=85), label="task_result:BBBBBBBB", topic_id=10
+        )
+        named_session = reg.register(
+            chat_id=1, process=_mock_process(pid=86), label="ns:review", topic_id=10
+        )
+        normal = reg.register(
+            chat_id=1, process=_mock_process(pid=87), label="main", topic_id=10
+        )
+
+        with patch(
+            "ductor_bot.cli.process_registry._kill_processes",
+            new_callable=AsyncMock,
+            return_value=1,
+        ):
+            killed = await reg.kill_by_chat_topic(1, 10)
+
+        assert killed == 1
+        remaining_ids = {id(t) for t in reg._processes[1]}
+        assert id(normal) not in remaining_ids
+        assert {id(task), id(task_result), id(named_session)} <= remaining_ids
+
+        with patch(
+            "ductor_bot.cli.process_registry._kill_processes",
+            new_callable=AsyncMock,
+            return_value=1,
+        ):
+            task_killed = await reg.kill_for_task("AAAAAAAA")
+
+        assert task_killed == 1
+        remaining_ids = {id(t) for t in reg._processes[1]}
+        assert id(task) not in remaining_ids
+        assert {id(task_result), id(named_session)} <= remaining_ids
+
+    async def test_kill_by_chat_topic_protected_only_returns_zero(self) -> None:
+        reg = ProcessRegistry()
+        reg.register(chat_id=1, process=_mock_process(pid=88), label="task:AAAAAAAA", topic_id=10)
+        reg.register(chat_id=1, process=_mock_process(pid=89), label="ns:review", topic_id=10)
+
+        killed = await reg.kill_by_chat_topic(1, 10)
+
+        assert killed == 0
+        assert reg.was_aborted_topic(1, 10) is False
+        assert reg.has_active(1, topic_id=10) is True
+        assert len(reg._processes[1]) == 2
+
+    async def test_kill_all_sweeps_protected_labels(self) -> None:
+        reg = ProcessRegistry()
+        reg.register(chat_id=1, process=_mock_process(pid=90), label="task:AAAAAAAA", topic_id=10)
+        reg.register(
+            chat_id=1, process=_mock_process(pid=91), label="task_result:BBBBBBBB", topic_id=10
+        )
+        reg.register(chat_id=1, process=_mock_process(pid=92), label="ns:review", topic_id=10)
+
+        with patch(
+            "ductor_bot.cli.process_registry._kill_processes",
+            new_callable=AsyncMock,
+            return_value=3,
+        ):
+            killed = await reg.kill_all(1)
+
+        assert killed == 3
+        assert reg.has_active(1) is False
+        assert 1 not in reg._processes
+
+    def test_preserved_prefixes_pinned(self) -> None:
+        assert _PRESERVED_LABEL_PREFIXES == ("task:", "task_result:", "ns:")
+
+    async def test_kill_by_chat_topic_preserves_other_topics(self) -> None:
+        reg = ProcessRegistry()
+        proc_topic_a = _mock_process(pid=93)
+        proc_topic_b = _mock_process(pid=94)
+        reg.register(chat_id=1, process=proc_topic_a, label="main", topic_id=10)
+        reg.register(chat_id=1, process=proc_topic_b, label="main", topic_id=20)
+
+        with patch(
+            "ductor_bot.cli.process_registry._kill_processes",
+            new_callable=AsyncMock,
+            return_value=1,
+        ):
+            killed = await reg.kill_by_chat_topic(1, 20)
+
+        assert killed == 1
+        assert reg.has_active(1, topic_id=10) is True
+        assert reg.has_active(1, topic_id=20) is False
+        assert proc_topic_a.returncode is None
+
+    async def test_kill_by_chat_topic_none_topic_flat_chat(self) -> None:
+        reg = ProcessRegistry()
+        flat_normal = reg.register(
+            chat_id=1, process=_mock_process(pid=95), label="main", topic_id=None
+        )
+        flat_task = reg.register(
+            chat_id=1, process=_mock_process(pid=96), label="task:AAAAAAAA", topic_id=None
+        )
+        topic_normal = reg.register(
+            chat_id=1, process=_mock_process(pid=97), label="main", topic_id=10
+        )
+
+        with patch(
+            "ductor_bot.cli.process_registry._kill_processes",
+            new_callable=AsyncMock,
+            return_value=1,
+        ):
+            killed = await reg.kill_by_chat_topic(1, None)
+
+        assert killed == 1
+        remaining_ids = {id(t) for t in reg._processes[1]}
+        assert id(flat_normal) not in remaining_ids
+        assert {id(flat_task), id(topic_normal)} <= remaining_ids
 
 
 async def test_kill_stale_handles_already_exited() -> None:

--- a/tests/messenger/telegram/test_handlers.py
+++ b/tests/messenger/telegram/test_handlers.py
@@ -52,6 +52,27 @@ class TestHandleAbort:
         assert result is True
         orchestrator.abort.assert_called_once_with(42, topic_id=None)
 
+    async def test_abort_zero_killed_sends_nothing_text(self) -> None:
+        from ductor_bot.messenger.telegram.handlers import handle_abort
+        from ductor_bot.text.response_format import stop_text
+
+        orchestrator = MagicMock()
+        orchestrator.abort = AsyncMock(return_value=0)
+        orchestrator.active_provider_name = "Claude"
+        bot = MagicMock()
+        msg = _make_message(chat_id=42)
+
+        with patch(
+            "ductor_bot.messenger.telegram.handlers.send_rich",
+            new_callable=AsyncMock,
+        ) as send_rich:
+            result = await handle_abort(orchestrator, bot, chat_id=42, message=msg)
+
+        assert result is True
+        send_rich.assert_awaited_once()
+        assert send_rich.call_args.args[2] == stop_text(False, "Claude")
+        assert "Nothing running right now." in send_rich.call_args.args[2]
+
     async def test_abort_no_orchestrator(self) -> None:
         from ductor_bot.messenger.telegram.handlers import handle_abort
 

--- a/tests/orchestrator/test_commands.py
+++ b/tests/orchestrator/test_commands.py
@@ -35,12 +35,12 @@ async def test_model_list_returns_keyboard(orch: Orchestrator) -> None:
 
 async def test_model_direct_switch(orch: Orchestrator) -> None:
     kill_mock = AsyncMock(return_value=0)
-    object.__setattr__(orch._process_registry, "kill_all", kill_mock)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", kill_mock)
     result = await cmd_model(orch, SessionKey(chat_id=1), "/model sonnet")
     assert "opus" in result.text
     assert "sonnet" in result.text
     assert orch._config.model == "sonnet"
-    kill_mock.assert_called_once_with(1)
+    kill_mock.assert_called_once_with(1, None)
 
 
 async def test_model_already_set(orch: Orchestrator) -> None:
@@ -49,13 +49,13 @@ async def test_model_already_set(orch: Orchestrator) -> None:
 
 
 async def test_model_provider_change(orch: Orchestrator) -> None:
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     result = await cmd_model(orch, SessionKey(chat_id=1), "/model o3")
     assert "Provider:" in result.text
 
 
 async def test_model_switch_persists_to_config(orch: Orchestrator) -> None:
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     await cmd_model(orch, SessionKey(chat_id=1), "/model sonnet")
     saved = json.loads(orch.paths.config_path.read_text(encoding="utf-8"))
     assert saved["model"] == "sonnet"
@@ -63,7 +63,7 @@ async def test_model_switch_persists_to_config(orch: Orchestrator) -> None:
 
 
 async def test_model_provider_change_persists_to_config(orch: Orchestrator) -> None:
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     await cmd_model(orch, SessionKey(chat_id=1), "/model o3")
     saved = json.loads(orch.paths.config_path.read_text(encoding="utf-8"))
     assert saved["model"] == "o3"
@@ -72,11 +72,11 @@ async def test_model_provider_change_persists_to_config(orch: Orchestrator) -> N
 
 async def test_model_same_provider_does_not_show_reset(orch: Orchestrator) -> None:
     kill_mock = AsyncMock(return_value=0)
-    object.__setattr__(orch._process_registry, "kill_all", kill_mock)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", kill_mock)
     result = await cmd_model(orch, SessionKey(chat_id=1), "/model sonnet")
     assert "Session reset" not in result.text
     assert "Provider:" not in result.text
-    kill_mock.assert_called_once_with(1)
+    kill_mock.assert_called_once_with(1, None)
 
 
 # -- cmd_status --
@@ -228,7 +228,7 @@ async def test_diagnose_shows_effective_runtime_target(orch: Orchestrator) -> No
 
 async def test_model_unknown_name(orch: Orchestrator) -> None:
     """Unknown model names are treated as codex models and the switch succeeds."""
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     result = await cmd_model(orch, SessionKey(chat_id=1), "/model totally_fake_model")
     assert "Model switched" in result.text
     assert "totally_fake_model" in result.text

--- a/tests/orchestrator/test_core.py
+++ b/tests/orchestrator/test_core.py
@@ -38,10 +38,10 @@ def _mock_response(**kwargs: object) -> AgentResponse:
 
 async def test_new_command(orch: Orchestrator) -> None:
     mock_kill = AsyncMock(return_value=0)
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
     result = await orch.handle_message(SessionKey(chat_id=1), "/new")
     assert "session reset" in result.text.lower()
-    mock_kill.assert_called_once_with(1)
+    mock_kill.assert_called_once_with(1, None)
 
 
 async def test_new_command_resets_only_active_provider_bucket(orch: Orchestrator) -> None:
@@ -172,14 +172,14 @@ async def test_reset_command_with_args_uses_reset_dispatch(orch: Orchestrator) -
     mock_kill = AsyncMock(return_value=0)
     mock_reset = AsyncMock(return_value="codex")
     mock_execute = AsyncMock()
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
     object.__setattr__(orch, "reset_current_provider_session", mock_reset)
     object.__setattr__(orch._cli_service, "execute", mock_execute)
 
     result = await orch.handle_message(SessionKey(chat_id=17), "/reset extra")
 
     assert "Session reset for Codex" in result.text
-    mock_kill.assert_awaited_once_with(17)
+    mock_kill.assert_awaited_once_with(17, None)
     mock_reset.assert_awaited_once_with(SessionKey(chat_id=17))
     mock_execute.assert_not_called()
 

--- a/tests/orchestrator/test_error_no_reset.py
+++ b/tests/orchestrator/test_error_no_reset.py
@@ -40,7 +40,7 @@ async def test_error_preserves_session_id(orch: Orchestrator) -> None:
             return_value=_mock_response(is_error=True, result="Token limit", session_id="sess-keep")
         ),
     )
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Fail once")
 
@@ -59,7 +59,7 @@ async def test_error_on_new_session_persists_response_session_id(orch: Orchestra
             return_value=_mock_response(is_error=True, result="Token limit", session_id="sess-new")
         ),
     )
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Fail before first success")
 
@@ -76,7 +76,7 @@ async def test_error_message_contains_new_hint(orch: Orchestrator) -> None:
         "execute",
         AsyncMock(return_value=_mock_response(is_error=True, result="Error")),
     )
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Broken")
 
@@ -89,7 +89,7 @@ async def test_no_auto_retry_on_resume_failure(orch: Orchestrator) -> None:
 
     mock_execute = AsyncMock(return_value=_mock_response(is_error=True, result="Resume failed"))
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     await normal(orch, SessionKey(chat_id=1), "Retry")
 
@@ -105,7 +105,7 @@ async def test_next_message_after_error_resumes_same_session(orch: Orchestrator)
     success_resp = _mock_response(result="Recovered", session_id="sess-keep")
     mock_execute = AsyncMock(side_effect=[error_resp, success_resp])
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     first = await normal(orch, SessionKey(chat_id=1), "Flaky")
     second = await normal(orch, SessionKey(chat_id=1), "Try again")
@@ -128,7 +128,7 @@ async def test_sigkill_still_auto_recovers(orch: Orchestrator) -> None:
     mock_reset_provider = AsyncMock()
 
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     object.__setattr__(orch._sessions, "reset_provider_session", mock_reset_provider)
 
     result = await normal(orch, SessionKey(chat_id=1), "Run")
@@ -153,7 +153,7 @@ async def test_sigkill_resets_only_affected_provider(orch: Orchestrator) -> None
     object.__setattr__(
         orch._cli_service, "execute", AsyncMock(side_effect=[sigkill_resp, sigkill_resp])
     )
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Run")
 
@@ -171,7 +171,7 @@ async def test_streaming_error_preserves_session(orch: Orchestrator) -> None:
 
     mock_streaming = AsyncMock(return_value=_mock_response(is_error=True, result="Stream error"))
     object.__setattr__(orch._cli_service, "execute_streaming", mock_streaming)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal_streaming(orch, SessionKey(chat_id=1), "Broken stream")
 
@@ -205,7 +205,7 @@ async def test_streaming_no_auto_retry_on_resume_failure(orch: Orchestrator) -> 
 
     mock_streaming = AsyncMock(return_value=_mock_response(is_error=True, result="Resume failed"))
     object.__setattr__(orch._cli_service, "execute_streaming", mock_streaming)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     await normal_streaming(orch, SessionKey(chat_id=1), "Retry")
 
@@ -224,7 +224,7 @@ async def test_auth_error_shows_hint(orch: Orchestrator) -> None:
         "execute",
         AsyncMock(return_value=_mock_response(is_error=True, result=error_text)),
     )
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Test")
 
@@ -240,7 +240,7 @@ async def test_rate_limit_error_shows_hint(orch: Orchestrator) -> None:
         "execute",
         AsyncMock(return_value=_mock_response(is_error=True, result=error_text)),
     )
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Test")
 
@@ -254,7 +254,7 @@ async def test_unknown_error_shows_detail_line(orch: Orchestrator) -> None:
         "execute",
         AsyncMock(return_value=_mock_response(is_error=True, result=error_text)),
     )
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Test")
 
@@ -268,7 +268,7 @@ async def test_streaming_auth_error_shows_hint(orch: Orchestrator) -> None:
         return_value=_mock_response(is_error=True, result=error_text),
     )
     object.__setattr__(orch._cli_service, "execute_streaming", mock_streaming)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal_streaming(orch, SessionKey(chat_id=1), "Test")
 

--- a/tests/orchestrator/test_flows.py
+++ b/tests/orchestrator/test_flows.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -97,14 +97,14 @@ async def test_normal_error_preserves_session(orch: Orchestrator) -> None:
     )
     mock_kill = AsyncMock(return_value=0)
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
 
     result = await normal(orch, SessionKey(chat_id=1), "Hello")
     assert "Session Error" in result.text
     assert "[opus]" in result.text
     assert "/new" in result.text
     assert mock_execute.call_count == 1
-    mock_kill.assert_called_once_with(1)
+    mock_kill.assert_called_once_with(1, None)
 
 
 async def test_normal_timeout_preserves_session(orch: Orchestrator) -> None:
@@ -115,7 +115,7 @@ async def test_normal_timeout_preserves_session(orch: Orchestrator) -> None:
         return_value=_mock_response(is_error=True, timed_out=True, result=""),
     )
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     result = await normal(orch, SessionKey(chat_id=1), "Hello")
     assert "Timeout" in result.text
@@ -131,7 +131,7 @@ async def test_normal_next_message_can_succeed_after_error(orch: Orchestrator) -
     success_resp = _mock_response(result="All good")
     mock_execute = AsyncMock(side_effect=[error_resp, success_resp])
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
 
     first = await normal(orch, SessionKey(chat_id=1), "Hello")
     second = await normal(orch, SessionKey(chat_id=1), "Hello again")
@@ -156,7 +156,7 @@ async def test_normal_sigkill_recovers_once_then_succeeds(orch: Orchestrator) ->
     mock_execute = AsyncMock(side_effect=[sigkill_resp, success_resp])
     mock_reset_provider = AsyncMock()
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     object.__setattr__(orch._sessions, "reset_provider_session", mock_reset_provider)
 
     result = await normal(orch, SessionKey(chat_id=1), "Hello")
@@ -173,7 +173,7 @@ async def test_normal_sigkill_recovers_once_then_asks_user_retry(orch: Orchestra
     mock_execute = AsyncMock(side_effect=[sigkill_resp, sigkill_resp])
     mock_reset_provider = AsyncMock()
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     object.__setattr__(orch._sessions, "reset_provider_session", mock_reset_provider)
 
     result = await normal(orch, SessionKey(chat_id=1), "Hello")
@@ -182,6 +182,31 @@ async def test_normal_sigkill_recovers_once_then_asks_user_retry(orch: Orchestra
     mock_reset_provider.assert_called_once_with(
         SessionKey(chat_id=1), provider="claude", model="opus"
     )
+
+
+async def test_normal_recovery_clears_topic_abort_marker(orch: Orchestrator) -> None:
+    """Recovery retry clears only the invoking topic abort marker."""
+    key = SessionKey(chat_id=1, topic_id=42)
+    sigkill_resp = _mock_response(is_error=True, result="killed", returncode=-9)
+    success_resp = _mock_response(result="Recovered")
+    mock_execute = AsyncMock(side_effect=[sigkill_resp, success_resp])
+    mock_kill = AsyncMock(return_value=1)
+    mock_clear_topic_abort = MagicMock()
+    mock_reset_provider = AsyncMock()
+
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
+    object.__setattr__(
+        orch._process_registry, "clear_topic_abort", mock_clear_topic_abort
+    )
+    object.__setattr__(orch._sessions, "reset_provider_session", mock_reset_provider)
+
+    result = await normal(orch, key, "Hello")
+
+    assert result.text == "Recovered"
+    mock_kill.assert_awaited_once_with(1, 42)
+    mock_clear_topic_abort.assert_called_once_with(1, 42)
+    mock_reset_provider.assert_called_once_with(key, provider="claude", model="opus")
 
 
 async def test_normal_stale_session_recovery_failed_circuit_breaker(orch: Orchestrator) -> None:
@@ -198,7 +223,7 @@ async def test_normal_stale_session_recovery_failed_circuit_breaker(orch: Orches
     mock_execute = AsyncMock(side_effect=[stale_resp, stale_resp])
     mock_reset_provider = AsyncMock()
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     object.__setattr__(orch._sessions, "reset_provider_session", mock_reset_provider)
 
     result = await normal(orch, SessionKey(chat_id=1), "Hello")
@@ -397,7 +422,7 @@ async def test_streaming_sigkill_recovers_once_then_succeeds(orch: Orchestrator)
     mock_streaming = AsyncMock(side_effect=[sigkill_resp, success_resp])
     mock_reset_provider = AsyncMock()
     object.__setattr__(orch._cli_service, "execute_streaming", mock_streaming)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     object.__setattr__(orch._sessions, "reset_provider_session", mock_reset_provider)
 
     result = await normal_streaming(orch, SessionKey(chat_id=1), "Hello")
@@ -416,12 +441,12 @@ async def test_streaming_error_preserves_session(orch: Orchestrator) -> None:
         AsyncMock(return_value=_mock_response(is_error=True, result="Stream failed")),
     )
     mock_kill = AsyncMock(return_value=0)
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
 
     result = await normal_streaming(orch, SessionKey(chat_id=1), "Hello")
     assert "Session Error" in result.text
     assert "[opus]" in result.text
-    mock_kill.assert_called_once_with(1)
+    mock_kill.assert_called_once_with(1, None)
 
 
 async def test_streaming_error_with_model_override(orch: Orchestrator) -> None:
@@ -431,7 +456,7 @@ async def test_streaming_error_with_model_override(orch: Orchestrator) -> None:
         "execute_streaming",
         AsyncMock(return_value=_mock_response(is_error=True, result="Error")),
     )
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     object.__setattr__(orch._sessions, "reset_session", AsyncMock())
 
     result = await normal_streaming(orch, SessionKey(chat_id=1), "Hello", model_override="sonnet")
@@ -580,7 +605,7 @@ async def test_normal_no_auto_retry_on_resume_failure(orch: Orchestrator) -> Non
     )
     mock_kill = AsyncMock(return_value=0)
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
 
     await normal(orch, SessionKey(chat_id=1), "Hello")
     assert mock_execute.call_count == 1
@@ -598,7 +623,7 @@ async def test_streaming_no_auto_retry_on_resume_failure(orch: Orchestrator) -> 
     )
     mock_kill = AsyncMock(return_value=0)
     object.__setattr__(orch._cli_service, "execute_streaming", mock_streaming)
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
 
     await normal_streaming(orch, SessionKey(chat_id=1), "Hello")
     assert mock_streaming.call_count == 1
@@ -611,7 +636,7 @@ async def test_normal_no_retry_on_new_session_error(orch: Orchestrator) -> None:
     )
     mock_kill = AsyncMock(return_value=0)
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
     object.__setattr__(orch._sessions, "reset_session", AsyncMock())
 
     await normal(orch, SessionKey(chat_id=1), "Hello")
@@ -626,7 +651,7 @@ async def test_streaming_no_retry_on_new_session_error(orch: Orchestrator) -> No
     )
     mock_kill = AsyncMock(return_value=0)
     object.__setattr__(orch._cli_service, "execute_streaming", mock_streaming)
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
     object.__setattr__(orch._sessions, "reset_session", AsyncMock())
 
     await normal_streaming(orch, SessionKey(chat_id=1), "Hello")
@@ -712,20 +737,20 @@ async def test_topic_abort_skips_recovery(orch: Orchestrator) -> None:
     assert mock_execute.call_count == 1
 
 
-async def test_topic_abort_error_response_skips_chat_wide_reset(orch: Orchestrator) -> None:
-    """Non-SIGKILL error after a topic /stop must not fall through to kill_all."""
+async def test_topic_abort_error_response_skips_topic_reset(orch: Orchestrator) -> None:
+    """Non-SIGKILL error after a topic /stop must not fall through to reset."""
     key = SessionKey(chat_id=1, topic_id=42)
     mock_execute = AsyncMock(
         return_value=_mock_response(is_error=True, result="boom", returncode=1),
     )
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    kill_all = AsyncMock(return_value=0)
-    object.__setattr__(orch._process_registry, "kill_all", kill_all)
+    kill_by_topic = AsyncMock(return_value=0)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", kill_by_topic)
     orch._process_registry._aborted_topics.add((1, 42))
 
     result = await normal(orch, key, "Hello")
     assert result.text == ""
-    kill_all.assert_not_awaited()
+    kill_by_topic.assert_not_awaited()
 
 
 async def test_streaming_abort_skips_retry(orch: Orchestrator) -> None:
@@ -770,6 +795,18 @@ async def test_named_session_topic_abort(orch: Orchestrator) -> None:
     assert ns.status == "idle"
 
 
+async def test_named_session_flow_uses_ns_process_label(orch: Orchestrator) -> None:
+    ns = orch._named_sessions.create(1, "claude", "opus", "Setup")
+    orch._named_sessions.update_after_response(1, ns.name, "sess-named")
+    mock_execute = AsyncMock(return_value=_mock_response(result="Agent replied"))
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+
+    await named_session_flow(orch, SessionKey(chat_id=1, topic_id=42), ns.name, "Hello")
+
+    request = mock_execute.call_args[0][0]
+    assert request.process_label == f"ns:{ns.name}"
+
+
 async def test_streaming_abort_discards_successful_response(orch: Orchestrator) -> None:
     """Even when streaming CLI responds successfully, abort flag causes empty result."""
     mock_streaming = AsyncMock(
@@ -788,7 +825,7 @@ async def test_normal_abort_on_new_session_returns_empty(orch: Orchestrator) -> 
         return_value=_mock_response(is_error=True, result="killed"),
     )
     object.__setattr__(orch._cli_service, "execute", mock_execute)
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     object.__setattr__(orch._sessions, "reset_session", AsyncMock())
     orch._process_registry._aborted.add(1)
 

--- a/tests/orchestrator/test_model_selector.py
+++ b/tests/orchestrator/test_model_selector.py
@@ -264,7 +264,7 @@ async def test_callback_provider_antigravity(orch: Orchestrator) -> None:
 
 
 async def test_callback_model_claude_switches(orch: Orchestrator) -> None:
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     resp = await handle_model_callback(orch, SessionKey(chat_id=1), "ms:m:sonnet")
     assert "sonnet" in resp.text
     assert resp.buttons is None
@@ -274,7 +274,7 @@ async def test_callback_model_claude_switches(orch: Orchestrator) -> None:
 async def test_callback_model_antigravity_switches_without_reasoning_step(
     orch: Orchestrator,
 ) -> None:
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     resp = await handle_model_callback(orch, SessionKey(chat_id=1), "ms:m:antigravity-default")
     assert "antigravity-default" in resp.text
     assert "Thinking level" not in resp.text
@@ -309,7 +309,7 @@ async def test_callback_model_codex_mini_limited_efforts(orch: Orchestrator) -> 
 
 
 async def test_callback_reasoning_switches(orch: Orchestrator) -> None:
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     resp = await handle_model_callback(orch, SessionKey(chat_id=1), "ms:r:high:gpt-5.2-codex")
     assert "gpt-5.2-codex" in resp.text
     assert "high" in resp.text.lower()
@@ -340,7 +340,7 @@ async def test_callback_back_provider(orch: Orchestrator) -> None:
 async def test_switch_model_basic(orch: Orchestrator) -> None:
     mock_kill = AsyncMock(return_value=0)
     mock_reset = AsyncMock()
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
     object.__setattr__(orch._sessions, "reset_provider_session", mock_reset)
     result = await switch_model(orch, SessionKey(chat_id=1), "sonnet")
     assert "opus" in result
@@ -348,13 +348,13 @@ async def test_switch_model_basic(orch: Orchestrator) -> None:
     assert "Session reset" not in result
     assert "Resuming session" not in result
     assert orch._config.model == "sonnet"
-    mock_kill.assert_called_once_with(1)
+    mock_kill.assert_called_once_with(1, None)
     mock_reset.assert_not_called()
 
 
 async def test_switch_model_opus_1m_persists(orch: Orchestrator) -> None:
     """opus[1m] is a valid Claude alias; switch_model persists it to config (#76)."""
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     result = await switch_model(orch, SessionKey(chat_id=1), "opus[1m]")
     assert "opus[1m]" in result
     assert orch._config.model == "opus[1m]"
@@ -369,7 +369,7 @@ async def test_switch_model_already_set(orch: Orchestrator) -> None:
 
 
 async def test_switch_model_with_reasoning_effort(orch: Orchestrator) -> None:
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     result = await switch_model(orch, SessionKey(chat_id=1), "sonnet", reasoning_effort="high")
     assert "high" in result.lower()
     assert orch._config.reasoning_effort == "high"
@@ -378,7 +378,7 @@ async def test_switch_model_with_reasoning_effort(orch: Orchestrator) -> None:
 
 
 async def test_switch_model_persists_to_config(orch: Orchestrator) -> None:
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     await switch_model(orch, SessionKey(chat_id=1), "sonnet")
     saved = json.loads(orch.paths.config_path.read_text(encoding="utf-8"))
     assert saved["model"] == "sonnet"
@@ -386,7 +386,7 @@ async def test_switch_model_persists_to_config(orch: Orchestrator) -> None:
 
 async def test_switch_model_provider_change(orch: Orchestrator) -> None:
     mock_reset = AsyncMock()
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     object.__setattr__(orch._sessions, "reset_provider_session", mock_reset)
     result = await switch_model(orch, SessionKey(chat_id=1), "o3")
     assert "Provider:" in result
@@ -401,7 +401,7 @@ async def test_switch_model_shows_resume_hint_same_provider(orch: Orchestrator) 
     session.session_id = "claude-abc123"
     await orch._sessions.update_session(session)
 
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     result = await switch_model(orch, SessionKey(chat_id=1), "sonnet")
 
     assert "Resuming session `claude-abc123`." in result
@@ -417,7 +417,7 @@ async def test_switch_model_shows_resume_hint_provider_change(orch: Orchestrator
     session.session_id = "codex-xyz789"
     await orch._sessions.update_session(session)
 
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     result = await switch_model(orch, SessionKey(chat_id=1), "o3")
 
     assert "Resuming session `codex-xyz789`." in result
@@ -430,7 +430,7 @@ async def test_switch_reasoning_only(orch: Orchestrator) -> None:
     """Changing only reasoning effort does not reset session."""
     mock_kill = AsyncMock(return_value=0)
     mock_reset = AsyncMock()
-    object.__setattr__(orch._process_registry, "kill_all", mock_kill)
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", mock_kill)
     object.__setattr__(orch._sessions, "reset_provider_session", mock_reset)
     result = await switch_model(orch, SessionKey(chat_id=1), "opus", reasoning_effort="high")
     assert "Reasoning effort updated" in result
@@ -444,7 +444,7 @@ async def test_switch_model_rejects_invalid_codex_reasoning_effort(orch: Orchest
     from ductor_bot.cli.codex_cache import CodexModelCache
     from ductor_bot.cli.codex_discovery import CodexModelInfo
 
-    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    object.__setattr__(orch._process_registry, "kill_by_chat_topic", AsyncMock(return_value=0))
     orch._observers.codex_cache_obs = MagicMock(
         get_cache=MagicMock(
             return_value=CodexModelCache(

--- a/tests/tasks/test_hub.py
+++ b/tests/tasks/test_hub.py
@@ -139,6 +139,32 @@ class TestRunAndDeliver:
 
         await hub.shutdown()
 
+    async def test_task_request_uses_task_label(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        captured: list[object] = []
+        cli = _make_cli_service("task output")
+
+        async def _execute(request: object) -> object:
+            captured.append(request)
+            return _make_cli_service("task output").execute.return_value
+
+        cli.execute = AsyncMock(side_effect=_execute)
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=cli,
+            config=_make_config(),
+        )
+
+        task_id = hub.submit(_submit())
+        await asyncio.sleep(0.1)
+
+        assert captured
+        assert captured[0].process_label == f"task:{task_id}"
+
+        await hub.shutdown()
+
     async def test_delivers_error_on_cli_failure(
         self, registry: TaskRegistry, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Problem

Six call sites kill every registered CLI process for the whole chat via
`ProcessRegistry.kill_all(chat_id)`:

- `switch_model` (model selector) — `/model` confirmation
- `cmd_reset` / `cmd_reset_current` — `/new`, `/reset` command-registry handlers
- session-error preserve, timeout preserve, and recovery-retry flows

In a multi-topic group every topic shares one `chat_id`, so any of these
events in one topic aborts **other topics' in-flight turns and background
task subprocesses**. The killed CLI exits 143 and surfaces as
`CLI returned empty output (exit=143)`; a background task hit this way is
marked failed/cancelled and its (already billed) work is lost.

This also contradicts the contract documented on `Orchestrator.abort()`
(the `/stop` handler): a topic-scoped stop deliberately leaves background
tasks and named sessions alone because they have their own management
surfaces (`/tasks`, `/sessions`), yet task/named-session subprocesses are
registered under the same chat bucket and get swept by the chat-wide kills.

Reproduce: in a group with topics, start a background task from topic A,
then run `/model` (pick a different model) in topic B → the task's
subprocess dies mid-run.

## Fix

- Switch the six call sites to `kill_by_chat_topic(chat_id, topic_id)` —
  the primitive `/stop` already uses. The callers all have the full
  `SessionKey` in hand; they now use it.
- Teach `kill_by_chat_topic` to preserve processes whose lifecycle is
  owned elsewhere (`task:`, `task_result:`, `ns:` labels), matching the
  `Orchestrator.abort()` contract. Preserved entries **stay registered**
  so `TaskHub.cancel()` → `kill_for_task()` can still terminate them.
- The recovery flow clears the matching topic-level abort flag
  (`clear_topic_abort`) instead of the chat-level one.
- `kill_all()` itself is unchanged: `/stop_all` and shutdown teardown
  still sweep everything, tasks included.

Behavior notes:

- Flat chats (`topic_id=None`: private chats, non-topic groups) behave as
  before, minus the protected labels.
- `/stop` in a topic where only protected processes are running now
  reports "nothing to stop" — the task keeps running and is cancellable
  via `/tasks`.

## Tests

- `kill_by_chat_topic` preserves protected labels, keeps them registered,
  and `kill_for_task` still kills them; protected-only topics return 0
  and set no abort flag; cross-topic survival; `topic_id=None` flat-chat
  behavior; `kill_all` still sweeps protected labels.
- Recovery retry asserts `clear_topic_abort(chat, topic)`.
- `/stop` zero-kill UX pinned at the Telegram handler.
- Label prefixes pinned against their producers (task hub, result
  envelope origin, named-session flows).
- Existing kill_all assertions for the six call sites updated.

13 files changed, +310/−74. Rollback = revert (no config/schema impact).

> **Note for merging alongside #164**: this PR touches `model_selector.py`
> and `flows.py` in hunks adjacent to #164 (per-session reasoning effort).
> Both are independent single-commit PRs off current `main`; merging them
> in either order yields at most trivial context conflicts.
