### PR TITLE
fix(logging): redact environment values from logged CLI commands

### DIFF
--- a/ductor_bot/cli/_log_redact.py
+++ b/ductor_bot/cli/_log_redact.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import re
-
-_ENV_ASSIGNMENT = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", re.DOTALL)
 _VISIBLE_ENV_KEYS = {
     "DUCTOR_HOME",
     "DUCTOR_AGENT_NAME",
@@ -23,11 +20,12 @@ _VISIBLE_ENV_KEYS = {
 }
 
 
-def _redact_assignment(value: str) -> str:
-    match = _ENV_ASSIGNMENT.fullmatch(value)
-    if match is None:
+def _redact_assignment(value: str, *, force: bool = False) -> str:
+    key, separator, raw_value = value.partition("=")
+    if not separator:
         return value
-    key, raw_value = match.groups()
+    if not force and (value.startswith("-") or " " in key or "/" in key):
+        return value
     if key in _VISIBLE_ENV_KEYS:
         return f"{key}={raw_value}"
     return f"{key}=***"
@@ -36,13 +34,20 @@ def _redact_assignment(value: str) -> str:
 def redact_cmd_for_log(cmd: list[str]) -> list[str]:
     """Return a copy of *cmd* with environment values safe for logs."""
     redacted: list[str] = []
+    expects_env = False
     for arg in cmd:
-        if arg.startswith("--env="):
-            redacted.append("--env=" + _redact_assignment(arg.removeprefix("--env=")))
+        if expects_env:
+            redacted.append(_redact_assignment(arg, force=True))
+            expects_env = False
+        elif arg in {"-e", "--env"}:
+            redacted.append(arg)
+            expects_env = True
+        elif arg.startswith("--env="):
+            redacted.append("--env=" + _redact_assignment(arg.removeprefix("--env="), force=True))
         elif arg.startswith("-e="):
-            redacted.append("-e=" + _redact_assignment(arg.removeprefix("-e=")))
+            redacted.append("-e=" + _redact_assignment(arg.removeprefix("-e="), force=True))
         elif arg.startswith("-e") and arg != "-e" and "=" in arg[2:]:
-            redacted.append("-e" + _redact_assignment(arg[2:]))
+            redacted.append("-e" + _redact_assignment(arg[2:], force=True))
         else:
             redacted.append(_redact_assignment(arg))
     return redacted

--- a/ductor_bot/cli/_log_redact.py
+++ b/ductor_bot/cli/_log_redact.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-_ENV_ASSIGNMENT = re.compile(r"^([A-Z0-9_]+)=(.*)$", re.DOTALL)
+_ENV_ASSIGNMENT = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", re.DOTALL)
 _VISIBLE_ENV_KEYS = {
     "DUCTOR_HOME",
     "DUCTOR_AGENT_NAME",
@@ -21,7 +21,6 @@ _VISIBLE_ENV_KEYS = {
     "CONTAINER",
     "PLAYWRIGHT_BROWSERS_PATH",
 }
-_VISIBLE_ENV_SUFFIXES = ("_URL", "_HOST", "_PORT")
 
 
 def _redact_assignment(value: str) -> str:
@@ -29,7 +28,7 @@ def _redact_assignment(value: str) -> str:
     if match is None:
         return value
     key, raw_value = match.groups()
-    if key in _VISIBLE_ENV_KEYS or key.endswith(_VISIBLE_ENV_SUFFIXES):
+    if key in _VISIBLE_ENV_KEYS:
         return f"{key}={raw_value}"
     return f"{key}=***"
 

--- a/ductor_bot/cli/_log_redact.py
+++ b/ductor_bot/cli/_log_redact.py
@@ -1,0 +1,49 @@
+"""Redact environment assignments before command logging."""
+
+from __future__ import annotations
+
+import re
+
+_ENV_ASSIGNMENT = re.compile(r"^([A-Z0-9_]+)=(.*)$", re.DOTALL)
+_VISIBLE_ENV_KEYS = {
+    "DUCTOR_HOME",
+    "DUCTOR_AGENT_NAME",
+    "DUCTOR_TRANSPORT",
+    "DUCTOR_CHAT_ID",
+    "DUCTOR_TOPIC_ID",
+    "DUCTOR_INTERAGENT_PORT",
+    "DUCTOR_INTERAGENT_HOST",
+    "DUCTOR_SHARED_MEMORY_PATH",
+    "TZ",
+    "PYTHONPATH",
+    "HOME",
+    "LANG",
+    "CONTAINER",
+    "PLAYWRIGHT_BROWSERS_PATH",
+}
+_VISIBLE_ENV_SUFFIXES = ("_URL", "_HOST", "_PORT")
+
+
+def _redact_assignment(value: str) -> str:
+    match = _ENV_ASSIGNMENT.fullmatch(value)
+    if match is None:
+        return value
+    key, raw_value = match.groups()
+    if key in _VISIBLE_ENV_KEYS or key.endswith(_VISIBLE_ENV_SUFFIXES):
+        return f"{key}={raw_value}"
+    return f"{key}=***"
+
+
+def redact_cmd_for_log(cmd: list[str]) -> list[str]:
+    """Return a copy of *cmd* with environment values safe for logs."""
+    redacted: list[str] = []
+    for arg in cmd:
+        if arg.startswith("--env="):
+            redacted.append("--env=" + _redact_assignment(arg.removeprefix("--env=")))
+        elif arg.startswith("-e="):
+            redacted.append("-e=" + _redact_assignment(arg.removeprefix("-e=")))
+        elif arg.startswith("-e") and arg != "-e" and "=" in arg[2:]:
+            redacted.append("-e" + _redact_assignment(arg[2:]))
+        else:
+            redacted.append(_redact_assignment(arg))
+    return redacted

--- a/ductor_bot/cli/antigravity_provider.py
+++ b/ductor_bot/cli/antigravity_provider.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncGenerator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ductor_bot.cli._log_redact import redact_cmd_for_log
 from ductor_bot.cli.antigravity_events import parse_antigravity_json
 from ductor_bot.cli.antigravity_runtime import antigravity_process_env
 from ductor_bot.cli.base import BaseCLI, CLIConfig
@@ -291,7 +292,7 @@ class AntigravityCLI(BaseCLI):
 
 def _safe_command_for_logging(cmd: list[str]) -> list[str]:
     """Return a command safe for debug logs."""
-    safe = [part if len(part) <= 80 else part[:80] + "..." for part in cmd]
+    safe = [part if len(part) <= 80 else part[:80] + "..." for part in redact_cmd_for_log(cmd)]
     if "--print" in cmd and safe:
         safe[-1] = "<prompt>"
     return safe

--- a/ductor_bot/cli/claude_provider.py
+++ b/ductor_bot/cli/claude_provider.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING
 
+from ductor_bot.cli._log_redact import redact_cmd_for_log
 from ductor_bot.cli.base import (
     _IS_WINDOWS,
     BaseCLI,
@@ -162,10 +163,11 @@ def _add_opt(cmd: list[str], flag: str, value: str | None) -> None:
 
 
 def _log_cmd(cmd: list[str], *, streaming: bool = False) -> None:
-    """Log the CLI command with truncated long values."""
+    """Log the CLI command with redacted and truncated long values."""
+    redacted_cmd = redact_cmd_for_log(cmd)
     safe_cmd = [
-        (c[:80] + "...") if len(c) > 80 and i > 0 and cmd[i - 1].startswith("--") else c
-        for i, c in enumerate(cmd)
+        (c[:80] + "...") if len(c) > 80 and i > 0 and redacted_cmd[i - 1].startswith("--") else c
+        for i, c in enumerate(redacted_cmd)
     ]
     prefix = "CLI stream cmd" if streaming else "CLI cmd"
     logger.info("%s: %s", prefix, " ".join(safe_cmd))

--- a/ductor_bot/cli/codex_provider.py
+++ b/ductor_bot/cli/codex_provider.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING
 
+from ductor_bot.cli._log_redact import redact_cmd_for_log
 from ductor_bot.cli.base import (
     BaseCLI,
     CLIConfig,
@@ -418,7 +419,7 @@ def _extract_codex_error_detail(raw: str) -> str:
 
 
 def _log_cmd(cmd: list[str], *, streaming: bool = False) -> None:
-    """Log the CLI command with truncated long values."""
-    safe_cmd = [(c[:80] + "...") if len(c) > 80 else c for c in cmd]
+    """Log the CLI command with redacted and truncated long values."""
+    safe_cmd = [(c[:80] + "...") if len(c) > 80 else c for c in redact_cmd_for_log(cmd)]
     prefix = "Codex stream cmd" if streaming else "Codex cmd"
     logger.info("%s: %s", prefix, " ".join(safe_cmd))

--- a/ductor_bot/cli/gemini_provider.py
+++ b/ductor_bot/cli/gemini_provider.py
@@ -13,6 +13,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ductor_bot.cli._log_redact import redact_cmd_for_log
 from ductor_bot.cli.auth import gemini_api_key_mode_selected
 from ductor_bot.cli.base import (
     BaseCLI,
@@ -577,27 +578,15 @@ async def _cleanup_file(path: str | None) -> None:
         await asyncio.to_thread(Path(path).unlink, missing_ok=True)
 
 
-_SENSITIVE_ENV_KEYS = ("GEMINI_API_KEY",)
-
-
 def _log_cmd(cmd: list[str], *, streaming: bool = False) -> None:
-    """Log the CLI command with sensitive env values masked."""
-    safe: list[str] = []
-    mask_next = False
-    for i, c in enumerate(cmd):
-        if mask_next:
-            safe.append(c[:4] + "***" if len(c) > 4 else "***")
-            mask_next = False
-            continue
-        if c == "-e" and i + 1 < len(cmd):
-            nxt = cmd[i + 1]
-            if any(nxt.startswith(f"{k}=") for k in _SENSITIVE_ENV_KEYS):
-                mask_next = True
-        if len(c) > 80 and i > 0 and cmd[i - 1].startswith("--"):
-            safe.append(c[:80] + "...")
-        else:
-            safe.append(c)
-    logger.info("%s: %s", "Gemini stream cmd" if streaming else "Gemini cmd", " ".join(safe))
+    """Log the CLI command with redacted and truncated long values."""
+    redacted_cmd = redact_cmd_for_log(cmd)
+    safe = [
+        (c[:80] + "...") if len(c) > 80 and i > 0 and redacted_cmd[i - 1].startswith("--") else c
+        for i, c in enumerate(redacted_cmd)
+    ]
+    prefix = "Gemini stream cmd" if streaming else "Gemini cmd"
+    logger.info("%s: %s", prefix, " ".join(safe))
 
 
 def _gemini_settings_path(env: dict[str, str]) -> Path:

--- a/ductor_bot/infra/docker.py
+++ b/ductor_bot/infra/docker.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING, ClassVar
 
+from ductor_bot.cli._log_redact import redact_cmd_for_log
 from ductor_bot.config import DockerConfig
 from ductor_bot.workspace.paths import DuctorPaths
 
@@ -398,7 +399,7 @@ class DockerManager:
         cmd.append(image)
 
         logger.info("Starting Docker container '%s' from image '%s'", name, image)
-        logger.debug("docker run cmd: %s", " ".join(cmd))
+        logger.debug("docker run cmd: %s", " ".join(redact_cmd_for_log(cmd)))
         rc, output = await self._exec(*cmd)
         if rc != 0:
             logger.error("docker run failed:\n%s", output[-2000:])

--- a/tests/cli/test_log_redact.py
+++ b/tests/cli/test_log_redact.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -12,8 +14,12 @@ from ductor_bot.cli.antigravity_provider import _safe_command_for_logging
 from ductor_bot.cli.claude_provider import _log_cmd as log_claude_cmd
 from ductor_bot.cli.codex_provider import _log_cmd as log_codex_cmd
 from ductor_bot.cli.gemini_provider import _log_cmd as log_gemini_cmd
+from ductor_bot.config import DockerConfig
+from ductor_bot.infra.docker import DockerManager
+from ductor_bot.workspace.paths import DuctorPaths
 
 _FAKE_SECRET = "ghp_FAKESECRET123"
+_FAKE_DATABASE_VALUE = "postgres://fake-user:fake-password@example.invalid/db"
 _CMD = [
     "docker",
     "exec",
@@ -50,7 +56,39 @@ def test_redact_cmd_for_log_handles_inline_env_forms() -> None:
         "docker",
         "--env=API_TOKEN=***",
         "-eINLINE_TOKEN=***",
-        "SERVICE_URL=https://example.test",
+        "SERVICE_URL=***",
+    ]
+
+
+def test_redact_cmd_for_log_masks_all_non_whitelisted_dotenv_keys() -> None:
+    cmd = [
+        "docker",
+        "exec",
+        "-e",
+        f"DATABASE_URL={_FAKE_DATABASE_VALUE}",
+        "-e",
+        "api_key=fake-lowercase-secret",
+        "--env=MyToken=fake-mixed-secret",
+        "-e",
+        "DUCTOR_CHAT_ID=42",
+        "--model",
+        "opus",
+    ]
+
+    redacted = redact_cmd_for_log(cmd)
+
+    assert redacted == [
+        "docker",
+        "exec",
+        "-e",
+        "DATABASE_URL=***",
+        "-e",
+        "api_key=***",
+        "--env=MyToken=***",
+        "-e",
+        "DUCTOR_CHAT_ID=42",
+        "--model",
+        "opus",
     ]
 
 
@@ -69,6 +107,57 @@ def test_provider_command_logs_redact_secret(
     assert _FAKE_SECRET not in caplog.text
     assert "GITHUB_TOKEN=***" in caplog.text
     assert "DUCTOR_CHAT_ID=42" in caplog.text
+
+
+def test_claude_info_log_masks_embedded_url_credentials(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.INFO):
+        log_claude_cmd(["docker", "-e", f"DATABASE_URL={_FAKE_DATABASE_VALUE}"])
+
+    assert _FAKE_DATABASE_VALUE not in caplog.text
+    assert "DATABASE_URL=***" in caplog.text
+
+
+async def test_docker_debug_log_masks_embedded_url_credentials(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    home = tmp_path / ".ductor"
+    workspace = home / "workspace"
+    framework = tmp_path / "framework"
+    workspace.mkdir(parents=True)
+    framework.mkdir()
+    paths = DuctorPaths(
+        ductor_home=home,
+        home_defaults=framework / "workspace",
+        framework_root=framework,
+    )
+    manager = DockerManager(
+        DockerConfig(enabled=True, image_name="test-img", container_name="test-ctr"),
+        paths,
+    )
+
+    async def mock_exec(*args: str, **_kwargs: object) -> tuple[int, str]:
+        command = " ".join(args)
+        if "container inspect" in command:
+            return 1, ""
+        return 0, "ok"
+
+    with (
+        caplog.at_level(logging.DEBUG),
+        patch("shutil.which", return_value="/usr/bin/docker"),
+        patch.object(manager, "_exec", new=AsyncMock(side_effect=mock_exec)),
+        patch.object(
+            manager,
+            "_env_secret_flags",
+            return_value=["-e", f"DATABASE_URL={_FAKE_DATABASE_VALUE}"],
+        ),
+    ):
+        await manager.setup()
+
+    assert _FAKE_DATABASE_VALUE not in caplog.text
+    assert "DATABASE_URL=***" in caplog.text
 
 
 def test_antigravity_safe_command_redacts_before_truncation() -> None:

--- a/tests/cli/test_log_redact.py
+++ b/tests/cli/test_log_redact.py
@@ -1,0 +1,80 @@
+"""Tests for command-log environment redaction."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+import pytest
+
+from ductor_bot.cli._log_redact import redact_cmd_for_log
+from ductor_bot.cli.antigravity_provider import _safe_command_for_logging
+from ductor_bot.cli.claude_provider import _log_cmd as log_claude_cmd
+from ductor_bot.cli.codex_provider import _log_cmd as log_codex_cmd
+from ductor_bot.cli.gemini_provider import _log_cmd as log_gemini_cmd
+
+_FAKE_SECRET = "ghp_FAKESECRET123"
+_CMD = [
+    "docker",
+    "exec",
+    "-e",
+    f"GITHUB_TOKEN={_FAKE_SECRET}",
+    "-e",
+    "DUCTOR_CHAT_ID=42",
+    "--model",
+    "opus",
+]
+
+
+def test_redact_cmd_for_log_masks_secret_and_preserves_structure() -> None:
+    redacted = redact_cmd_for_log(_CMD)
+    rendered = " ".join(redacted)
+
+    assert _FAKE_SECRET not in rendered
+    assert "GITHUB_TOKEN=***" in rendered
+    assert "DUCTOR_CHAT_ID=42" in rendered
+    assert redacted[-2:] == ["--model", "opus"]
+
+
+def test_redact_cmd_for_log_handles_inline_env_forms() -> None:
+    redacted = redact_cmd_for_log(
+        [
+            "docker",
+            "--env=API_TOKEN=inline-secret",
+            "-eINLINE_TOKEN=compact-secret",
+            "SERVICE_URL=https://example.test",
+        ]
+    )
+
+    assert redacted == [
+        "docker",
+        "--env=API_TOKEN=***",
+        "-eINLINE_TOKEN=***",
+        "SERVICE_URL=https://example.test",
+    ]
+
+
+@pytest.mark.parametrize(
+    "log_cmd",
+    [log_claude_cmd, log_codex_cmd, log_gemini_cmd],
+    ids=["claude", "codex", "gemini"],
+)
+def test_provider_command_logs_redact_secret(
+    caplog: pytest.LogCaptureFixture,
+    log_cmd: Callable[[list[str]], None],
+) -> None:
+    with caplog.at_level(logging.INFO):
+        log_cmd(_CMD)
+
+    assert _FAKE_SECRET not in caplog.text
+    assert "GITHUB_TOKEN=***" in caplog.text
+    assert "DUCTOR_CHAT_ID=42" in caplog.text
+
+
+def test_antigravity_safe_command_redacts_before_truncation() -> None:
+    safe = _safe_command_for_logging(_CMD)
+    rendered = " ".join(safe)
+
+    assert _FAKE_SECRET not in rendered
+    assert "GITHUB_TOKEN=***" in rendered
+    assert "DUCTOR_CHAT_ID=42" in rendered

--- a/tests/cli/test_log_redact.py
+++ b/tests/cli/test_log_redact.py
@@ -60,6 +60,51 @@ def test_redact_cmd_for_log_handles_inline_env_forms() -> None:
     ]
 
 
+def test_redact_cmd_for_log_masks_env_values_without_parsing_key_syntax() -> None:
+    redacted = redact_cmd_for_log(
+        [
+            "docker",
+            "-e",
+            "api-key=hyphen-secret",
+            "--env",
+            "api.key=dot-secret",
+            "-e",
+            "1TOKEN=digit-secret",
+            "--env=키=unicode-secret",
+            "line-key=first=second\nthird",
+            "DUCTOR_CHAT_ID=42",
+        ]
+    )
+
+    assert redacted == [
+        "docker",
+        "-e",
+        "api-key=***",
+        "--env",
+        "api.key=***",
+        "-e",
+        "1TOKEN=***",
+        "--env=키=***",
+        "line-key=***",
+        "DUCTOR_CHAT_ID=42",
+    ]
+
+
+def test_redact_cmd_for_log_preserves_non_env_arguments() -> None:
+    cmd = [
+        "command",
+        "--flag",
+        "--flag=value",
+        "/tmp/file=name",
+        "https://example.test/path?query=value",
+        "plain prompt",
+        "-e",
+        "HOST_ONLY_KEY",
+    ]
+
+    assert redact_cmd_for_log(cmd) == cmd
+
+
 def test_redact_cmd_for_log_masks_all_non_whitelisted_dotenv_keys() -> None:
     cmd = [
         "docker",
@@ -102,11 +147,10 @@ def test_provider_command_logs_redact_secret(
     log_cmd: Callable[[list[str]], None],
 ) -> None:
     with caplog.at_level(logging.INFO):
-        log_cmd(_CMD)
+        log_cmd(["docker", "-e", f"api-key={_FAKE_SECRET}"])
 
     assert _FAKE_SECRET not in caplog.text
-    assert "GITHUB_TOKEN=***" in caplog.text
-    assert "DUCTOR_CHAT_ID=42" in caplog.text
+    assert "api-key=***" in caplog.text
 
 
 def test_claude_info_log_masks_embedded_url_credentials(
@@ -151,13 +195,13 @@ async def test_docker_debug_log_masks_embedded_url_credentials(
         patch.object(
             manager,
             "_env_secret_flags",
-            return_value=["-e", f"DATABASE_URL={_FAKE_DATABASE_VALUE}"],
+            return_value=["-e", f"api.key={_FAKE_DATABASE_VALUE}"],
         ),
     ):
         await manager.setup()
 
     assert _FAKE_DATABASE_VALUE not in caplog.text
-    assert "DATABASE_URL=***" in caplog.text
+    assert "api.key=***" in caplog.text
 
 
 def test_antigravity_safe_command_redacts_before_truncation() -> None:


### PR DESCRIPTION
## Problem

Every CLI invocation logs the full command line, including the `-e KEY=VALUE` environment flags passed to the sandbox container. Since `~/.ductor/.env` is injected into every CLI subprocess, **every secret in it is written to the log in plaintext**:

- `cli/claude_provider.py` — `CLI stream cmd` / `CLI cmd` (INFO)
- `cli/codex_provider.py` — `Codex cmd` (INFO)
- `cli/gemini_provider.py` — `Gemini cmd` (INFO)
- `cli/antigravity_provider.py` — `Antigravity send` (DEBUG)
- `infra/docker.py` — `docker run cmd` (DEBUG)

The existing "safe_cmd" logic only truncates values that follow a `--flag`; `-e API_KEY=...` is untouched, and most tokens are short enough to survive truncation anyway. Raising `log_level` to INFO or DEBUG for debugging therefore dumps API keys, tokens and passwords into `agent.log` (and its rotations).

## What changed

A shared helper, `cli/_log_redact.py`:

```python
redact_cmd_for_log(cmd: list[str]) -> list[str]
```

- Masks the value of any `KEY=VALUE` argument whose key looks like an environment variable (uppercase / digits / underscore): `-e GITHUB_TOKEN=ghp_…` → `-e GITHUB_TOKEN=***`.
- Handles `-e KEY=VALUE`, `-eKEY=VALUE`, `--env=KEY=VALUE`, and bare inline assignments.
- **Fail-closed**: anything that is not on an explicit non-sensitive allowlist gets masked, so a newly added secret is protected by default.
- Keeps the *keys* and the command structure intact, so logs remain useful for debugging.
- Preserves values for execution context that carries no secrets: `DUCTOR_*` (chat/topic/transport/agent/home/ports), `TZ`, `PYTHONPATH`, `HOME`, `LANG`, `CONTAINER`, Playwright browser path, and `*_URL` / `*_HOST` / `*_PORT` settings.
- Returns a new list; the command actually executed is untouched.

Applied at every command-logging site (Claude, Codex, Gemini, Antigravity, Docker). Existing truncation and prompt-substitution behavior is preserved; masking is applied first, so a masked value is never truncated into something misleading.

## Example

Before:

```
Codex cmd: docker exec -e GITHUB_TOKEN=ghp_REALSECRET -e MAIL_PASS=hunter2 -e DUCTOR_CHAT_ID=42 ductor-sandbox codex exec --model gpt-5
```

After:

```
Codex cmd: docker exec -e GITHUB_TOKEN=*** -e MAIL_PASS=*** -e DUCTOR_CHAT_ID=42 ductor-sandbox codex exec --model gpt-5
```

## Testing

New tests cover: secret values absent from the rendered log line, key names preserved, allowlisted values preserved, command structure preserved, the inline/`-e`/`--env=` forms, and per-provider `caplog` assertions that no secret reaches the log record. Full suite: no new failures vs. base; `ruff`, `ruff format`, `mypy` and the i18n check pass.

Only fake tokens are used in the tests.
