### PR TITLE
Add opt-in cron preflight hooks

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -137,5 +137,10 @@
         "finished_retention_hours": 168,
         "finished_keep_last": 100
     },
+    "cron_preflight": {
+        "enabled": false,
+        "timeout_seconds": 15.0,
+        "skip_marker": "HEARTBEAT_OK"
+    },
     "interagent_port": 8799
 }

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -265,6 +265,14 @@ class TasksConfig(BaseModel):
     finished_keep_last: int = 100
 
 
+class CronPreflightConfig(BaseModel):
+    """Task-local deterministic gate that can skip a cron agent run."""
+
+    enabled: bool = False
+    timeout_seconds: float = Field(default=15.0, gt=0)
+    skip_marker: str = "HEARTBEAT_OK"
+
+
 class TimeoutConfig(BaseModel):
     """Per-execution-path timeout settings."""
 
@@ -463,6 +471,7 @@ class AgentConfig(BaseModel):
     image: ImageConfig = Field(default_factory=ImageConfig)
     timeouts: TimeoutConfig = Field(default_factory=TimeoutConfig)
     tasks: TasksConfig = Field(default_factory=TasksConfig)
+    cron_preflight: CronPreflightConfig = Field(default_factory=CronPreflightConfig)
     scene: SceneConfig = Field(default_factory=SceneConfig)
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
     transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)

--- a/ductor_bot/cron/observer.py
+++ b/ductor_bot/cron/observer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import sys
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -362,6 +364,15 @@ class CronObserver(BaseTaskObserver):
         logger.info("Cron job starting job=%s", job_title)
         t0 = time.monotonic()
 
+        if await self._run_preflight(job_title, task_folder):
+            self._manager.update_run_status(
+                job_id,
+                status="success:preflight",
+                delivery_status="skipped",
+            )
+            await self._watcher.update_mtime()
+            return
+
         overrides = TaskOverrides(
             provider=job.provider if job else None,
             model=job.model if job else None,
@@ -452,6 +463,54 @@ class CronObserver(BaseTaskObserver):
         # run-status write as a user-initiated change and trigger a full
         # reschedule of all other jobs.
         await self._watcher.update_mtime()
+
+    async def _run_preflight(self, job_title: str, task_folder: str) -> bool:
+        """Return true when an enabled task-local preflight safely skips the agent."""
+        preflight = self._config.cron_preflight
+        if not preflight.enabled:
+            return False
+        folder = self._paths.cron_tasks_dir / task_folder
+        script = folder / "scripts" / "preflight.py"
+        if not script.is_file():
+            return False
+
+        env = os.environ.copy()
+        env["DUCTOR_HOME"] = str(self._paths.ductor_home)
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(script),
+            cwd=str(folder),
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            async with asyncio.timeout(preflight.timeout_seconds):
+                stdout, stderr = await proc.communicate()
+        except TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            logger.warning("Cron preflight timed out job=%s", job_title)
+            return False
+
+        output = stdout.decode(errors="replace")
+        error = stderr.decode(errors="replace").strip()
+        last_line = next(
+            (line.strip() for line in reversed(output.splitlines()) if line.strip()),
+            "",
+        )
+        if proc.returncode == 0 and last_line == preflight.skip_marker:
+            logger.info("Cron preflight skipped agent job=%s task=%s", job_title, task_folder)
+            return True
+        if proc.returncode not in (0, 2) or error:
+            logger.warning(
+                "Cron preflight failed open job=%s returncode=%s stdout=%d stderr=%d",
+                job_title,
+                proc.returncode,
+                len(stdout),
+                len(stderr),
+            )
+        return False
 
     def _is_quiet_hours(self, job: CronJob | None, job_title: str) -> bool:
         """Return True when the job must be skipped due to quiet-hour settings."""

--- a/tests/cron/test_observer.py
+++ b/tests/cron/test_observer.py
@@ -259,6 +259,86 @@ class TestCronObserverScheduling:
 class TestCronObserverExecution:
     """Job execution tests."""
 
+    async def test_preflight_skip_avoids_agent_execution(self, tmp_path: Path) -> None:
+        paths = _make_paths(tmp_path)
+        mgr = _make_manager(paths)
+        mgr.add_job(_make_job("daily"))
+        scripts = paths.cron_tasks_dir / "daily" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "preflight.py").write_text("print('HEARTBEAT_OK')\n")
+        observer = _make_observer(paths, mgr, cron_preflight={"enabled": True})
+
+        preflight_proc = AsyncMock()
+        preflight_proc.returncode = 0
+        preflight_proc.communicate = AsyncMock(return_value=(b"checked\nHEARTBEAT_OK\n", b""))
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=preflight_proc),
+            patch("ductor_bot.cron.observer.execute_in_task_folder") as execute,
+        ):
+            await observer._execute_job("daily", "Do work", "daily")
+
+        execute.assert_not_awaited()
+        job = mgr.get_job("daily")
+        assert job is not None
+        assert job.last_run_status == "success:preflight"
+        assert job.last_delivery_status == "skipped"
+
+    async def test_preflight_is_opt_in(self, tmp_path: Path) -> None:
+        paths = _make_paths(tmp_path)
+        mgr = _make_manager(paths)
+        scripts = paths.cron_tasks_dir / "daily" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "preflight.py").write_text("print('HEARTBEAT_OK')\n")
+        observer = _make_observer(paths, mgr)
+
+        with patch("asyncio.create_subprocess_exec") as spawn:
+            assert await observer._run_preflight("Daily Report", "daily") is False
+
+        spawn.assert_not_called()
+
+    async def test_preflight_non_skip_result_fails_open(self, tmp_path: Path) -> None:
+        paths = _make_paths(tmp_path)
+        mgr = _make_manager(paths)
+        scripts = paths.cron_tasks_dir / "daily" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "preflight.py").write_text("raise SystemExit(2)\n")
+        observer = _make_observer(paths, mgr, cron_preflight={"enabled": True})
+        preflight_proc = AsyncMock()
+        preflight_proc.returncode = 2
+        preflight_proc.communicate = AsyncMock(return_value=(b"CONTINUE\n", b""))
+
+        with patch("asyncio.create_subprocess_exec", return_value=preflight_proc):
+            assert await observer._run_preflight("Daily Report", "daily") is False
+
+    async def test_preflight_timeout_kills_process_and_fails_open(self, tmp_path: Path) -> None:
+        paths = _make_paths(tmp_path)
+        mgr = _make_manager(paths)
+        scripts = paths.cron_tasks_dir / "daily" / "scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "preflight.py").write_text("pass\n")
+        observer = _make_observer(
+            paths,
+            mgr,
+            cron_preflight={"enabled": True, "timeout_seconds": 0.01},
+        )
+        preflight_proc = AsyncMock()
+        preflight_proc.returncode = -9
+        calls = 0
+
+        async def communicate() -> tuple[bytes, bytes]:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                await asyncio.sleep(999)
+            return b"", b""
+
+        preflight_proc.communicate = AsyncMock(side_effect=communicate)
+        preflight_proc.kill = MagicMock()
+        with patch("asyncio.create_subprocess_exec", return_value=preflight_proc):
+            assert await observer._run_preflight("Daily Report", "daily") is False
+
+        preflight_proc.kill.assert_called_once()
+
     async def test_handles_missing_task_folder(self, tmp_path: Path) -> None:
         paths = _make_paths(tmp_path)
         mgr = _make_manager(paths)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,9 @@ def test_agent_config_defaults() -> None:
     assert cfg.gemini_api_key is None
     assert cfg.telegram_token == ""
     assert cfg.allowed_user_ids == []
+    assert cfg.cron_preflight.enabled is False
+    assert cfg.cron_preflight.timeout_seconds == 15.0
+    assert cfg.cron_preflight.skip_marker == "HEARTBEAT_OK"
 
 
 def test_agent_config_normalizes_nullish_gemini_api_key() -> None:


### PR DESCRIPTION
## What changed

- Add an opt-in task-local cron preflight hook.
- Run `cron_tasks/<task>/scripts/preflight.py` before provider dispatch.
- Skip the provider run when the script exits successfully and its last non-empty line matches the configured marker.
- Fail open on timeout, script errors, or any non-matching result.
- Add configuration and tests for skip, disabled, continue, and timeout behavior.

## Why

I use this hook in my own Ductor fork for cron jobs where a cheap deterministic check can establish that no agent work is needed. Examples include checking whether today's health data has arrived, whether a source contains unseen items, or whether an idempotency marker already exists. Without a preflight, those no-op checks still launch a full Claude or Codex session and load the workspace prompt.

Example configuration:

```json
"cron_preflight": {
  "enabled": true,
  "timeout_seconds": 15.0,
  "skip_marker": "HEARTBEAT_OK"
}
```

Example task-local script:

```python
if nothing_new_to_process():
    print("HEARTBEAT_OK")
    raise SystemExit(0)
raise SystemExit(2)
```

The hook is disabled by default. It executes a fixed Python file without a shell, receives `DUCTOR_HOME`, and fails open so a broken preflight does not suppress the scheduled agent run.

## Impact

Existing cron jobs are unchanged. Opted-in deployments can avoid provider latency and token usage for deterministic no-op runs while retaining the normal cron execution path whenever the gate is uncertain.

## Validation

- `pytest -q` — full suite passed
- `pytest tests/cron/test_observer.py tests/test_config.py` — 82 passed
- `ruff check` on all changed Python files
- `mypy ductor_bot/config.py ductor_bot/cron/observer.py`
