### PR TITLE
fix: persist /model selection in topics whose session is missing or stale

### DIFF
--- a/ductor_bot/orchestrator/selectors/model_selector.py
+++ b/ductor_bot/orchestrator/selectors/model_selector.py
@@ -290,19 +290,26 @@ async def switch_model(  # noqa: C901
     if validation_error is not None:
         return validation_error
 
-    resume_session_id, resume_message_count = _resume_state_for_provider(
-        active_session,
-        new_provider,
-    )
-
+    resume_source = active_session
     if not same_model:
         await orch._process_registry.kill_all(key.chat_id)
-        if active_session is not None:
+        if is_topic:
+            resolved, created = await orch._sessions.resolve_session_target(
+                key,
+                provider=new_provider,
+                model=model_id,
+            )
+            resume_source = None if created else resolved
+        elif active_session is not None:
             await orch._sessions.sync_session_target(
                 active_session,
                 provider=new_provider,
                 model=model_id,
             )
+    resume_session_id, resume_message_count = _resume_state_for_provider(
+        resume_source,
+        new_provider,
+    )
 
     if not is_topic:
         # Global config: update only from main chat / DM (not from topics).

--- a/ductor_bot/session/manager.py
+++ b/ductor_bot/session/manager.py
@@ -346,6 +346,53 @@ class SessionManager:
         sessions = await self._load()
         return sessions.get(key.storage_key)
 
+    async def resolve_session_target(
+        self, key: SessionKey, *, provider: str, model: str
+    ) -> tuple[SessionData, bool]:
+        """Atomically record the model target for *key*'s next-message session.
+
+        Fresh existing sessions are retargeted in place; stale or missing
+        sessions are replaced by a fresh shell carrying the target. Runs
+        under ``self._lock``. Returns ``(session, created)``.
+        """
+        async with self._lock:
+            sessions = await self._load()
+            skey = key.storage_key
+            existing = sessions.get(skey)
+
+            if existing and self._is_fresh_for_target(existing, provider):
+                changed = False
+                if existing.provider != provider:
+                    logger.info("Provider switch %s -> %s", existing.provider, provider)
+                    existing.provider = provider
+                    changed = True
+                if existing.model != model:
+                    existing.model = model
+                    changed = True
+                if self._apply_topic_name(existing):
+                    changed = True
+                if changed:
+                    await self._save(sessions)
+                return existing, False
+
+            topic_name: str | None = None
+            if key.topic_id is not None and self._topic_name_resolver is not None:
+                topic_name = self._topic_name_resolver(key.chat_id, key.topic_id)
+
+            new = SessionData(
+                chat_id=key.chat_id,
+                transport=key.transport,
+                topic_id=key.topic_id,
+                topic_name=topic_name,
+                provider=provider,
+                model=model,
+                provider_sessions={},
+            )
+            sessions[skey] = new
+            await self._save(sessions)
+            logger.info("Session created provider=%s model=%s", provider, model)
+            return new, True
+
     async def list_active_for_chat(self, chat_id: int) -> list[SessionData]:
         """Return all fresh sessions belonging to *chat_id*."""
         sessions = await self._load()
@@ -569,6 +616,22 @@ class SessionManager:
                     entry = data[raw_key]
                     break
         return isinstance(entry, dict) and "model" not in entry
+
+    def _is_fresh_for_target(self, session: SessionData, provider: str) -> bool:
+        """Check freshness using the next message's provider bucket."""
+        provider_data = session.provider_sessions.get(provider)
+        message_count = provider_data.message_count if provider_data is not None else 0
+        max_messages = self._config.max_session_messages
+        if max_messages is not None and message_count >= max_messages:
+            logger.debug("Session fresh check: fresh=no reason=max_messages")
+            return False
+
+        current_provider = session.provider
+        session.provider = provider
+        try:
+            return self._is_fresh(session)
+        finally:
+            session.provider = current_provider
 
     def _is_fresh(self, session: SessionData) -> bool:
         now = datetime.now(UTC)

--- a/tests/orchestrator/test_model_selector.py
+++ b/tests/orchestrator/test_model_selector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from contextlib import contextmanager
 from datetime import UTC, datetime
@@ -13,8 +14,10 @@ import pytest
 from ductor_bot.cli.auth import AuthResult, AuthStatus
 from ductor_bot.cli.codex_cache import CodexModelCache
 from ductor_bot.cli.codex_discovery import CodexModelInfo
+from ductor_bot.cli.types import AgentResponse
 from ductor_bot.config import reset_gemini_models, set_gemini_models
 from ductor_bot.orchestrator.core import Orchestrator
+from ductor_bot.orchestrator.flows import normal
 from ductor_bot.orchestrator.selectors.model_selector import (
     handle_model_callback,
     is_model_selector_callback,
@@ -22,6 +25,7 @@ from ductor_bot.orchestrator.selectors.model_selector import (
     switch_model,
 )
 from ductor_bot.session.key import SessionKey
+from ductor_bot.session.manager import ProviderSessionData
 
 _AUTHED_CLAUDE = AuthResult("claude", AuthStatus.AUTHENTICATED)
 _AUTHED_CODEX = AuthResult("codex", AuthStatus.AUTHENTICATED)
@@ -316,6 +320,78 @@ async def test_callback_reasoning_switches(orch: Orchestrator) -> None:
     assert resp.buttons is None
 
 
+async def test_callback_reasoning_topic_without_session_targets_next_message(
+    orch: Orchestrator,
+) -> None:
+    key = SessionKey(chat_id=-100, topic_id=42)
+    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    mock_execute = AsyncMock(
+        return_value=AgentResponse(result="ok", session_id="codex-topic-session")
+    )
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+
+    await handle_model_callback(orch, key, "ms:r:high:gpt-5.2-codex")
+    await normal(orch, key, "hello", model_override=None)
+
+    request = mock_execute.call_args.args[0]
+    assert request.model_override == "gpt-5.2-codex"
+    assert request.provider_override == "codex"
+
+
+async def test_callback_reasoning_stale_topic_targets_next_message(orch: Orchestrator) -> None:
+    key = SessionKey(chat_id=-100, topic_id=43)
+    orch._config.max_session_messages = 1
+    stale, _ = await orch._sessions.resolve_session(key, provider="claude", model="opus")
+    stale.session_id = "stale-claude-session"
+    await orch._sessions.update_session(stale)
+
+    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    mock_execute = AsyncMock(
+        return_value=AgentResponse(result="ok", session_id="fresh-codex-session")
+    )
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+
+    await handle_model_callback(orch, key, "ms:r:high:gpt-5.2-codex")
+    await normal(orch, key, "hello", model_override=None)
+
+    request = mock_execute.call_args.args[0]
+    assert request.model_override == "gpt-5.2-codex"
+    assert request.provider_override == "codex"
+
+
+async def test_callback_reasoning_stale_target_bucket_targets_next_message(
+    orch: Orchestrator,
+) -> None:
+    key = SessionKey(chat_id=-100, topic_id=47)
+    orch._config.max_session_messages = 3
+    existing, _ = await orch._sessions.resolve_session(key, provider="claude", model="opus")
+    existing.provider_sessions["claude"] = ProviderSessionData(
+        session_id="fresh-claude-session",
+        message_count=1,
+    )
+    existing.provider_sessions["codex"] = ProviderSessionData(
+        session_id="stale-codex-session",
+        message_count=4,
+    )
+    await orch._sessions.preserve_session_identity(existing)
+
+    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    mock_execute = AsyncMock(
+        return_value=AgentResponse(result="ok", session_id="fresh-codex-session")
+    )
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+
+    await handle_model_callback(orch, key, "ms:r:high:gpt-5.2-codex")
+    replacement = await orch._sessions.get_active(key)
+    assert replacement is not None
+    assert replacement.provider_sessions == {}
+    await normal(orch, key, "hello", model_override=None)
+
+    request = mock_execute.call_args.args[0]
+    assert request.model_override == "gpt-5.2-codex"
+    assert request.provider_override == "codex"
+
+
 # -- handle_model_callback: back navigation --
 
 
@@ -350,6 +426,102 @@ async def test_switch_model_basic(orch: Orchestrator) -> None:
     assert orch._config.model == "sonnet"
     mock_kill.assert_called_once_with(1)
     mock_reset.assert_not_called()
+
+
+async def test_switch_model_topic_does_not_change_global_defaults(orch: Orchestrator) -> None:
+    key = SessionKey(chat_id=-100, topic_id=44)
+    config_before = (
+        orch._config.provider,
+        orch._config.model,
+        orch._config.reasoning_effort,
+    )
+    config_file_before = orch.paths.config_path.read_bytes()
+    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+
+    await handle_model_callback(orch, key, "ms:r:high:gpt-5.2-codex")
+
+    assert (
+        orch._config.provider,
+        orch._config.model,
+        orch._config.reasoning_effort,
+    ) == config_before
+    assert orch.paths.config_path.read_bytes() == config_file_before
+    orch._cli_service.update_default_model.assert_not_called()
+    orch._cli_service.update_reasoning_effort.assert_not_called()
+
+
+async def test_switch_model_dm_without_session_keeps_global_persistence(
+    orch: Orchestrator,
+) -> None:
+    key = SessionKey(chat_id=1)
+    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+    resolve_target = AsyncMock(wraps=orch._sessions.resolve_session_target)
+
+    with patch.object(orch._sessions, "resolve_session_target", new=resolve_target):
+        await switch_model(orch, key, "sonnet")
+
+    resolve_target.assert_not_awaited()
+    assert await orch._sessions.get_active(key) is None
+    assert orch._config.model == "sonnet"
+    saved = json.loads(orch.paths.config_path.read_text(encoding="utf-8"))
+    assert saved["model"] == "sonnet"
+    assert saved["provider"] == "claude"
+    orch._cli_service.update_default_model.assert_called_once_with("sonnet")
+
+
+async def test_switch_model_fresh_topic_preserves_all_provider_sessions(
+    orch: Orchestrator,
+) -> None:
+    key = SessionKey(chat_id=-100, topic_id=45)
+    session, _ = await orch._sessions.resolve_session(key, provider="claude", model="opus")
+    session.provider_sessions["claude"] = ProviderSessionData(
+        session_id="claude-session",
+        message_count=4,
+        total_cost_usd=0.4,
+        total_tokens=400,
+    )
+    session.provider_sessions["codex"] = ProviderSessionData(
+        session_id="codex-session",
+        message_count=2,
+        total_cost_usd=0.2,
+        total_tokens=200,
+    )
+    await orch._sessions.preserve_session_identity(session)
+    persisted = await orch._sessions.get_active(key)
+    assert persisted is not None
+    provider_sessions_before = copy.deepcopy(persisted.provider_sessions)
+    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+
+    await switch_model(orch, key, "gpt-5.2-codex")
+
+    retargeted = await orch._sessions.get_active(key)
+    assert retargeted is not None
+    assert retargeted.provider == "codex"
+    assert retargeted.model == "gpt-5.2-codex"
+    assert retargeted.provider_sessions == provider_sessions_before
+    assert retargeted.session_id == "codex-session"
+
+
+async def test_switch_model_stale_topic_does_not_show_resume_hint(
+    orch: Orchestrator,
+) -> None:
+    key = SessionKey(chat_id=-100, topic_id=46)
+    orch._config.max_session_messages = 1
+    stale, _ = await orch._sessions.resolve_session(key, provider="claude", model="opus")
+    stale.session_id = "stale-claude-session"
+    stale.provider_sessions["codex"] = ProviderSessionData(
+        session_id="stale-codex-session",
+        message_count=7,
+    )
+    await orch._sessions.update_session(stale)
+    object.__setattr__(orch._process_registry, "kill_all", AsyncMock(return_value=0))
+
+    result = await switch_model(orch, key, "gpt-5.2-codex")
+
+    assert "Resuming" not in result
+    replaced = await orch._sessions.get_active(key)
+    assert replaced is not None
+    assert replaced.provider_sessions == {}
 
 
 async def test_switch_model_opus_1m_persists(orch: Orchestrator) -> None:

--- a/tests/session/test_manager.py
+++ b/tests/session/test_manager.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import copy
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +12,7 @@ import time_machine
 
 from ductor_bot.config import AgentConfig
 from ductor_bot.session.key import SessionKey
-from ductor_bot.session.manager import SessionData, SessionManager
+from ductor_bot.session.manager import ProviderSessionData, SessionData, SessionManager
 
 
 def _make_manager(tmp_path: Path, **overrides: Any) -> SessionManager:
@@ -52,6 +54,193 @@ async def test_resolve_treats_empty_session_id_as_new(tmp_path: Path) -> None:
     s2, new2 = await mgr.resolve_session(key=SessionKey(chat_id=1))
     assert new2 is True
     assert s2.session_id == ""
+
+
+async def test_resolve_session_target_creates_missing_session(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    mgr.set_topic_name_resolver(lambda _chat, _topic: "new topic")
+    key = SessionKey(chat_id=-100, topic_id=10)
+
+    session, created = await mgr.resolve_session_target(
+        key,
+        provider="codex",
+        model="gpt-5.2-codex",
+    )
+
+    assert created is True
+    assert session.provider == "codex"
+    assert session.model == "gpt-5.2-codex"
+    assert session.topic_name == "new topic"
+    assert session.provider_sessions == {}
+
+
+async def test_resolve_session_target_retargets_fresh_session(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path)
+    key = SessionKey(chat_id=-100, topic_id=11)
+    existing, _ = await mgr.resolve_session(key, provider="claude", model="opus")
+    existing.session_id = "claude-session"
+    await mgr.update_session(existing)
+    mgr.set_topic_name_resolver(lambda _chat, _topic: "existing topic")
+
+    session, created = await mgr.resolve_session_target(
+        key,
+        provider="codex",
+        model="gpt-5.2-codex",
+    )
+
+    assert created is False
+    assert session.provider == "codex"
+    assert session.model == "gpt-5.2-codex"
+    assert session.topic_name == "existing topic"
+    assert session.provider_sessions["claude"].session_id == "claude-session"
+
+
+async def test_resolve_session_target_replaces_stale_session(tmp_path: Path) -> None:
+    mgr = _make_manager(tmp_path, max_session_messages=1)
+    key = SessionKey(chat_id=-100, topic_id=12)
+    stale, _ = await mgr.resolve_session(key, provider="claude", model="opus")
+    stale.session_id = "stale-session"
+    stale.provider_sessions["codex"] = ProviderSessionData(message_count=1)
+    await mgr.update_session(stale)
+
+    session, created = await mgr.resolve_session_target(
+        key,
+        provider="codex",
+        model="gpt-5.2-codex",
+    )
+
+    assert created is True
+    assert session.provider == "codex"
+    assert session.model == "gpt-5.2-codex"
+    assert session.provider_sessions == {}
+
+
+async def test_resolve_session_target_replaces_when_target_bucket_is_stale(
+    tmp_path: Path,
+) -> None:
+    mgr = _make_manager(tmp_path, max_session_messages=3)
+    key = SessionKey(chat_id=-100, topic_id=15)
+    existing, _ = await mgr.resolve_session(key, provider="claude", model="opus")
+    existing.provider_sessions["claude"] = ProviderSessionData(
+        session_id="fresh-claude-session",
+        message_count=1,
+    )
+    existing.provider_sessions["codex"] = ProviderSessionData(
+        session_id="stale-codex-session",
+        message_count=4,
+    )
+    await mgr.preserve_session_identity(existing)
+
+    session, created = await mgr.resolve_session_target(
+        key,
+        provider="codex",
+        model="gpt-5.2-codex",
+    )
+
+    assert created is True
+    assert session.provider == "codex"
+    assert session.model == "gpt-5.2-codex"
+    assert session.provider_sessions == {}
+
+
+async def test_resolve_session_target_retargets_when_target_bucket_is_fresh(
+    tmp_path: Path,
+) -> None:
+    mgr = _make_manager(tmp_path, max_session_messages=3)
+    key = SessionKey(chat_id=-100, topic_id=16)
+    existing, _ = await mgr.resolve_session(key, provider="claude", model="opus")
+    existing.provider_sessions["claude"] = ProviderSessionData(
+        session_id="stale-claude-session",
+        message_count=4,
+    )
+    existing.provider_sessions["codex"] = ProviderSessionData(
+        session_id="fresh-codex-session",
+        message_count=1,
+    )
+    await mgr.preserve_session_identity(existing)
+    history_before = copy.deepcopy(existing.provider_sessions)
+
+    session, created = await mgr.resolve_session_target(
+        key,
+        provider="codex",
+        model="gpt-5.2-codex",
+    )
+
+    assert created is False
+    assert session.provider == "codex"
+    assert session.model == "gpt-5.2-codex"
+    assert session.provider_sessions == history_before
+
+
+@pytest.mark.parametrize(
+    "target_first", [True, False], ids=["target-then-update", "update-then-target"]
+)
+async def test_resolve_session_target_and_other_topic_update_preserve_both_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    target_first: bool,
+) -> None:
+    mgr = _make_manager(tmp_path)
+    target_key = SessionKey(chat_id=-100, topic_id=13)
+    update_key = SessionKey(chat_id=-100, topic_id=14)
+    await mgr.resolve_session(target_key, provider="claude", model="opus")
+    update_record, _ = await mgr.resolve_session(update_key, provider="claude", model="opus")
+    update_record.session_id = "other-topic-session"
+    await mgr.update_session(update_record)
+
+    first_loaded = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+    original_load = mgr._load
+    first_task: asyncio.Task[None] | None = None
+    paused = False
+
+    async def controlled_load() -> dict[str, SessionData]:
+        nonlocal paused
+        sessions = await original_load()
+        if asyncio.current_task() is first_task and not paused:
+            paused = True
+            first_loaded.set()
+            await release_first.wait()
+        return sessions
+
+    async def retarget() -> None:
+        await mgr.resolve_session_target(
+            target_key,
+            provider="codex",
+            model="gpt-5.2-codex",
+        )
+
+    async def update_other() -> None:
+        await mgr.update_session(update_record, cost_usd=0.25, tokens=25)
+
+    monkeypatch.setattr(mgr, "_load", controlled_load)
+    first_operation, second_operation = (
+        (retarget, update_other) if target_first else (update_other, retarget)
+    )
+    first_task = asyncio.create_task(first_operation())
+    await first_loaded.wait()
+
+    async def run_second() -> None:
+        second_started.set()
+        await second_operation()
+
+    second_task = asyncio.create_task(run_second())
+    await second_started.wait()
+    release_first.set()
+    await first_task
+    await second_task
+
+    final_target = await mgr.get_active(target_key)
+    final_update = await mgr.get_active(update_key)
+    assert final_target is not None
+    assert final_update is not None
+    assert final_target.provider == "codex"
+    assert final_target.model == "gpt-5.2-codex"
+    assert final_update.session_id == "other-topic-session"
+    assert final_update.message_count == 2
+    assert final_update.total_cost_usd == pytest.approx(0.25)
+    assert final_update.total_tokens == 25
 
 
 @time_machine.travel("2025-06-15 12:00:00", tick=False)


### PR DESCRIPTION
## Problem

In a topic that has no usable session yet, completing the `/model` wizard
reports success but the selection is persisted nowhere. Sessions are only
created by the message flow; the wizard's switch path records the target
only on an already-existing session object; and topic switches never touch
the global config by design. So in a brand-new topic (no message sent yet)
— or one whose session has gone stale via idle timeout, daily reset, or
the target provider's bucket reaching `max_session_messages` — the next
message resolves a fresh session from the global defaults and the user's
choice is silently discarded. Re-running `/model` doesn't help.

When the stored session was stale, the switch summary could also
advertise a "Resuming …" state belonging to a session the next message
was about to discard.

## Fix

- New `SessionManager.resolve_session_target(key, *, provider, model)
  -> (session, created)`: atomically (under the manager lock) record the
  target on the session the next message will actually use — fresh
  sessions are retargeted in place, stale or missing ones are replaced by
  a fresh shell carrying the target. Freshness is judged against the
  **target** provider's bucket count (plus the usual idle/daily checks),
  matching what the next message-flow resolve will decide.
- `switch_model` uses it for topic switches and recomputes the resume
  summary from the resolved session, so newly created or replaced shells
  no longer advertise stale resume state. DM/main-chat behavior is
  unchanged (global-config path).

Deliberately out of scope (pre-existing behavior, separate issue
candidates): the remaining unlocked full-file session writers
(`resolve_session`, `reset_*`) and `update_session`'s caller-identity
write-back.

## Tests

- E2E through the real message path: wizard `ms:r` callback → a normal
  turn with no override asserts the CLI `AgentRequest` carries the
  selected provider/model (fresh, empty-topic, and target-stale cases).
- Manager unit matrix: fresh retarget / stale shell / missing shell;
  current-fresh–target-stale and the reverse; deterministic two-order
  concurrency contract for the new method.
- Global config/file/CLI default unchanged on topic switches; DM
  no-session path creates nothing; provider bucket deep-snapshot
  preservation; stale-resume suppression; existing switch tests intact.

4 files changed, +438/−7. Rollback = revert (no config/schema impact).

> **Merge notes**: #166 replaces the adjacent kill line in
> `switch_model` (this PR's kill mocks adapt on merge). #164
> (per-session effort) overlaps the same sync region — when it lands,
> the creation path should pass `reasoning_effort` (preserving a fresh
> session's effort when `None`). #156 moves bucket keys to
> `session_bucket_key(provider, interactive=…)` — the target-count
> lookup adapts accordingly.
