### PR TITLE
feat(interagent): scope named sessions per sender chat/topic origin

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,5 +285,5 @@ Rule sync:
 - sub-agents are full stacks with own transport credentials/workspace/session files (each sub-agent can use a different transport)
 - all stacks share one event loop, inter-agent bus, and optional shared task hub
 - async inter-agent results are injected via bus envelopes
-- provider switch during `ia-<sender>` conversations auto-resets that named session and surfaces a provider-switch notice
+- provider switch during scoped `ia.<sender-slug>.t<topic>.x<hash>` conversations (legacy `ia-<sender>` without source context) auto-resets that named session and surfaces a provider-switch notice
 - async agent-tool pipelines can route replies explicitly via `reply_to` and suppress recipient noise via `silent`

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -28,7 +28,7 @@ Key properties:
 - `/status` shows active background tasks
 - `/session` background timeout uses `config.timeouts.background`
 
-Inter-agent sessions (`ia-<sender>`) use a deterministic registry path and are not created through `/session`.
+Inter-agent sessions use deterministic scoped names (`ia.<sender-slug>.t<topic>.x<hash>`, or legacy `ia-<sender>` without source context) and are not created through `/session`.
 
 Restart behavior:
 

--- a/docs/modules/multiagent.md
+++ b/docs/modules/multiagent.md
@@ -109,7 +109,7 @@ Shared across process:
 - sync: waits for target response (`send`)
 - async: returns task ID immediately (`send_async`)
 
-Recipient processing uses deterministic named session `ia-<sender>`.
+Recipient processing uses deterministic scoped session `ia.<sender-slug>.t<topic>.x<hash>`, or legacy `ia-<sender>` without source context.
 
 Async send metadata currently supports:
 
@@ -121,7 +121,7 @@ Async send metadata currently supports:
 
 Provider-switch safeguard:
 
-- if recipient provider changed since prior `ia-<sender>` session, old session is ended and recreated
+- if the recipient provider changed since the prior scoped or legacy inter-agent session, the old session is ended and recreated
 - provider-switch notice is surfaced back to sender side
 - when `reply_to` is set, async result handler lookup uses that agent name instead of `sender`
 - recipient notifications are skipped when `silent=true` or `reply_to` is set

--- a/docs/modules/orchestrator.md
+++ b/docs/modules/orchestrator.md
@@ -158,7 +158,7 @@ All injection paths respect `topic_id` when provided.
 
 Inter-agent ingress also lives in `injection.py`:
 
-- deterministic named sessions use `ia-<sender>`
+- deterministic named sessions use scoped `ia.<sender-slug>.t<topic>.x<hash>` names, or legacy `ia-<sender>` without source context
 - if the provider CLI rejects a stored inter-agent session after an update/cache clear, the orchestrator ends that named session, retries once with a fresh session, and surfaces a visible recovery notice back to the caller
 
 ## Observer and bus wiring

--- a/docs/modules/session.md
+++ b/docs/modules/session.md
@@ -99,7 +99,7 @@ Consumer-facing nuance:
 Purpose:
 
 - background `/session` registry
-- deterministic inter-agent sessions (`ia-<sender>`)
+- deterministic inter-agent sessions (`ia.<sender-slug>.t<topic>.x<hash>`, or legacy `ia-<sender>` without source context)
 
 Model fields:
 
@@ -117,7 +117,7 @@ Behavior:
 - user-created cap: `MAX_SESSIONS_PER_CHAT = 10`
 - persisted `running` entries are downgraded to `idle` on load
 - recovered-running sessions are tracked for startup recovery
-- inter-agent conversations use deterministic names `ia-<sender>`
+- inter-agent conversations use deterministic scoped names `ia.<sender-slug>.t<topic>.x<hash>`, or legacy `ia-<sender>` without source context
 - stale CLI session IDs on those named sessions are retried once with a fresh session after update/cache-clear style failures
 
 ## Persistence

--- a/ductor_bot/_home_defaults/workspace/tools/agent_tools/RULES.md
+++ b/ductor_bot/_home_defaults/workspace/tools/agent_tools/RULES.md
@@ -207,19 +207,21 @@ python3 tools/agent_tools/ask_agent.py --new "agent-name" "Brand new question"
 
 ### Named Sessions for inter-agent work
 
-Each inter-agent conversation creates a **Named Session** on the recipient
-agent called `ia-{sender}` (e.g. if `main` sends to `codex`, the session
-is `ia-main` on codex).
+With source chat/topic context, each inter-agent conversation creates a
+**Named Session** on the recipient agent with a sender/chat/topic-scoped name
+(for example, `ia.main.t12345.xab12cd34`). Follow-up messages from the same
+chat/topic reuse that session. Calls without source context use the legacy
+`ia-{sender}` name.
 
 These sessions:
 - Persist across messages and survive bot restarts
 - Run in the background, independent of the recipient's direct chat
-- Can be continued by the user directly in the recipient's chat
-  via `@ia-{sender} <message>` (e.g. `@ia-main tell me more`)
 - Are visible in the recipient's `/sessions` list
 
-When reporting async results to the user, mention the session name so they
-can follow up directly with the sub-agent if needed.
+Async responses report the exact session name. To continue it directly in the
+recipient's chat, use the reported name exactly: `@<session-name> <message>`.
+Synchronous responses do not include the session name; use async or find it in
+the recipient's `/sessions` list. Do not guess session names.
 
 ## Shared Knowledge
 

--- a/ductor_bot/_home_defaults/workspace/tools/agent_tools/ask_agent.py
+++ b/ductor_bot/_home_defaults/workspace/tools/agent_tools/ask_agent.py
@@ -49,6 +49,12 @@ def main() -> None:
     body: dict[str, object] = {"from": sender, "to": target, "message": message}
     if new_session:
         body["new_session"] = True
+    chat_id = os.environ.get("DUCTOR_CHAT_ID", "")
+    topic_id = os.environ.get("DUCTOR_TOPIC_ID", "")
+    if chat_id:
+        body["chat_id"] = int(chat_id)
+    if topic_id:
+        body["topic_id"] = int(topic_id)
     payload = json.dumps(body).encode()
 
     req = urllib.request.Request(

--- a/ductor_bot/infra/recovery.py
+++ b/ductor_bot/infra/recovery.py
@@ -35,7 +35,7 @@ class RecoveryPlanner:
     - Max 1 foreground recovery per chat_id
     - Skip ``is_recovery=True`` entries (prevents infinite loops)
     - Skip entries older than ``max_age_seconds``
-    - Skip inter-agent sessions (``ia-`` prefix)
+    - Skip inter-agent sessions (``ia-`` or ``ia.`` prefix)
     - Skip named sessions without a session_id (never started)
     - Skip named sessions that are not in "idle" status
     - Use ``--resume`` via session_id when available
@@ -84,7 +84,7 @@ class RecoveryPlanner:
         """Plan named session recovery from session registry."""
         actions: list[RecoveryAction] = []
         for ns in self._named_sessions:
-            if ns.name.startswith("ia-"):
+            if ns.name.startswith(("ia-", "ia.")):
                 continue
             if ns.status != "idle":
                 continue

--- a/ductor_bot/multiagent/bus.py
+++ b/ductor_bot/multiagent/bus.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ductor_bot.i18n import t
+from ductor_bot.session.named import interagent_session_name
 
 if TYPE_CHECKING:
     from ductor_bot.multiagent.stack import AgentStack
@@ -142,7 +143,7 @@ class InterAgentBus:
         """List all registered agent names."""
         return list(self._agents.keys())
 
-    async def send(
+    async def send(  # noqa: PLR0913
         self,
         sender: str,
         recipient: str,
@@ -150,6 +151,8 @@ class InterAgentBus:
         *,
         send_timeout: float = _DEFAULT_TIMEOUT,
         new_session: bool = False,
+        chat_id: int = 0,
+        topic_id: int | None = None,
     ) -> InterAgentResponse:
         """Send a message to another agent and wait for the response.
 
@@ -185,12 +188,22 @@ class InterAgentBus:
                     error=f"Agent '{recipient}' orchestrator not initialized",
                 )
 
-            result_text, _session_name, _notice = await asyncio.wait_for(
-                orch.handle_interagent_message(
+            if chat_id or topic_id is not None:
+                execution = orch.handle_interagent_message(
                     sender,
                     message,
                     new_session=new_session,
-                ),
+                    source_chat_id=chat_id,
+                    source_topic_id=topic_id,
+                )
+            else:
+                execution = orch.handle_interagent_message(
+                    sender,
+                    message,
+                    new_session=new_session,
+                )
+            result_text, _session_name, _notice = await asyncio.wait_for(
+                execution,
                 timeout=send_timeout,
             )
             logger.info(
@@ -314,12 +327,22 @@ class InterAgentBus:
             # Notify the recipient agent's Telegram chat about the incoming task
             await self._notify_recipient(task)
 
-            result_text, session_name, provider_notice = await asyncio.wait_for(
-                orch.handle_interagent_message(
+            if task.chat_id or task.topic_id is not None:
+                execution = orch.handle_interagent_message(
                     task.sender,
                     task.message,
                     new_session=task.new_session,
-                ),
+                    source_chat_id=task.chat_id,
+                    source_topic_id=task.topic_id,
+                )
+            else:
+                execution = orch.handle_interagent_message(
+                    task.sender,
+                    task.message,
+                    new_session=task.new_session,
+                )
+            result_text, session_name, provider_notice = await asyncio.wait_for(
+                execution,
                 timeout=_ASYNC_TIMEOUT,
             )
             logger.info(
@@ -420,7 +443,7 @@ class InterAgentBus:
                 preview = task.summary
             else:
                 preview = task.message if len(task.message) <= 200 else task.message[:200] + "…"
-            session_name = f"ia-{task.sender}"
+            session_name = interagent_session_name(task.sender, task.chat_id, task.topic_id)
             text = t(
                 "multiagent.async_task_received",
                 sender=task.sender,

--- a/ductor_bot/multiagent/internal_api.py
+++ b/ductor_bot/multiagent/internal_api.py
@@ -141,6 +141,8 @@ class InternalAgentAPI:
         recipient = data.get("to", "")
         message = data.get("message", "")
         new_session = bool(data.get("new_session", False))
+        chat_id = int(data["chat_id"]) if data.get("chat_id") else 0
+        topic_id = int(data["topic_id"]) if data.get("topic_id") else None
 
         if not recipient or not message:
             return web.json_response(
@@ -154,6 +156,8 @@ class InternalAgentAPI:
             recipient=recipient,
             message=message,
             new_session=new_session,
+            chat_id=chat_id,
+            topic_id=topic_id,
         )
         return web.json_response(asdict(result))
 

--- a/ductor_bot/orchestrator/core.py
+++ b/ductor_bot/orchestrator/core.py
@@ -807,13 +807,22 @@ class Orchestrator:
         message: str,
         *,
         new_session: bool = False,
+        source_chat_id: int = 0,
+        source_topic_id: int | None = None,
     ) -> tuple[str, str, str]:
         """Process a message from another agent via the InterAgentBus."""
         from ductor_bot.orchestrator.injection import (
             handle_interagent_message as _handle_ia,
         )
 
-        return await _handle_ia(self, sender, message, new_session=new_session)
+        return await _handle_ia(
+            self,
+            sender,
+            message,
+            new_session=new_session,
+            source_chat_id=source_chat_id,
+            source_topic_id=source_topic_id,
+        )
 
     async def handle_async_interagent_result(
         self,

--- a/ductor_bot/orchestrator/injection.py
+++ b/ductor_bot/orchestrator/injection.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 from ductor_bot.cli.types import AgentRequest
 from ductor_bot.orchestrator.flows import _is_invalid_session, _update_session
 from ductor_bot.session.key import SessionKey
-from ductor_bot.session.named import NamedSession
+from ductor_bot.session.named import NamedSession, interagent_session_name
 from ductor_bot.workspace.loader import build_appended_files_block
 
 if TYPE_CHECKING:
@@ -98,11 +98,13 @@ def _get_or_create_interagent_session(
     sender: str,
     *,
     new_session: bool = False,
+    source_chat_id: int = 0,
+    source_topic_id: int | None = None,
 ) -> tuple[NamedSession, bool, str]:
     """Get or create a Named Session for an inter-agent conversation.
 
-    Uses a deterministic name ``ia-{sender}`` so follow-up messages from
-    the same sender automatically resume the same session.
+    Uses a deterministic name scoped by sender chat/topic. Calls without
+    source context keep the legacy ``ia-{sender}`` name.
 
     If *new_session* is True, any existing session for this sender is
     ended first so a fresh one is created.
@@ -114,7 +116,7 @@ def _get_or_create_interagent_session(
     Returns ``(session, is_new, provider_switch_notice)``.
     """
     chat_id = _interagent_chat_id(orch)
-    session_name = f"ia-{sender}"
+    session_name = interagent_session_name(sender, source_chat_id, source_topic_id)
     provider_switch_notice = ""
 
     if new_session and orch._named_sessions.end_session(chat_id, session_name):
@@ -164,18 +166,22 @@ def _get_or_create_interagent_session(
 # ---------------------------------------------------------------------------
 
 
-async def handle_interagent_message(
+async def handle_interagent_message(  # noqa: PLR0913
     orch: Orchestrator,
     sender: str,
     message: str,
     *,
     new_session: bool = False,
+    source_chat_id: int = 0,
+    source_topic_id: int | None = None,
 ) -> tuple[str, str, str]:
     """Process a message from another agent via the InterAgentBus.
 
-    Uses a Named Session per sender so that context is preserved across
-    multiple inter-agent interactions.  The session can also be resumed
-    manually from Telegram via ``@ia-{sender} <message>``.
+    With source context, uses a sender/chat/topic-scoped Named Session and
+    reuses it for follow-up messages from the same chat/topic. Calls without
+    source context keep the legacy ``ia-{sender}`` name. The exact session name
+    is returned so callers can report it and users can resume it manually from
+    Telegram via ``@<session-name> <message>``.
 
     Returns ``(result_text, session_name, provider_switch_notice)``.
     The *provider_switch_notice* is non-empty when a provider change
@@ -188,6 +194,8 @@ async def handle_interagent_message(
         orch,
         sender,
         new_session=new_session,
+        source_chat_id=source_chat_id,
+        source_topic_id=source_topic_id,
     )
 
     prompt = (
@@ -239,7 +247,13 @@ async def handle_interagent_message(
             stale_id,
         )
         orch._named_sessions.end_session(chat_id, ns.name)
-        ns, _, _ = _get_or_create_interagent_session(orch, sender, new_session=True)
+        ns, _, _ = _get_or_create_interagent_session(
+            orch,
+            sender,
+            new_session=True,
+            source_chat_id=source_chat_id,
+            source_topic_id=source_topic_id,
+        )
         ns.status = "running"
         files_block = await build_appended_files_block(
             orch.paths, orch._config.append_system_prompt_files

--- a/ductor_bot/session/named.py
+++ b/ductor_bot/session/named.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
+import re
 import secrets
 import time
 from dataclasses import asdict, dataclass
@@ -14,6 +16,23 @@ from ductor_bot.infra.json_store import atomic_json_save, load_json
 from ductor_bot.session.key import SessionKey
 
 logger = logging.getLogger(__name__)
+
+
+def interagent_session_name(
+    sender: str,
+    source_chat_id: int = 0,
+    source_topic_id: int | None = None,
+) -> str:
+    """Return the legacy or chat/topic-scoped inter-agent session name."""
+    if not source_chat_id:
+        return f"ia-{sender}"
+    slug = re.sub(r"[^a-z0-9]+", "-", sender.lower()).strip("-")[:12] or "agent"
+    topic = f"t{source_topic_id}" if source_topic_id is not None else "t0"
+    digest = hashlib.sha256(f"{sender}\0{source_chat_id}\0{source_topic_id}".encode()).hexdigest()[
+        :8
+    ]
+    return f"{f'ia.{slug}.{topic}'[:30]}.x{digest}"
+
 
 _ADJECTIVES: tuple[str, ...] = (
     "bold",
@@ -346,7 +365,7 @@ class NamedSessionRegistry:
 
         If *chat_id* is given, only return sessions for that chat.
         If *transport* is given, only return sessions for that transport.
-        Excludes inter-agent sessions (``ia-`` prefix).
+        Excludes inter-agent sessions (``ia-`` or ``ia.`` prefix).
         """
         results: list[NamedSession] = []
         to_remove: list[tuple[int, str]] = []
@@ -355,7 +374,7 @@ class NamedSessionRegistry:
                 continue
             if transport is not None and ns.transport != transport:
                 continue
-            if ns.name.startswith("ia-"):
+            if ns.name.startswith(("ia-", "ia.")):
                 continue
             results.append(ns)
             to_remove.append(key)

--- a/ductor_bot/workspace/init.py
+++ b/ductor_bot/workspace/init.py
@@ -511,11 +511,15 @@ Python tool commands to the user — those are for YOU to use internally.
 Responses from these tools always come back to YOU, never to the sub-agent's chat.
 Use async for tasks that may take more than a few seconds.
 
-When you delegate a task asynchronously, the sub-agent processes it in a \
-Named Session called `ia-{name}`. The user can continue that session \
-in the sub-agent's chat via `@ia-{name} <message>`. When \
-reporting results to the user, mention this session name so they know \
-how to follow up directly with the sub-agent.
+When you delegate a task asynchronously with source chat/topic context, the \
+sub-agent processes it in a **Named Session** with a sender/chat/topic-scoped \
+name (for example, `ia.main.t12345.xab12cd34`). Follow-up messages from the \
+same chat/topic reuse that session. Calls without source context use the \
+legacy `ia-<sender>` name.
+
+The exact session name is reported with the response. To continue it in the \
+sub-agent's chat, use the reported name exactly: \
+`@<session-name> <message>`. Do not guess session names.
 """
 
 _IDENTITY_SUB = """
@@ -542,13 +546,20 @@ chat via these tools.
 
 ### Inter-Agent Named Sessions
 
-When another agent sends you a message, it runs in a **Named Session** \
-called `ia-{{sender}}` (e.g. `ia-main`). These sessions:
+When another agent sends you a message with source chat/topic context, it \
+runs in a **Named Session** with a sender/chat/topic-scoped name (for \
+example, `ia.main.t12345.xab12cd34`). Follow-up messages from the same \
+chat/topic reuse that session. Calls without source context use the legacy \
+`ia-{{sender}}` name. These sessions:
 
 - Preserve context across multiple messages from the same sender agent
 - Run in the background, independent of your direct chat
-- Are visible to the user via `/sessions` and can be continued \
-manually with `@ia-{{sender}} <message>` in your chat
+- Are visible to the user via `/sessions`
+
+Async responses report the exact session name. To continue it, use the \
+reported name exactly: `@<session-name> <message>`. Synchronous responses \
+do not include the session name; use async or find it in the recipient's \
+`/sessions` list. Do not guess session names.
 
 When you receive an `[INTER-AGENT MESSAGE]` marker, respond directly \
 and concisely. If the user asks about running tasks or background \

--- a/tests/infra/test_recovery.py
+++ b/tests/infra/test_recovery.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from ductor_bot.infra.inflight import InflightTracker, InflightTurn
 from ductor_bot.infra.recovery import RecoveryAction, RecoveryPlanner
 
@@ -96,11 +98,14 @@ class TestRecoveryPlannerNamedSessions:
         assert ns_actions[0].session_name == "boldowl"
         assert ns_actions[0].session_id == "sess-ns-1"
 
-    def test_skips_inter_agent_sessions(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "name", ["ia-research", "ia.main.t3892.xf47692", "ia.main.t10.x255106fd"]
+    )
+    def test_skips_inter_agent_sessions(self, tmp_path: Path, name: str) -> None:
         from ductor_bot.session.named import NamedSession
 
         ns = NamedSession(
-            name="ia-research",
+            name=name,
             chat_id=100,
             provider="claude",
             model="opus",

--- a/tests/multiagent/test_bus.py
+++ b/tests/multiagent/test_bus.py
@@ -6,6 +6,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 from ductor_bot.multiagent.bus import AsyncSendOptions, InterAgentBus
+from ductor_bot.session.named import interagent_session_name
 
 
 def _make_stack(
@@ -261,12 +262,14 @@ class TestBusNewSessionFlag:
             "sender",
             "target",
             "Hello",
-            opts=AsyncSendOptions(new_session=True),
+            opts=AsyncSendOptions(new_session=True, chat_id=777, topic_id=10),
         )
         await asyncio.sleep(0.1)
 
         assert len(call_kwargs) == 1
         assert call_kwargs[0]["new_session"] is True
+        assert call_kwargs[0]["source_chat_id"] == 777
+        assert call_kwargs[0]["source_topic_id"] == 10
 
     async def test_async_send_new_session_false_by_default(self) -> None:
         bus = InterAgentBus()
@@ -347,6 +350,32 @@ class TestBusNotifyRecipient:
         assert call_args[0][0] == 12345  # chat_id
         assert "main" in call_args[0][1]  # sender name in text
         assert "ia-main" in call_args[0][1]  # session name in text
+
+    async def test_notify_uses_scoped_session_name_with_source_context(self) -> None:
+        bus = InterAgentBus()
+        stack = _make_stack()
+        stack.config.allowed_user_ids = [12345]
+        mock_ns = AsyncMock()
+        stack.bot.notification_service = mock_ns
+        bus.register("target", stack)
+
+        from ductor_bot.multiagent.bus import AsyncInterAgentTask
+
+        task = AsyncInterAgentTask(
+            task_id="abc123",
+            sender="main",
+            recipient="target",
+            message="Do something important",
+            chat_id=777,
+            topic_id=10,
+        )
+
+        await bus._notify_recipient(task)
+
+        expected = interagent_session_name("main", 777, 10)
+        text = mock_ns.notify.call_args[0][1]
+        assert expected in text
+        assert "ia-main" not in text
 
     async def test_notify_broadcasts_when_no_users(self) -> None:
         """When no allowed_user_ids, notify_all() is used instead."""

--- a/tests/multiagent/test_internal_api.py
+++ b/tests/multiagent/test_internal_api.py
@@ -144,6 +144,8 @@ class TestNewSessionFlag:
                 "to": "target",
                 "message": "Hello",
                 "new_session": True,
+                "chat_id": 777,
+                "topic_id": 10,
             },
         )
         assert resp.status == 200
@@ -151,6 +153,8 @@ class TestNewSessionFlag:
             "sender",
             "Hello",
             new_session=True,
+            source_chat_id=777,
+            source_topic_id=10,
         )
 
     async def test_send_defaults_new_session_false(

--- a/tests/orchestrator/test_interagent.py
+++ b/tests/orchestrator/test_interagent.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.util
+import json
+import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,7 +18,10 @@ from ductor_bot.orchestrator.injection import (
     _get_or_create_interagent_session,
     _interagent_chat_id,
 )
+from ductor_bot.session.named import interagent_session_name
 from ductor_bot.workspace.paths import DuctorPaths
+
+_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
@@ -114,6 +121,14 @@ class TestGetOrCreateInteragentSession:
         assert is_new is False
         assert notice == ""
 
+    def test_scopes_names_by_source_chat_and_topic(self) -> None:
+        topic_10 = interagent_session_name("main", 777, 10)
+        topic_20 = interagent_session_name("main", 777, 20)
+        assert topic_10 != topic_20
+        assert topic_10.startswith("ia.main.t10.x")
+        assert len(topic_10) <= 40
+        assert interagent_session_name("main") == "ia-main"
+
 
 class TestHandleInteragentMessage:
     """Test handle_interagent_message."""
@@ -163,6 +178,97 @@ class TestHandleInteragentMessage:
         call_args = orch_ia._cli_service.execute.call_args
         request = call_args[0][0]
         assert request.resume_session is None
+
+    async def test_same_topic_reuses_scoped_session(self, orch_ia: Orchestrator) -> None:
+        _, first_name, _ = await orch_ia.handle_interagent_message(
+            "main", "Task 1", source_chat_id=777, source_topic_id=10
+        )
+        _, second_name, _ = await orch_ia.handle_interagent_message(
+            "main", "Task 2", source_chat_id=777, source_topic_id=10
+        )
+        assert second_name == first_name
+        assert orch_ia._cli_service.execute.call_args.args[0].resume_session == "sess-001"
+
+    async def test_different_topics_use_different_scoped_sessions(
+        self, orch_ia: Orchestrator
+    ) -> None:
+        _, topic_10, _ = await orch_ia.handle_interagent_message(
+            "main", "Task 1", source_chat_id=777, source_topic_id=10
+        )
+        _, topic_20, _ = await orch_ia.handle_interagent_message(
+            "main", "Task 2", source_chat_id=777, source_topic_id=20
+        )
+        assert topic_10 != topic_20
+
+    async def test_new_keeps_scoped_destination(self, orch_ia: Orchestrator) -> None:
+        _, first_name, _ = await orch_ia.handle_interagent_message(
+            "main", "Task 1", source_chat_id=777, source_topic_id=10
+        )
+        _, new_name, _ = await orch_ia.handle_interagent_message(
+            "main",
+            "Task 2",
+            new_session=True,
+            source_chat_id=777,
+            source_topic_id=10,
+        )
+        assert new_name == first_name
+        assert orch_ia._cli_service.execute.call_args.args[0].resume_session is None
+
+    async def test_interagent_request_uses_recipient_anchor(self, orch_ia: Orchestrator) -> None:
+        await orch_ia.handle_interagent_message(
+            "main", "Task", source_chat_id=777, source_topic_id=10
+        )
+        request = orch_ia._cli_service.execute.call_args.args[0]
+        assert request.chat_id == 12345
+        assert request.chat_id != 777
+
+    async def test_task_delivery_keeps_recipient_anchor(
+        self, orch_ia: Orchestrator, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ductor_bot.cli.base import CLIConfig
+        from ductor_bot.cli.executor import build_subprocess_env
+
+        await orch_ia.handle_interagent_message(
+            "main", "Create a task", source_chat_id=777, source_topic_id=10
+        )
+        request = orch_ia._cli_service.execute.call_args.args[0]
+        assert request.chat_id == 12345
+
+        monkeypatch.delenv("DUCTOR_CHAT_ID", raising=False)
+        monkeypatch.delenv("DUCTOR_TOPIC_ID", raising=False)
+        env = build_subprocess_env(
+            CLIConfig(
+                working_dir="/tmp/workspace",
+                chat_id=request.chat_id,
+                topic_id=request.topic_id,
+                transport=request.transport,
+            )
+        )
+        assert env is not None
+        monkeypatch.setenv("DUCTOR_CHAT_ID", env["DUCTOR_CHAT_ID"])
+
+        tool = _ROOT / "ductor_bot/_home_defaults/workspace/tools/task_tools/create_task.py"
+        spec = importlib.util.spec_from_file_location("create_task_tool", tool)
+        assert spec is not None
+        assert spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        captured: dict[str, object] = {}
+
+        def post_json(_url: str, body: dict[str, object], *, timeout: int) -> dict[str, object]:
+            assert timeout == 10
+            captured.update(body)
+            return {"success": True, "task_id": "task-1"}
+
+        monkeypatch.setattr(
+            mod,
+            "_load_shared",
+            lambda: (lambda _path: "http://example.invalid", post_json, lambda: "codex"),
+        )
+        monkeypatch.setattr(sys, "argv", ["create_task.py", "do work"])
+        mod.main()
+        assert captured["chat_id"] == 12345
+        assert "topic_id" not in captured
 
     async def test_prompt_contains_interagent_markers(self, orch_ia: Orchestrator) -> None:
         await orch_ia.handle_interagent_message("main", "Hello world")
@@ -326,3 +432,31 @@ class TestHandleAsyncInteragentResult:
         call_args = orch_ia._cli_service.execute.call_args
         request = call_args[0][0]
         assert request.resume_session == "active-session-999"
+
+
+def test_ask_agent_forwards_source_chat_topic(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = _ROOT / "ductor_bot/_home_defaults/workspace/tools/agent_tools/ask_agent.py"
+    spec = importlib.util.spec_from_file_location("ask_agent_tool", tool)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = json.dumps(
+        {"success": True, "text": "ok"}
+    ).encode()
+    captured: dict[str, object] = {}
+
+    def urlopen(request: object, timeout: int) -> MagicMock:
+        assert timeout == 300
+        captured.update(json.loads(request.data.decode()))
+        return response
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(sys, "argv", ["ask_agent.py", "codex", "hello"])
+    monkeypatch.setenv("DUCTOR_AGENT_NAME", "main")
+    monkeypatch.setenv("DUCTOR_CHAT_ID", "777")
+    monkeypatch.setenv("DUCTOR_TOPIC_ID", "10")
+    mod.main()
+    assert captured["chat_id"] == 777
+    assert captured["topic_id"] == 10

--- a/tests/session/test_named_recovery.py
+++ b/tests/session/test_named_recovery.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
+import pytest
+
 from ductor_bot.session.key import SessionKey
 from ductor_bot.session.named import NamedSessionRegistry
 
@@ -126,8 +128,9 @@ class TestRecoveredRunning:
         assert len(reg.pop_recovered_running(transport="tg")) == 0
         assert len(reg.pop_recovered_running(transport="sl")) == 1
 
-    def test_ia_sessions_excluded(self, tmp_path: Path) -> None:
-        path = self._persist_running_session(tmp_path, name="ia-sub1")
+    @pytest.mark.parametrize("name", ["ia-sub1", "ia.main.t3892.xf47692", "ia.main.t10.x255106fd"])
+    def test_ia_sessions_excluded(self, tmp_path: Path, name: str) -> None:
+        path = self._persist_running_session(tmp_path, name=name)
         reg = NamedSessionRegistry(path)
         assert len(reg.pop_recovered_running()) == 0
 


### PR DESCRIPTION
## Problem

All inter-agent requests from a given sender share one `ia-{sender}` named session on the recipient. When the same sender delegates from several chats or forum topics at once:

- conversations interleave inside a single session (context contamination),
- requests serialize behind each other,
- `--new` from one caller resets state for every other caller,
- the sync path (`ask_agent.py` → `/interagent/send`) carries no origin, so scoping is impossible there,
- execution failures are reported to the caller as successful responses.

## What changed

**Identity & naming**

- `NamedSession` gains optional structured fields `ia_sender` / `ia_transport` / `ia_chat_id` / `ia_topic_id`, plus `reservation_gen` and `last_active_at`. Existing JSON loads with defaults (missing = legacy); round-trip is preserved.
- Session lookup is field-based; names are display handles only. Scoped names use a physically disjoint namespace `ia.{slug}.t{topic}.x{hash}` (third char `.`), so no sender string can collide with legacy `ia-{sender}` names. The slug is bounded (lowercase, max 16 chars); the raw sender only feeds the identity fields and hash. Names are capped at 40 bytes.
- Requests without a valid origin keep using the legacy session — older tools continue to work unchanged.

**Origin plumbing**

- Async: origin travels with the task and is honored on stale retries. Sync: `ask_agent.py` exports origin env vars → `/interagent/send` → `bus.send()`.
- All three transports are supported (`tg`, `mx`, `sl`).
- Direct inter-agent executions carry the caller's origin separately from process ownership: `AgentRequest` / `CLIConfig` gain `origin_chat_id` / `origin_topic_id` / `origin_transport`, which is what the CLI subprocess sees, while `chat_id` / `topic_id` remain the recipient anchor used for process registration and kills. Without this split, a recipient that delegates onward (two-hop) would collapse distinct caller topics into one downstream session.
- Named background sessions propagate chat, topic, and transport through `BackgroundSubmit` / `BackgroundTask` into the subprocess env (`DUCTOR_CHAT_ID` / `DUCTOR_TOPIC_ID` / `DUCTOR_TRANSPORT`), and background results route back on their originating transport. Restart recovery re-submits named sessions with their original topic and transport.
- Origin env vars are *cleared*, not merely skipped, when the effective origin has no chat/topic — a stale `DUCTOR_TOPIC_ID` inherited from the parent process can no longer scope a topic-less delegation into an unrelated topic. Host and Docker execution produce the same environment.

**Failure reporting**

- `InterAgentOutcome.ok` is explicit at every construction site. Execution exceptions, stale-retry failures, and CLI-reported errors (`is_error`) return failed outcomes (`error_kind`: `execution` / `cli`); busy and ceiling rejections are typed. Sync callers get `success=false` with an error message; async senders receive a failure notification instead of error text disguised as a normal answer.

**Concurrency & lifecycle**

- A new `NamedSessionLockPool` ((chat, name)-keyed, fair waiter handoff, refcounted eviction) serializes every named-session execution path, including background follow-up reservations — a queued background submit can no longer overtake a foreground waiter.
- `--new` on a busy session never blocks and never resets running work; a session holding a background reservation rejects overtaking direct requests. Both get a typed `busy` rejection.
- Recipient-wide running ceiling (16) with typed `ceiling` rejection; per-sender idle quota (8) and global idle quota (32) with oldest-idle pruning. The global cap is computed on the survivors of the per-sender cap, automatic pruning physically removes pruned sessions from the in-memory registry, and interagent sessions no longer consume the per-chat `/session` quota.
- Background reservations carry a generation token; every failure path (resolver error, submit error, cancellation, shutdown) rolls the session back transactionally — no phantom `running` sessions. Every queued task delivers exactly one terminal result (`success` / `error` / `aborted` / `superseded`), including ceiling rejections and cancellations that land before start or mid-delivery, for named and stateless tasks alike. `ended` is terminal.
- Named executions register a per-execution `ns:{session}:{token}` process label with sticky abort markers, so `/sessions end`, **End all**, and chat-wide abort terminate the underlying CLI processes even when they race with subprocess registration — late-registering processes go through the full kill ladder (TERM → grace → KILL → reap), shutdown drains those cleanups, ending an idle session leaves no stale abort behind, and abort markers never accumulate. Topic-scoped `/stop` continues to preserve `ns:` processes.

**Hints & i18n**

- Async result hints only advertise `@{session} <message>` manual resume when the recipient has a supporting transport configured, independent of transport order.
- Locale strings updated for all locales.

## Compatibility & downgrade

- Legacy `ia-{sender}` sessions are untouched; old JSON round-trips unchanged; no migration required.
- Failure reporting is a behavior change: CLI execution failures now surface as `success=false` (the response schema is unchanged — the `success` / `error` fields already exist). Callers that parsed error strings out of successful responses should use the explicit flag.
- **Downgrade:** end scoped `ia.` sessions before rolling back — older versions do not recognize the `ia.` namespace and would recover them as ordinary background sessions.

## Out of scope (follow-ups)

- Result delivery fallback when the originating chat/topic no longer exists.
- Origin propagation for background tasks spawned via the task CLI (task-context delegations currently fall back to the anchor chat).
- Multi-transport restart recovery orchestration: recovery runs during primary-bot startup (before secondary transports are ready) and recovery *notifications* go through the primary transport — pre-existing behavior, unchanged here. Recovered task results themselves are transport/topic-correct.
- Pinning per-session reasoning effort on inter-agent sessions: they still follow the recipient's global effort, exactly as before this PR. Kept separate to keep this change focused; a follow-up builds on it.

## Testing

- `tests/test_interagent_scope.py`: 75 tests, including concurrency and isolation reproductions — lock handoff steal attempt, background reservation vs. foreground waiter ordering, cancellation restore (pre-start, mid-delivery, named and stateless), submission-failure rollback, end-all / chat-wide abort termination incl. late-registering and TERM-ignoring processes, abort-marker lifecycle races, two-hop origin isolation across transports, host/Docker subprocess-env parity incl. stale-env clearing, restart-recovery origin preservation, and pruning bounds.
- Full suite: no new failures vs. base; `ruff check .`, `ruff format --check`, `mypy`, and the i18n completeness check all pass.
