### PR TITLE
fix: re-assert the configured model when resuming a Codex session

### DIFF
--- a/ductor_bot/cli/codex_provider.py
+++ b/ductor_bot/cli/codex_provider.py
@@ -112,10 +112,15 @@ class CodexCLI(BaseCLI):
         self, final_prompt: str, session_id: str, *, json_output: bool
     ) -> list[str]:
         """Build command to resume an existing Codex session."""
+        cfg = self._config
         cmd = [self._cli, "exec", "resume"]
         if json_output:
             cmd.append("--json")
         cmd += self._sandbox_flags()
+        # Codex stores the model at session creation; re-assert it so later
+        # /model changes apply on resume, matching Claude's per-turn --model.
+        if cfg.model:
+            cmd += ["--model", cfg.model]
         cmd += ["--", session_id]
         cmd.append("-" if _IS_WINDOWS else final_prompt)
         return cmd

--- a/tests/cli/test_codex_provider.py
+++ b/tests/cli/test_codex_provider.py
@@ -278,11 +278,23 @@ class TestBuildCommand:
         assert cmd[2] == "resume"
         assert "--json" in cmd
         assert "--dangerously-bypass-approvals-and-sandbox" in cmd
-        assert "thread-abc" in cmd
-        # resume does not include --model, --color, --skip-git-repo-check
-        assert "--model" not in cmd
+        idx_model = cmd.index("--model")
+        assert cmd[idx_model + 1] == "gpt-5.2-codex"
+        idx_separator = cmd.index("--")
+        assert idx_model < idx_separator
+        assert cmd[idx_separator + 1] == "thread-abc"
+        assert cmd[-1] == "hello"
         assert "--color" not in cmd
         assert "--skip-git-repo-check" not in cmd
+
+    @pytest.mark.parametrize("model", [None, ""])
+    def test_resume_session_no_model_omits_flag(
+        self, monkeypatch: pytest.MonkeyPatch, model: str | None
+    ) -> None:
+        cli = _make_cli(monkeypatch, model=model)
+        cmd = cli._build_command("hello", resume_session="thread-abc")
+        assert "--model" not in cmd
+        assert cmd[-3:] == ["--", "thread-abc", "hello"]
 
     def test_resume_session_json_output_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cli = _make_cli(monkeypatch)


### PR DESCRIPTION
## Problem

Switching `/model` to a different Codex model has no effect on chats that
already have a Codex session: `codex exec resume` runs the model stored in
the session at creation time, and the resume command builder passes no
model flag. Unlike Claude — which re-sends `--model` on every turn — the
new selection is silently ignored on resumed turns.

It can also hard-fail: if the new selection sets a reasoning effort the
stored model doesn't support (e.g. an effort level introduced with a newer
model generation), the resumed turn dies with
`400 invalid_request_error: Invalid value ... reasoning.effort` and the
turn is lost.

Reproduce: create a Codex session on an older model, `/model` to a newer
model plus a newer-only effort level, then send a message in the same chat
→ the CLI exits 1.

## Fix

Mirror the fresh-session `--model` flag in `_build_resume_command`,
emitted under the same condition (only when a model is configured).
Verified against the Codex CLI: `codex exec resume --model <new>`
overrides the stored session model, and subsequent turn contexts record
the new model.

## Tests

- resume command asserts `--model <value>` placed before the `--`
  separator (the structure test previously asserted the flag's absence)
- `None`/empty configured model omits the flag
- existing resume ordering/structure assertions unchanged

2 files changed, +20/−3. Rollback = revert (no config/schema impact).

> **Note for merging alongside #164** (per-session reasoning effort):
> #164 adds an effort re-assert in the same pre-`--` region of
> `_build_resume_command`. The blocks compose in either merge order:
> sandbox flags → `--model` → effort `-c` → `-- <session-id>`.
