### PR TITLE
fix(telegram): preserve shared allowlist set identity in AuthMiddleware

### DIFF
--- a/ductor_bot/messenger/telegram/middleware.py
+++ b/ductor_bot/messenger/telegram/middleware.py
@@ -104,7 +104,7 @@ class AuthMiddleware(BaseMiddleware):
         on_rejected: RejectedCallback | None = None,
     ) -> None:
         self._allowed_users = allowed_user_ids
-        self._allowed_groups = allowed_group_ids or set()
+        self._allowed_groups = allowed_group_ids if allowed_group_ids is not None else set()
         self._on_rejected = on_rejected
 
     async def __call__(


### PR DESCRIPTION
## The bug

When the bot starts with an **empty group allowlist**, `AuthMiddleware` does:

```python
self._allowed_groups = allowed_group_ids or set()
```

An empty set is falsy, so the middleware silently replaces the caller's shared set with a fresh **private copy**. The hot-reload path (`_on_auth_hot_reload` in `app.py`) mutates the *original* set in place via `clear()`/`update()` — which never reaches the middleware's private copy. Result: group ids added to the config at runtime are hot-reloaded everywhere except the auth filter, and group messages keep getting silently rejected while the config looks perfectly correct.

Observed in production (bot deployed before the group was configured); worked around by restarting the bot, which re-reads the config at construction time.

## Steps to reproduce

1. Start the bot with `allowed_group_ids` empty (or absent) in the config.
2. While the bot is running, add a group id to `allowed_group_ids` and let hot-reload pick it up (logs confirm the reload).
3. Send a message in that group — it is still rejected until the bot is restarted.

## The fix

Keep the caller's set object unless it is actually `None`:

```python
self._allowed_groups = allowed_group_ids if allowed_group_ids is not None else set()
```

This preserves the shared-set identity, so in-place hot-reload updates are visible to the middleware immediately. Behavior for `None` is unchanged.

Verified with `tests/messenger/telegram/test_middleware.py` (60 passed), ruff, and mypy on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
