### PR TITLE
Skip model observers for missing provider CLIs

### DIFF
--- a/ductor_bot/orchestrator/observers.py
+++ b/ductor_bot/orchestrator/observers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import shutil
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
@@ -68,35 +69,43 @@ class ObserverManager:
         on_antigravity_refresh: Callable[[tuple[str, ...]], None],
     ) -> CodexModelCache:
         """Start Gemini, Antigravity, and Codex cache observers, return Codex cache."""
-        # Gemini
-        gemini_cache_path = self._paths.config_path.parent / "gemini_models.json"
-        gemini_observer = GeminiCacheObserver(gemini_cache_path, on_refresh=on_gemini_refresh)
-        await gemini_observer.start()
-        self.gemini_cache_obs = gemini_observer
+        # Optional provider observers are useful only when their CLIs are installed.
+        if shutil.which("gemini"):
+            gemini_cache_path = self._paths.config_path.parent / "gemini_models.json"
+            gemini_observer = GeminiCacheObserver(gemini_cache_path, on_refresh=on_gemini_refresh)
+            await gemini_observer.start()
+            self.gemini_cache_obs = gemini_observer
 
-        if not get_gemini_models():
-            logger.warning("Gemini cache is empty after startup (Gemini may not be installed)")
+            if not get_gemini_models():
+                logger.warning("Gemini cache is empty after startup")
+        else:
+            logger.debug("Gemini CLI not found; cache observer disabled")
 
-        # Antigravity
-        antigravity_cache_path = self._paths.config_path.parent / "antigravity_models.json"
-        antigravity_observer = AntigravityCacheObserver(
-            antigravity_cache_path, on_refresh=on_antigravity_refresh
-        )
-        await antigravity_observer.start()
-        self.antigravity_cache_obs = antigravity_observer
+        if shutil.which("agy"):
+            antigravity_cache_path = self._paths.config_path.parent / "antigravity_models.json"
+            antigravity_observer = AntigravityCacheObserver(
+                antigravity_cache_path, on_refresh=on_antigravity_refresh
+            )
+            await antigravity_observer.start()
+            self.antigravity_cache_obs = antigravity_observer
 
-        if not get_antigravity_models():
-            logger.warning("Antigravity cache is empty after startup (agy may not be installed)")
+            if not get_antigravity_models():
+                logger.warning("Antigravity cache is empty after startup")
+        else:
+            logger.debug("Antigravity CLI not found; cache observer disabled")
 
-        # Codex
-        codex_cache_path = self._paths.config_path.parent / "codex_models.json"
-        codex_observer = CodexCacheObserver(codex_cache_path)
-        await codex_observer.start()
-        self.codex_cache_obs = codex_observer
-        codex_cache = codex_observer.get_cache()
+        codex_cache: CodexModelCache | None = None
+        if shutil.which("codex"):
+            codex_cache_path = self._paths.config_path.parent / "codex_models.json"
+            codex_observer = CodexCacheObserver(codex_cache_path)
+            await codex_observer.start()
+            self.codex_cache_obs = codex_observer
+            codex_cache = codex_observer.get_cache()
 
-        if not codex_cache or not codex_cache.models:
-            logger.warning("Codex cache is empty after startup (Codex may not be authenticated)")
+            if not codex_cache or not codex_cache.models:
+                logger.warning("Codex cache is empty after startup")
+        else:
+            logger.debug("Codex CLI not found; cache observer disabled")
 
         return codex_cache or CodexModelCache("", [])
 

--- a/tests/orchestrator/test_optional_model_observers.py
+++ b/tests/orchestrator/test_optional_model_observers.py
@@ -1,0 +1,70 @@
+"""Tests for optional provider model-cache observers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ductor_bot.cli.codex_cache import CodexModelCache
+from ductor_bot.orchestrator.observers import ObserverManager
+
+
+def _manager() -> ObserverManager:
+    return ObserverManager(MagicMock(), MagicMock())
+
+
+async def test_skips_observers_for_missing_optional_clis() -> None:
+    manager = _manager()
+
+    with (
+        patch("ductor_bot.orchestrator.observers.shutil.which", return_value=None),
+        patch("ductor_bot.orchestrator.observers.GeminiCacheObserver") as gemini_cls,
+        patch("ductor_bot.orchestrator.observers.AntigravityCacheObserver") as agy_cls,
+        patch("ductor_bot.orchestrator.observers.CodexCacheObserver") as codex_cls,
+    ):
+        cache = await manager.init_model_caches(
+            on_gemini_refresh=MagicMock(),
+            on_antigravity_refresh=MagicMock(),
+        )
+
+    gemini_cls.assert_not_called()
+    agy_cls.assert_not_called()
+    codex_cls.assert_not_called()
+    assert manager.gemini_cache_obs is None
+    assert manager.antigravity_cache_obs is None
+    assert manager.codex_cache_obs is None
+    assert cache.models == []
+
+
+async def test_starts_observers_for_installed_optional_clis() -> None:
+    manager = _manager()
+    gemini_observer = MagicMock()
+    gemini_observer.start = AsyncMock()
+    agy_observer = MagicMock()
+    agy_observer.start = AsyncMock()
+    codex_observer = MagicMock()
+    codex_observer.start = AsyncMock()
+    codex_observer.get_cache.return_value = CodexModelCache("", [])
+
+    with (
+        patch("ductor_bot.orchestrator.observers.shutil.which", return_value="/usr/bin/cli"),
+        patch(
+            "ductor_bot.orchestrator.observers.GeminiCacheObserver",
+            return_value=gemini_observer,
+        ),
+        patch(
+            "ductor_bot.orchestrator.observers.AntigravityCacheObserver",
+            return_value=agy_observer,
+        ),
+        patch("ductor_bot.orchestrator.observers.CodexCacheObserver", return_value=codex_observer),
+    ):
+        await manager.init_model_caches(
+            on_gemini_refresh=MagicMock(),
+            on_antigravity_refresh=MagicMock(),
+        )
+
+    gemini_observer.start.assert_awaited_once()
+    agy_observer.start.assert_awaited_once()
+    assert manager.gemini_cache_obs is gemini_observer
+    assert manager.antigravity_cache_obs is agy_observer
+    assert manager.codex_cache_obs is codex_observer
+    codex_observer.start.assert_awaited_once()


### PR DESCRIPTION
## What changed

- Start the Gemini model-cache observer only when the `gemini` CLI is installed.
- Start the Antigravity model-cache observer only when the `agy` CLI is installed.
- Start the Codex model-cache observer only when the `codex` CLI is installed.
- Return the existing empty Codex cache fallback when Codex is unavailable.
- Add tests for hosts with and without the provider CLIs.

Claude does not have a model-cache observer in Ductor 0.19; its model list is static, so there is no equivalent Claude background component to guard.

## Why

I run Ductor 0.19 in my own fork with Codex and Claude enabled, but without Gemini or Antigravity installed. Before this guard, Ductor still started both unavailable optional observers, performed periodic discovery work, and logged empty-cache warnings for providers that could not be used on that host. The same issue applies to a Claude-only installation without the `codex` executable.

For example, a Codex + Claude deployment previously emitted warnings such as `Gemini cache is empty after startup (Gemini may not be installed)` even though the missing provider was intentional. With this change, unavailable provider observers remain `None` and are not scheduled. Installing a corresponding CLI preserves the existing discovery behavior.

## Impact

Users with a provider CLI installed see no functional change. Users without it avoid unnecessary background discovery and misleading warnings.

## Validation

- `pytest -q` — 4005 passed
- `pytest tests/orchestrator/test_optional_model_observers.py tests/bus/test_observers_wire.py` — 17 passed
- `ruff check ductor_bot/orchestrator/observers.py tests/orchestrator/test_optional_model_observers.py`
- `mypy ductor_bot/orchestrator/observers.py`
