### PR TITLE
Retry preserved cron delivery failures

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -137,5 +137,10 @@
         "finished_retention_hours": 168,
         "finished_keep_last": 100
     },
+    "cron_delivery_retry": {
+        "enabled": false,
+        "interval_seconds": 300,
+        "max_attempts": 12
+    },
     "interagent_port": 8799
 }

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -265,6 +265,14 @@ class TasksConfig(BaseModel):
     finished_keep_last: int = 100
 
 
+class CronDeliveryRetryConfig(BaseModel):
+    """Retry delivery of preserved cron results without rerunning the agent."""
+
+    enabled: bool = False
+    interval_seconds: int = Field(default=300, ge=1)
+    max_attempts: int = Field(default=12, ge=1)
+
+
 class TimeoutConfig(BaseModel):
     """Per-execution-path timeout settings."""
 
@@ -463,6 +471,7 @@ class AgentConfig(BaseModel):
     image: ImageConfig = Field(default_factory=ImageConfig)
     timeouts: TimeoutConfig = Field(default_factory=TimeoutConfig)
     tasks: TasksConfig = Field(default_factory=TasksConfig)
+    cron_delivery_retry: CronDeliveryRetryConfig = Field(default_factory=CronDeliveryRetryConfig)
     scene: SceneConfig = Field(default_factory=SceneConfig)
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
     transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)

--- a/ductor_bot/cron/manager.py
+++ b/ductor_bot/cron/manager.py
@@ -38,6 +38,8 @@ class CronJob:
     last_delivery_status: str | None = None  # "ok" | "failed" | "skipped" | None
     last_delivery_error: str = ""
     last_result_text: str | None = None
+    delivery_retry_attempts: int = 0
+    next_delivery_retry_at: str | None = None
 
     # Per-task execution overrides
     provider: str | None = None
@@ -96,6 +98,10 @@ class CronJob:
             result["last_delivery_error"] = self.last_delivery_error
         if self.last_result_text is not None:
             result["last_result_text"] = self.last_result_text
+        if self.delivery_retry_attempts:
+            result["delivery_retry_attempts"] = self.delivery_retry_attempts
+        if self.next_delivery_retry_at is not None:
+            result["next_delivery_retry_at"] = self.next_delivery_retry_at
         return result
 
     @classmethod
@@ -115,6 +121,8 @@ class CronJob:
             last_delivery_status=data.get("last_delivery_status"),
             last_delivery_error=data.get("last_delivery_error", ""),
             last_result_text=data.get("last_result_text"),
+            delivery_retry_attempts=data.get("delivery_retry_attempts", 0),
+            next_delivery_retry_at=data.get("next_delivery_retry_at"),
             provider=data.get("provider"),
             model=data.get("model"),
             reasoning_effort=data.get("reasoning_effort"),
@@ -215,6 +223,33 @@ class CronManager:
         job.last_delivery_status = delivery_status
         job.last_delivery_error = delivery_error
         job.last_result_text = result_text
+        job.delivery_retry_attempts = 0
+        job.next_delivery_retry_at = None
+        self._save()
+
+    def update_delivery_retry(
+        self,
+        job_id: str,
+        *,
+        delivered: bool,
+        delivery_error: str = "",
+        next_attempt_at: str | None = None,
+    ) -> None:
+        """Persist one delivery retry without changing the job execution status."""
+        job = self.get_job(job_id)
+        if job is None:
+            return
+        if delivered:
+            job.last_delivery_status = "ok"
+            job.last_delivery_error = ""
+            job.last_result_text = None
+            job.delivery_retry_attempts = 0
+            job.next_delivery_retry_at = None
+        else:
+            job.last_delivery_status = "failed"
+            job.last_delivery_error = delivery_error
+            job.delivery_retry_attempts += 1
+            job.next_delivery_retry_at = next_attempt_at
         self._save()
 
     def reload(self) -> None:

--- a/ductor_bot/cron/observer.py
+++ b/ductor_bot/cron/observer.py
@@ -7,7 +7,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from cronsim import CronSim, CronSimError
@@ -68,6 +68,7 @@ class CronObserver(BaseTaskObserver):
         self._executing: set[str] = set()
         self._reschedule_lock = asyncio.Lock()
         self._requested_reschedule_task: asyncio.Task[None] | None = None
+        self._delivery_retry_task: asyncio.Task[None] | None = None
         self._running = False
         self._watcher = FileWatcher(
             paths.cron_jobs_path,
@@ -83,12 +84,19 @@ class CronObserver(BaseTaskObserver):
         self._running = True
         await self._schedule_all()
         await self._watcher.start()
+        if self._config.cron_delivery_retry.enabled:
+            self._delivery_retry_task = asyncio.create_task(self._delivery_retry_loop())
         logger.info("CronObserver started (%d jobs scheduled)", len(self._scheduled))
 
     async def stop(self) -> None:
         """Stop the observer: cancel all scheduled jobs and the watcher."""
         self._running = False
         await self._watcher.stop()
+        retry_task = self._delivery_retry_task
+        self._delivery_retry_task = None
+        if retry_task is not None:
+            retry_task.cancel()
+            await asyncio.gather(retry_task, return_exceptions=True)
         request_task = self._requested_reschedule_task
         self._requested_reschedule_task = None
         if request_task is not None:
@@ -327,6 +335,69 @@ class CronObserver(BaseTaskObserver):
         except Exception as exc:
             logger.exception("Error in cron result handler for job %s", job_id)
             return False, type(exc).__name__
+
+    async def _delivery_retry_loop(self) -> None:
+        """Periodically retry preserved delivery failures without rerunning the agent."""
+        interval = self._config.cron_delivery_retry.interval_seconds
+        while self._running:
+            await asyncio.sleep(interval)
+            try:
+                await self._retry_failed_deliveries()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Cron delivery retry sweep failed")
+
+    async def _retry_failed_deliveries(self) -> None:
+        """Retry every due failed delivery once, preserving failures for later sweeps."""
+        retry_config = self._config.cron_delivery_retry
+        now = datetime.now(UTC)
+        changed = False
+        for job in self._manager.list_jobs():
+            if job.last_delivery_status != "failed" or not job.last_result_text:
+                continue
+            if job.delivery_retry_attempts >= retry_config.max_attempts:
+                continue
+            if job.next_delivery_retry_at:
+                try:
+                    if datetime.fromisoformat(job.next_delivery_retry_at) > now:
+                        continue
+                except ValueError:
+                    logger.warning(
+                        "Invalid next_delivery_retry_at for cron job %s; retrying now",
+                        job.id,
+                    )
+
+            routing = (job.chat_id, job.topic_id, job.transport)
+            delivered, error = await self._deliver_result(
+                job.id,
+                job.title,
+                job.last_result_text,
+                job.last_run_status or "success",
+                routing,
+            )
+            next_attempt = None
+            if not delivered:
+                next_attempt = (now + timedelta(seconds=retry_config.interval_seconds)).isoformat()
+            self._manager.update_delivery_retry(
+                job.id,
+                delivered=delivered,
+                delivery_error=error,
+                next_attempt_at=next_attempt,
+            )
+            changed = True
+            if delivered:
+                logger.info("Cron delivery retry succeeded job=%s", job.title)
+            else:
+                logger.warning(
+                    "Cron delivery retry failed job=%s attempt=%d/%d error=%s",
+                    job.title,
+                    job.delivery_retry_attempts,
+                    retry_config.max_attempts,
+                    error,
+                )
+        if changed:
+            await self._watcher.update_mtime()
 
     async def _execute_job(
         self,

--- a/tests/cron/test_manager.py
+++ b/tests/cron/test_manager.py
@@ -287,3 +287,35 @@ class TestDeliveryTracking:
         assert job.last_delivery_status == "ok"
         assert job.last_delivery_error == ""
         assert job.last_result_text is None
+
+    def test_delivery_retry_state_roundtrip_and_recovery(self, tmp_path: Path) -> None:
+        mgr = _make_manager(tmp_path)
+        mgr.add_job(_make_job("daily"))
+        mgr.update_run_status(
+            "daily",
+            status="success",
+            delivery_status="failed",
+            delivery_error="offline",
+            result_text="preserved",
+        )
+        mgr.update_delivery_retry(
+            "daily",
+            delivered=False,
+            delivery_error="still offline",
+            next_attempt_at="2026-07-12T12:00:00+00:00",
+        )
+
+        reloaded = CronManager(jobs_path=tmp_path / "cron_jobs.json")
+        job = reloaded.get_job("daily")
+        assert job is not None
+        assert job.delivery_retry_attempts == 1
+        assert job.next_delivery_retry_at == "2026-07-12T12:00:00+00:00"
+        assert job.last_result_text == "preserved"
+
+        reloaded.update_delivery_retry("daily", delivered=True)
+        recovered = reloaded.get_job("daily")
+        assert recovered is not None
+        assert recovered.last_delivery_status == "ok"
+        assert recovered.last_result_text is None
+        assert recovered.delivery_retry_attempts == 0
+        assert recovered.next_delivery_retry_at is None

--- a/tests/cron/test_observer.py
+++ b/tests/cron/test_observer.py
@@ -549,6 +549,70 @@ class TestCronObserverExecution:
         assert job.last_delivery_error == "TelegramNetworkError"
         assert job.last_result_text == "All done."
 
+    async def test_retries_preserved_result_without_rerunning_agent(self, tmp_path: Path) -> None:
+        paths = _make_paths(tmp_path)
+        mgr = _make_manager(paths)
+        job = _make_job(
+            "daily",
+            title="My Daily Task",
+            last_run_status="success",
+            last_delivery_status="failed",
+            last_delivery_error="TelegramNetworkError",
+            last_result_text="Preserved result",
+            chat_id=42,
+            topic_id=7,
+        )
+        mgr.add_job(job)
+        observer = _make_observer(
+            paths,
+            mgr,
+            cron_delivery_retry={"enabled": True, "interval_seconds": 60},
+        )
+        callback = AsyncMock(return_value=(True, ""))
+        observer.set_result_handler(callback)
+
+        with patch("ductor_bot.cron.observer.execute_in_task_folder") as execute:
+            await observer._retry_failed_deliveries()
+
+        execute.assert_not_called()
+        callback.assert_awaited_once_with(
+            "My Daily Task", "Preserved result", "success", 42, 7, "tg"
+        )
+        assert job.last_delivery_status == "ok"
+        assert job.last_result_text is None
+        assert job.delivery_retry_attempts == 0
+
+    async def test_failed_retry_obeys_cooldown_and_attempt_limit(self, tmp_path: Path) -> None:
+        paths = _make_paths(tmp_path)
+        mgr = _make_manager(paths)
+        job = _make_job(
+            "daily",
+            last_run_status="success",
+            last_delivery_status="failed",
+            last_result_text="Preserved result",
+        )
+        mgr.add_job(job)
+        observer = _make_observer(
+            paths,
+            mgr,
+            cron_delivery_retry={
+                "enabled": True,
+                "interval_seconds": 60,
+                "max_attempts": 1,
+            },
+        )
+        callback = AsyncMock(return_value=(False, "still offline"))
+        observer.set_result_handler(callback)
+
+        await observer._retry_failed_deliveries()
+        await observer._retry_failed_deliveries()
+
+        callback.assert_awaited_once()
+        assert job.last_delivery_status == "failed"
+        assert job.last_result_text == "Preserved result"
+        assert job.delivery_retry_attempts == 1
+        assert job.next_delivery_retry_at is not None
+
     async def test_execute_job_timeout_kills_process(self, tmp_path: Path) -> None:
         """Subprocess that exceeds cli_timeout is killed and reported as timeout."""
         paths = _make_paths(tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,9 @@ def test_agent_config_defaults() -> None:
     assert cfg.gemini_api_key is None
     assert cfg.telegram_token == ""
     assert cfg.allowed_user_ids == []
+    assert cfg.cron_delivery_retry.enabled is False
+    assert cfg.cron_delivery_retry.interval_seconds == 300
+    assert cfg.cron_delivery_retry.max_attempts == 12
 
 
 def test_agent_config_normalizes_nullish_gemini_api_key() -> None:


### PR DESCRIPTION
## What changed

- Add an opt-in `cron_delivery_retry` configuration with retry interval and maximum attempts.
- Retry preserved `last_result_text` through the original chat/topic/transport route.
- Persist retry attempts and the next eligible retry time across restarts.
- Clear the preserved result only after delivery is acknowledged.
- Add manager, observer, lifecycle, configuration, cooldown, and attempt-limit tests.

## Why

Ductor 0.19 correctly separates cron execution from delivery and preserves the result when delivery fails. I use this behavior in my own Ductor fork, where transient Telegram failures are recovered automatically by an external watchdog. Moving the retry into `CronObserver` closes the loop without rerunning the provider CLI or spending tokens again.

For example, if a daily report completes while Telegram is temporarily unavailable, Ductor retains `last_result_text`. With the following opt-in configuration it retries that exact report five minutes later:

```json
"cron_delivery_retry": {
  "enabled": true,
  "interval_seconds": 300,
  "max_attempts": 12
}
```

The execution timestamp and status remain unchanged. Only delivery metadata is updated. The behavior is at-least-once delivery, so it remains disabled by default for users who prefer manual recovery over the small risk of a duplicate after an ambiguous transport acknowledgement.

## Validation

- `pytest -q` — full suite passed
- `pytest tests/cron/test_observer.py tests/cron/test_manager.py tests/test_config.py` — 105 passed
- `ruff check` on all changed Python files
- `mypy ductor_bot/config.py ductor_bot/cron/manager.py ductor_bot/cron/observer.py`
