### PR TITLE
fix: don't discard a finished task result when cancel races completion

### DIFF
--- a/ductor_bot/multiagent/internal_api.py
+++ b/ductor_bot/multiagent/internal_api.py
@@ -421,6 +421,12 @@ class InternalAgentAPI:
                 )
 
         cancelled = await self._task_hub.cancel(task_id)
+        logger.info(
+            "Task cancel via API id=%s from=%s success=%s",
+            task_id,
+            sender or "?",
+            cancelled,
+        )
         return web.json_response({"success": cancelled})
 
     async def _handle_task_delete(  # noqa: PLR0911

--- a/ductor_bot/tasks/hub.py
+++ b/ductor_bot/tasks/hub.py
@@ -98,6 +98,7 @@ class TaskHub:
         # per-agent lookups take precedence via ``_agent_process_registries``.
         self._process_registry = process_registry
         self._agent_process_registries: dict[str, ProcessRegistry] = {}
+        self._pending_deliveries: set[asyncio.Task[None]] = set()
 
     def start_maintenance(self) -> None:
         """Start periodic orphan cleanup (call once after bot startup)."""
@@ -349,6 +350,7 @@ class TaskHub:
         """
         inflight = self._in_flight.get(task_id)
         if inflight is None or inflight.asyncio_task is None or inflight.asyncio_task.done():
+            logger.info("Cancel requested for non-running task id=%s", task_id)
             return False
         registry = self._resolve_process_registry(inflight.entry.parent_agent)
         if registry is not None:
@@ -356,6 +358,7 @@ class TaskHub:
         inflight.asyncio_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await inflight.asyncio_task
+        logger.info("Task cancel accepted id=%s name='%s'", task_id, inflight.entry.name)
         return True
 
     async def cancel_all(self, chat_id: int) -> int:
@@ -385,6 +388,7 @@ class TaskHub:
         for atask in cancelled:
             atask.cancel()
         await asyncio.gather(*cancelled, return_exceptions=True)
+        logger.info("Task cancel accepted for %d task(s) chat=%s", len(cancelled), chat_id)
         return len(cancelled)
 
     def active_tasks(self, chat_id: int | None = None) -> list[TaskEntry]:
@@ -414,6 +418,8 @@ class TaskHub:
         if cancelled:
             await asyncio.gather(*cancelled, return_exceptions=True)
         self._in_flight.clear()
+        if self._pending_deliveries:
+            await asyncio.gather(*self._pending_deliveries, return_exceptions=True)
 
     async def _maintenance_loop(self) -> None:
         """Periodically clean orphaned task entries/folders (every 5 hours)."""
@@ -428,6 +434,12 @@ class TaskHub:
                     logger.exception("Task maintenance failed (continuing)")
         except asyncio.CancelledError:
             pass
+
+    def _start_final_delivery(self, result: TaskResult) -> asyncio.Task[None]:
+        delivery_task = asyncio.create_task(self._deliver(result))
+        self._pending_deliveries.add(delivery_task)
+        delivery_task.add_done_callback(self._pending_deliveries.discard)
+        return delivery_task
 
     async def _run(
         self,
@@ -444,6 +456,7 @@ class TaskHub:
         assert cli is not None
 
         t0 = time.monotonic()
+        final_delivery_started = False
         try:
             timeout = self._config.timeout_seconds
 
@@ -505,27 +518,36 @@ class TaskHub:
                     f'python3 tools/task_tools/resume_task.py {entry.task_id} "your follow-up"'
                 )
 
-            await self._deliver(
-                TaskResult(
-                    task_id=entry.task_id,
-                    chat_id=entry.chat_id,
-                    parent_agent=entry.parent_agent,
-                    name=entry.name,
-                    prompt_preview=entry.prompt_preview,
-                    result_text=result_text,
-                    status=status,
-                    elapsed_seconds=elapsed,
-                    provider=entry.provider,
-                    model=entry.model,
-                    session_id=session_id,
-                    error=error,
-                    task_folder=str(self._registry.task_folder(entry.task_id)),
-                    original_prompt=entry.original_prompt,
-                    thread_id=entry.thread_id,
+            final_delivery_started = True
+            await asyncio.shield(
+                self._start_final_delivery(
+                    TaskResult(
+                        task_id=entry.task_id,
+                        chat_id=entry.chat_id,
+                        parent_agent=entry.parent_agent,
+                        name=entry.name,
+                        prompt_preview=entry.prompt_preview,
+                        result_text=result_text,
+                        status=status,
+                        elapsed_seconds=elapsed,
+                        provider=entry.provider,
+                        model=entry.model,
+                        session_id=session_id,
+                        error=error,
+                        task_folder=str(self._registry.task_folder(entry.task_id)),
+                        original_prompt=entry.original_prompt,
+                        thread_id=entry.thread_id,
+                    )
                 )
             )
 
         except asyncio.CancelledError:
+            if final_delivery_started:
+                logger.info(
+                    "Task %s cancelled after completion — finished result preserved",
+                    entry.task_id,
+                )
+                raise
             elapsed = time.monotonic() - t0
             self._registry.update_status(
                 entry.task_id,

--- a/tests/multiagent/test_internal_api.py
+++ b/tests/multiagent/test_internal_api.py
@@ -247,6 +247,33 @@ class TestHandleHealth:
         assert data["agents"]["sub1"]["restart_count"] == 1
 
 
+class TestHandleTaskCancel:
+    async def test_cancel_logs_sender(
+        self,
+        client: TestClient,
+        api: InternalAgentAPI,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        hub = MagicMock()
+        hub.cancel = AsyncMock(return_value=True)
+        hub.registry.get.return_value = MagicMock(parent_agent="main")
+        api.set_task_hub(hub)
+        caplog.set_level("INFO", logger="ductor_bot.multiagent.internal_api")
+
+        resp = await client.post(
+            "/tasks/cancel",
+            json={"task_id": "task-123", "from": "main"},
+        )
+
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["success"] is True
+        hub.cancel.assert_awaited_once_with("task-123")
+
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert "Task cancel via API id=task-123 from=main success=True" in messages
+
+
 class TestLifecycle:
     """Test InternalAgentAPI lifecycle return values."""
 

--- a/tests/tasks/test_hub.py
+++ b/tests/tasks/test_hub.py
@@ -246,6 +246,8 @@ class TestCancel:
         hub.set_result_handler("main", AsyncMock(side_effect=delivered.append))
 
         task_id = hub.submit(_submit())
+        memory = registry.taskmemory_path(task_id)
+        memory.write_text("partial cancellation notes\n", encoding="utf-8")
         await asyncio.sleep(0.05)
 
         success = await hub.cancel(task_id)
@@ -254,10 +256,94 @@ class TestCancel:
 
         assert len(delivered) == 1
         assert delivered[0].status == "cancelled"
+        assert "partial cancellation notes" in delivered[0].result_text
+        assert "CONTENT FROM TASKMEMORY.MD" in delivered[0].result_text
 
         entry = registry.get(task_id)
         assert entry is not None
         assert entry.status == "cancelled"
+
+    async def test_cancel_after_completion_preserves_result(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        delivery_started = asyncio.Event()
+        delivery_released = asyncio.Event()
+        delivered_event = asyncio.Event()
+        delivered: list[TaskResult] = []
+
+        async def _blocked_handler(result: TaskResult) -> None:
+            delivery_started.set()
+            await delivery_released.wait()
+            delivered.append(result)
+            delivered_event.set()
+
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=_make_cli_service("complete result"),
+            config=_make_config(),
+        )
+        hub.set_result_handler("main", _blocked_handler)
+
+        task_id = hub.submit(_submit())
+        await asyncio.wait_for(delivery_started.wait(), timeout=1)
+
+        success = await hub.cancel(task_id)
+        assert success
+
+        delivery_released.set()
+        await asyncio.wait_for(delivered_event.wait(), timeout=1)
+
+        assert len(delivered) == 1
+        assert delivered[0].status == "done"
+        assert "complete result" in delivered[0].result_text
+
+        entry = registry.get(task_id)
+        assert entry is not None
+        assert entry.status == "done"
+
+        await hub.shutdown()
+
+    async def test_cancel_all_after_completion_preserves_result(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        delivery_started = asyncio.Event()
+        delivery_released = asyncio.Event()
+        delivered_event = asyncio.Event()
+        delivered: list[TaskResult] = []
+
+        async def _blocked_handler(result: TaskResult) -> None:
+            delivery_started.set()
+            await delivery_released.wait()
+            delivered.append(result)
+            delivered_event.set()
+
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=_make_cli_service("complete result"),
+            config=_make_config(),
+        )
+        hub.set_result_handler("main", _blocked_handler)
+
+        task_id = hub.submit(_submit())
+        await asyncio.wait_for(delivery_started.wait(), timeout=1)
+
+        count = await hub.cancel_all(42)
+        assert count == 1
+
+        delivery_released.set()
+        await asyncio.wait_for(delivered_event.wait(), timeout=1)
+
+        assert len(delivered) == 1
+        assert delivered[0].status == "done"
+        assert "complete result" in delivered[0].result_text
+
+        entry = registry.get(task_id)
+        assert entry is not None
+        assert entry.status == "done"
+
+        await hub.shutdown()
 
     async def test_cancel_nonexistent(self, registry: TaskRegistry, tmp_path: Path) -> None:
         hub = TaskHub(
@@ -267,6 +353,104 @@ class TestCancel:
             config=_make_config(),
         )
         assert not await hub.cancel("nonexistent")
+
+    async def test_cancel_logs(
+        self,
+        registry: TaskRegistry,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level("INFO", logger="ductor_bot.tasks.hub")
+
+        async def _hang(_: object) -> MagicMock:
+            await asyncio.sleep(999)
+            return MagicMock()
+
+        cli = _make_cli_service()
+        cli.execute = AsyncMock(side_effect=_hang)
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=cli,
+            config=_make_config(),
+        )
+        hub.set_result_handler("main", AsyncMock())
+
+        task_id = hub.submit(_submit(name="Log Task"))
+        await asyncio.sleep(0.05)
+        assert await hub.cancel(task_id)
+        assert not await hub.cancel("missing-task")
+
+        hub.submit(_submit(name="A"))
+        hub.submit(_submit(name="B"))
+        await asyncio.sleep(0.05)
+        assert await hub.cancel_all(42) == 2
+
+        delivery_started = asyncio.Event()
+        delivery_released = asyncio.Event()
+
+        async def _blocked_handler(_: TaskResult) -> None:
+            delivery_started.set()
+            await delivery_released.wait()
+
+        late_hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=_make_cli_service("late complete"),
+            config=_make_config(),
+        )
+        late_hub.set_result_handler("main", _blocked_handler)
+        late_task_id = late_hub.submit(_submit(name="Late Log Task"))
+        await asyncio.wait_for(delivery_started.wait(), timeout=1)
+        assert await late_hub.cancel(late_task_id)
+        delivery_released.set()
+        await late_hub.shutdown()
+
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert f"Task cancel accepted id={task_id} name='Log Task'" in messages
+        assert "Cancel requested for non-running task id=missing-task" in messages
+        assert "Task cancel accepted for 2 task(s) chat=42" in messages
+        assert (
+            f"Task {late_task_id} cancelled after completion — finished result preserved"
+            in messages
+        )
+
+    async def test_shutdown_drains_pending_delivery(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        delivery_started = asyncio.Event()
+        delivery_released = asyncio.Event()
+        delivered_event = asyncio.Event()
+        delivered: list[TaskResult] = []
+
+        async def _blocked_handler(result: TaskResult) -> None:
+            delivery_started.set()
+            await delivery_released.wait()
+            delivered.append(result)
+            delivered_event.set()
+
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=_make_cli_service("shutdown result"),
+            config=_make_config(),
+        )
+        hub.set_result_handler("main", _blocked_handler)
+
+        task_id = hub.submit(_submit())
+        await asyncio.wait_for(delivery_started.wait(), timeout=1)
+        assert await hub.cancel(task_id)
+
+        shutdown_task = asyncio.create_task(hub.shutdown())
+        await asyncio.sleep(0.05)
+        assert not shutdown_task.done()
+
+        delivery_released.set()
+        await asyncio.wait_for(shutdown_task, timeout=1)
+        await asyncio.wait_for(delivered_event.wait(), timeout=1)
+
+        assert len(delivered) == 1
+        assert delivered[0].status == "done"
 
 
 class TestCancelWithProcessRegistry:


### PR DESCRIPTION
## Problem

1. **Completion race loses finished results.** `TaskHub._run()` obtains
   the CLI response, writes terminal status `done`, then awaits result
   delivery. A `TaskHub.cancel()` arriving in that window lands
   `CancelledError` at the delivery await: the handler overwrites the
   terminal status from `done` to `cancelled` and delivers only the
   TASKMEMORY excerpt — silently discarding the completed response the
   subprocess had already produced (and billed). From the user's side the
   task "finished into nothing".

2. **Cancellations leave no trace.** Neither `TaskHub.cancel()`,
   `cancel_all()`, nor the internal API cancel endpoint logged anything,
   so after the fact there is no way to tell who cancelled a task or when.

## Fix

- Run the final delivery as an explicit task, keep a strong reference in
  a hub-level `_pending_deliveries` set (dropped via done-callback), and
  await it through `asyncio.shield()`. The `CancelledError` handler
  becomes a no-op once final delivery has started: the terminal `done`
  status stands and the finished result is delivered exactly once.
  Mid-run cancellation is unchanged (status `cancelled`, TASKMEMORY
  partial delivered). Shutdown drains any pending deliveries.
- Log the cancel paths: accepted / non-running in `cancel()`, a count in
  `cancel_all()`, and the internal API cancel including the requesting
  agent.

Semantics note: the cancel API's `success=true` means the request was
accepted; when completion wins the race the task's final status remains
`done` and the result is delivered.

## Tests

Six scenarios: late cancel via `cancel()` preserves the result (delivered
once, status `done`, no partial `cancelled` delivery); same via
`cancel_all()`; mid-run cancel still delivers the TASKMEMORY partial with
status `cancelled`; the four cancel log flows (caplog); shutdown drains a
blocked pending delivery; API cancel logs the requesting agent.

4 files changed, +253/−17. Rollback = revert (no config/schema impact).

> **Note for merging alongside #164**: touches `tasks/hub.py` in hunks
> adjacent to #164 (per-session reasoning effort). Independent
> single-commit PRs off current `main`; either merge order yields at most
> trivial context conflicts.
