### PR TITLE
feat(workspace): per-topic project roots as CLI working directory

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -19,6 +19,8 @@
     "reasoning_effort": "medium",
     "file_access": "all",
     "append_system_prompt_files": [],
+    "_comment_project_roots": "Per-topic working dirs. Key: topic name, '<chat_id>:<topic_id>', or '<topic_id>'; value: directory path (~ expanded). Example: {\"my-project\": \"~/code/my-project\"}. Ignored in Docker mode and for named sessions.",
+    "project_roots": {},
     "gemini_api_key": "null",
     "transport": "telegram",
     "transports": ["telegram"],

--- a/ductor_bot/cli/service.py
+++ b/ductor_bot/cli/service.py
@@ -144,6 +144,20 @@ class CLIService:
         self._models = models
         self._available_providers = available_providers
         self._process_registry = process_registry
+        self._working_dir_resolver: Callable[[AgentRequest], str | None] | None = None
+
+    def set_working_dir_resolver(self, resolver: Callable[[AgentRequest], str | None]) -> None:
+        """Register a callback that maps a request to a per-request working dir.
+
+        The resolver returns an absolute path to use as the CLI working
+        directory, or ``None`` to keep the configured default workspace.
+        """
+        self._working_dir_resolver = resolver
+
+    @property
+    def docker_enabled(self) -> bool:
+        """True when CLI calls run inside a Docker container."""
+        return bool(self._config.docker_container)
 
     def update_available_providers(self, providers: frozenset[str]) -> None:
         self._available_providers = providers
@@ -349,10 +363,17 @@ class CLIService:
         # (mirrors model_override or default_model).
         effort = request.effort_override or self._config.reasoning_effort
 
+        # Per-request working dir override (project_roots). Skipped in Docker
+        # mode: docker_wrap maps cwd into the container via relative_to() and
+        # would fail on a path outside the workspace.
+        working_dir = self._config.working_dir
+        if self._working_dir_resolver is not None and not self._config.docker_container:
+            working_dir = self._working_dir_resolver(request) or working_dir
+
         return create_cli(
             CLIConfig(
                 provider=provider,
-                working_dir=self._config.working_dir,
+                working_dir=working_dir,
                 model=model,
                 system_prompt=request.system_prompt,
                 append_system_prompt=request.append_system_prompt,

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -449,6 +449,8 @@ class AgentConfig(BaseModel):
     reasoning_effort: str = "medium"
     file_access: str = "all"
     append_system_prompt_files: list[str] = Field(default_factory=list)
+    # Per-topic project roots: topic name | "<topic_id>" | "<chat_id>:<topic_id>" -> path
+    project_roots: dict[str, str] = Field(default_factory=dict)
     gemini_api_key: str | None = None
     streaming: StreamingConfig = Field(default_factory=StreamingConfig)
     docker: DockerConfig = Field(default_factory=DockerConfig)

--- a/ductor_bot/config_reload.py
+++ b/ductor_bot/config_reload.py
@@ -52,6 +52,7 @@ _HOT_RELOADABLE: frozenset[str] = frozenset(
         "heartbeat",
         "cleanup",
         "cli_parameters",
+        "project_roots",
         "allowed_user_ids",
         "allowed_group_ids",
         "group_mention_only",

--- a/ductor_bot/orchestrator/core.py
+++ b/ductor_bot/orchestrator/core.py
@@ -15,6 +15,7 @@ from ductor_bot.background import (
 from ductor_bot.cli.process_registry import ProcessRegistry
 from ductor_bot.cli.service import CLIService, CLIServiceConfig
 from ductor_bot.cli.stream_events import ToolUseEvent
+from ductor_bot.cli.types import AgentRequest
 from ductor_bot.config import AgentConfig
 from ductor_bot.cron.manager import CronManager
 from ductor_bot.errors import (
@@ -66,6 +67,7 @@ from ductor_bot.session.manager import SessionData
 from ductor_bot.session.named import NamedSessionRegistry
 from ductor_bot.webhook.manager import WebhookManager
 from ductor_bot.workspace.paths import DuctorPaths
+from ductor_bot.workspace.project_roots import resolve_project_root
 
 if TYPE_CHECKING:
     from ductor_bot.background import BackgroundObserver
@@ -167,6 +169,7 @@ class Orchestrator:
             available_providers=frozenset(),
             process_registry=self._process_registry,
         )
+        self._cli_service.set_working_dir_resolver(self._resolve_request_working_dir)
         self._cron_manager = CronManager(jobs_path=paths.cron_jobs_path)
         self._webhook_manager = WebhookManager(hooks_path=paths.webhooks_path)
         self._observers = ObserverManager(config, paths)
@@ -212,6 +215,22 @@ class Orchestrator:
         self._task_hub: TaskHub | None = None  # Set by supervisor or __main__.py
         self._command_registry = CommandRegistry()
         self._register_commands()
+
+    def _resolve_request_working_dir(self, request: AgentRequest) -> str | None:
+        """Map a CLI request to a per-topic project root, if configured.
+
+        Returns ``None`` (keep the default workspace) for named sessions —
+        their resume consistency depends on a stable working dir — and when
+        no ``project_roots`` entry matches the request's topic.
+        """
+        if request.process_label.startswith("ns:"):
+            return None  # named sessions stay in workspace (resume consistency)
+        return resolve_project_root(
+            self._config.project_roots,
+            chat_id=request.chat_id,
+            topic_id=request.topic_id,
+            topic_name=self._sessions.resolve_topic_name(request.chat_id, request.topic_id),
+        )
 
     @property
     def paths(self) -> DuctorPaths:

--- a/ductor_bot/orchestrator/flows.py
+++ b/ductor_bot/orchestrator/flows.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 import signal
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -162,7 +162,28 @@ async def _prepare_normal(
         timeout_seconds=timeout_secs,
         timeout_controller=_make_timeout_controller(orch, "normal"),
     )
+    request = _with_project_cwd_note(orch, request)
     return request, session
+
+
+def _with_project_cwd_note(orch: Orchestrator, request: AgentRequest) -> AgentRequest:
+    """Point the agent back at the shared workspace when a cwd override applies.
+
+    When ``project_roots`` moves the CLI into a project directory, the agent
+    no longer sees ``memory_system/`` and ``tools/`` in its cwd. Append a
+    short note so it knows where the shared workspace lives. No-op when the
+    override does not apply (Docker mode, named sessions, no matching root).
+    """
+    if orch.cli_service.docker_enabled:
+        return request
+    if orch._resolve_request_working_dir(request) is None:
+        return request
+    note = (
+        f"[ductor] Shared workspace (memory_system/, tools/) is at "
+        f"{orch.paths.workspace}; project cwd is intentional."
+    )
+    combined = f"{request.append_system_prompt}\n\n{note}" if request.append_system_prompt else note
+    return replace(request, append_system_prompt=combined)
 
 
 async def _update_session(

--- a/ductor_bot/session/manager.py
+++ b/ductor_bot/session/manager.py
@@ -278,6 +278,15 @@ class SessionManager:
         """Register a callback that resolves ``(chat_id, topic_id)`` to a name."""
         self._topic_name_resolver = resolver
 
+    def resolve_topic_name(self, chat_id: int, topic_id: int | None) -> str | None:
+        """Resolve a topic id to its human-readable name via the registered resolver.
+
+        Returns ``None`` when *topic_id* is ``None`` or no resolver is set.
+        """
+        if topic_id is None or self._topic_name_resolver is None:
+            return None
+        return self._topic_name_resolver(chat_id, topic_id)
+
     def _apply_topic_name(self, session: SessionData) -> bool:
         """Fill ``topic_name`` from the resolver when missing. Returns True if changed."""
         if session.topic_id is None or self._topic_name_resolver is None:

--- a/ductor_bot/workspace/__init__.py
+++ b/ductor_bot/workspace/__init__.py
@@ -15,6 +15,7 @@ from ductor_bot.workspace.loader import read_file as read_file
 from ductor_bot.workspace.loader import read_mainmemory as read_mainmemory
 from ductor_bot.workspace.paths import DuctorPaths as DuctorPaths
 from ductor_bot.workspace.paths import resolve_paths as resolve_paths
+from ductor_bot.workspace.project_roots import resolve_project_root as resolve_project_root
 from ductor_bot.workspace.skill_sync import cleanup_ductor_links as cleanup_ductor_links
 from ductor_bot.workspace.skill_sync import sync_bundled_skills as sync_bundled_skills
 from ductor_bot.workspace.skill_sync import sync_skills as sync_skills
@@ -33,6 +34,7 @@ __all__ = [
     "render_cron_task_claude_md",
     "render_task_description_md",
     "resolve_paths",
+    "resolve_project_root",
     "sync_bundled_skills",
     "sync_rule_files",
     "sync_skills",

--- a/ductor_bot/workspace/project_roots.py
+++ b/ductor_bot/workspace/project_roots.py
@@ -1,0 +1,55 @@
+"""Resolve per-topic project roots to working directories.
+
+The ``project_roots`` config maps a topic to a directory the CLI should run
+in instead of the shared workspace. Keys are matched in priority order:
+
+1. the human-readable topic name (as shown in Telegram),
+2. ``"<chat_id>:<topic_id>"`` — disambiguates equal topic ids across chats,
+3. ``"<topic_id>"`` — plain topic id.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_project_root(
+    roots: dict[str, str],
+    *,
+    chat_id: int,
+    topic_id: int | None,
+    topic_name: str | None,
+) -> str | None:
+    """Return the resolved project root for a topic, or ``None``.
+
+    Candidate keys are tried in priority order: *topic_name*, then
+    ``"{chat_id}:{topic_id}"``, then ``str(topic_id)``. The first key present
+    in *roots* whose path (after ``~`` expansion) is an existing directory
+    wins; its absolute resolved path is returned. A configured path that does
+    not exist logs a warning and the search continues with lower-priority
+    keys.
+
+    Returns ``None`` when *roots* is empty, *topic_id* is ``None`` (general
+    chat / no topic), or no candidate matches an existing directory.
+    """
+    if not roots or topic_id is None:
+        return None
+
+    candidates: list[str] = []
+    if topic_name:
+        candidates.append(topic_name)
+    candidates.append(f"{chat_id}:{topic_id}")
+    candidates.append(str(topic_id))
+
+    for key in candidates:
+        raw = roots.get(key)
+        if raw is None:
+            continue
+        path = Path(raw).expanduser()
+        if path.is_dir():
+            return str(path.resolve())
+        logger.warning("project_roots[%r] points to non-existent directory: %s", key, raw)
+    return None

--- a/tests/cli/test_service.py
+++ b/tests/cli/test_service.py
@@ -21,6 +21,7 @@ def _make_service(**overrides: Any) -> CLIService:
         max_turns=overrides.pop("max_turns", None),
         max_budget_usd=overrides.pop("max_budget_usd", None),
         permission_mode=overrides.pop("permission_mode", "bypassPermissions"),
+        docker_container=overrides.pop("docker_container", ""),
     )
     models = ModelRegistry()
 
@@ -233,3 +234,58 @@ async def test_stream_callbacks_dispatch_tool_event() -> None:
     assert text == ""
     assert result is None
     assert seen == [event]
+
+
+def test_make_cli_uses_working_dir_resolver() -> None:
+    svc = _make_service(working_dir="/default/workspace")
+    svc.set_working_dir_resolver(lambda _req: "/projects/alpha")
+
+    with patch("ductor_bot.cli.service.create_cli") as mock_create:
+        svc._make_cli(AgentRequest(prompt="hi", chat_id=1, topic_id=5))
+
+    cli_config = mock_create.call_args.args[0]
+    assert cli_config.working_dir == "/projects/alpha"
+
+
+def test_make_cli_resolver_none_keeps_default_working_dir() -> None:
+    svc = _make_service(working_dir="/default/workspace")
+    svc.set_working_dir_resolver(lambda _req: None)
+
+    with patch("ductor_bot.cli.service.create_cli") as mock_create:
+        svc._make_cli(AgentRequest(prompt="hi", chat_id=1, topic_id=5))
+
+    cli_config = mock_create.call_args.args[0]
+    assert cli_config.working_dir == "/default/workspace"
+
+
+def test_make_cli_no_resolver_keeps_default_working_dir() -> None:
+    svc = _make_service(working_dir="/default/workspace")
+
+    with patch("ductor_bot.cli.service.create_cli") as mock_create:
+        svc._make_cli(AgentRequest(prompt="hi", chat_id=1))
+
+    cli_config = mock_create.call_args.args[0]
+    assert cli_config.working_dir == "/default/workspace"
+
+
+def test_make_cli_docker_mode_ignores_resolver() -> None:
+    svc = _make_service(working_dir="/default/workspace", docker_container="ductor-sandbox")
+    calls: list[AgentRequest] = []
+
+    def resolver(req: AgentRequest) -> str:
+        calls.append(req)
+        return "/projects/alpha"
+
+    svc.set_working_dir_resolver(resolver)
+
+    with patch("ductor_bot.cli.service.create_cli") as mock_create:
+        svc._make_cli(AgentRequest(prompt="hi", chat_id=1, topic_id=5))
+
+    cli_config = mock_create.call_args.args[0]
+    assert cli_config.working_dir == "/default/workspace"
+    assert calls == []  # resolver must not even be consulted in docker mode
+
+
+def test_docker_enabled_property() -> None:
+    assert _make_service().docker_enabled is False
+    assert _make_service(docker_container="ductor-sandbox").docker_enabled is True

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -83,6 +83,12 @@ class TestClassifyChanges:
         _, restart = classify_changes(changes)
         assert "unknown_future_field" in restart
 
+    def test_project_roots_is_hot_reloadable(self) -> None:
+        changes = {"project_roots": ({}, {"my-project": "~/code/my-project"})}
+        hot, restart = classify_changes(changes)
+        assert hot == {"project_roots": {"my-project": "~/code/my-project"}}
+        assert restart == []
+
 
 class TestConfigReloader:
     def _write_config(self, path: Path, **overrides: Any) -> AgentConfig:
@@ -204,6 +210,23 @@ class TestConfigReloader:
 
         assert cfg.model == "opus"
         assert applied.get("model") == "opus"
+
+    async def test_project_roots_hot_reload(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.json"
+        cfg = self._write_config(config_path)
+
+        applied: dict[str, Any] = {}
+
+        def capture(_config: AgentConfig, hot: dict[str, Any]) -> None:
+            applied.update(hot)
+
+        reloader = ConfigReloader(config_path, cfg, on_hot_reload=capture)
+
+        self._write_config(config_path, project_roots={"my-project": "~/code/my-project"})
+        await reloader._check()
+
+        assert cfg.project_roots == {"my-project": "~/code/my-project"}
+        assert applied.get("project_roots") == {"my-project": "~/code/my-project"}
 
     async def test_same_content_rewrite_no_callback(self, tmp_path: Path) -> None:
         config_path = tmp_path / "config.json"

--- a/tests/workspace/test_project_roots.py
+++ b/tests/workspace/test_project_roots.py
@@ -1,0 +1,99 @@
+"""Tests for per-topic project root resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ductor_bot.workspace.project_roots import resolve_project_root
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_topic_name_has_highest_priority(tmp_path: Path) -> None:
+    by_name = tmp_path / "by-name"
+    by_chat_topic = tmp_path / "by-chat-topic"
+    by_topic = tmp_path / "by-topic"
+    for d in (by_name, by_chat_topic, by_topic):
+        d.mkdir()
+    roots = {
+        "my-project": str(by_name),
+        "100:5": str(by_chat_topic),
+        "5": str(by_topic),
+    }
+    result = resolve_project_root(roots, chat_id=100, topic_id=5, topic_name="my-project")
+    assert result == str(by_name.resolve())
+
+
+def test_chat_topic_key_beats_plain_topic_id(tmp_path: Path) -> None:
+    by_chat_topic = tmp_path / "by-chat-topic"
+    by_topic = tmp_path / "by-topic"
+    by_chat_topic.mkdir()
+    by_topic.mkdir()
+    roots = {"100:5": str(by_chat_topic), "5": str(by_topic)}
+    result = resolve_project_root(roots, chat_id=100, topic_id=5, topic_name=None)
+    assert result == str(by_chat_topic.resolve())
+
+
+def test_plain_topic_id_key(tmp_path: Path) -> None:
+    by_topic = tmp_path / "by-topic"
+    by_topic.mkdir()
+    roots = {"5": str(by_topic)}
+    result = resolve_project_root(roots, chat_id=100, topic_id=5, topic_name=None)
+    assert result == str(by_topic.resolve())
+
+
+def test_tilde_expansion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project = tmp_path / "code" / "proj"
+    project.mkdir(parents=True)
+    roots = {"proj": "~/code/proj"}
+    result = resolve_project_root(roots, chat_id=1, topic_id=7, topic_name="proj")
+    assert result == str(project.resolve())
+
+
+def test_missing_directory_warns_and_falls_back(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    existing = tmp_path / "exists"
+    existing.mkdir()
+    roots = {
+        "my-project": str(tmp_path / "does-not-exist"),
+        "100:5": str(existing),
+    }
+    with caplog.at_level("WARNING", logger="ductor_bot.workspace.project_roots"):
+        result = resolve_project_root(roots, chat_id=100, topic_id=5, topic_name="my-project")
+    assert result == str(existing.resolve())
+    assert any("does-not-exist" in rec.message for rec in caplog.records)
+
+
+def test_all_candidates_missing_returns_none(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    roots = {"5": str(tmp_path / "gone")}
+    with caplog.at_level("WARNING", logger="ductor_bot.workspace.project_roots"):
+        result = resolve_project_root(roots, chat_id=100, topic_id=5, topic_name=None)
+    assert result is None
+    assert any("gone" in rec.message for rec in caplog.records)
+
+
+def test_file_path_is_not_a_directory(tmp_path: Path) -> None:
+    file_path = tmp_path / "not-a-dir.txt"
+    file_path.write_text("hi")
+    roots = {"5": str(file_path)}
+    assert resolve_project_root(roots, chat_id=1, topic_id=5, topic_name=None) is None
+
+
+def test_topic_id_none_returns_none(tmp_path: Path) -> None:
+    roots = {"general": str(tmp_path)}
+    assert resolve_project_root(roots, chat_id=1, topic_id=None, topic_name="general") is None
+
+
+def test_empty_roots_returns_none() -> None:
+    assert resolve_project_root({}, chat_id=1, topic_id=5, topic_name="x") is None
+
+
+def test_no_matching_key_returns_none(tmp_path: Path) -> None:
+    roots = {"other": str(tmp_path)}
+    assert resolve_project_root(roots, chat_id=1, topic_id=5, topic_name="mine") is None


### PR DESCRIPTION
## Use case

Forum topics already give each conversation an isolated CLI context, but every topic shares the same `~/.ductor/workspace` cwd. With Claude Code in particular that leaves a lot on the table: `CLAUDE.md`, `.claude/agents`, `.claude/skills`, and `.mcp.json` all resolve from the CLI's working directory. If a topic *is* a project ("Paper X", "MyProject"), starting the CLI in that project's directory makes the agent pick up the project's own instructions, subagents, skills, and MCP servers with zero extra configuration.

This PR adds an opt-in `project_roots` config map from topic to directory:

```json
"project_roots": {
  "MyProject": "~/projects/my-project",
  "-100123456789:19": "~/projects/my-paper"
}
```

Keys are matched by topic name first, then by `<chat_id>:<topic_id>`, then by bare `<topic_id>`.

## Design highlights

- **Central resolver in `CLIService._make_cli`.** The working-dir override is applied at the single choke point where every CLI instance is built, so `--resume` stays consistent across all paths that spawn a CLI for the same session — normal messages, memory flush, heartbeat, and injection. Resolving anywhere higher up would risk resuming a session from a different cwd than it was created in.
- **Docker guard.** In Docker mode the override is skipped entirely: `docker_wrap` maps cwd into the container via `relative_to()` and would fail on paths outside the workspace.
- **Named sessions excluded.** `ns:`-labelled sessions keep the default workspace so their resume behavior is unchanged.
- **Hot-reloadable.** `project_roots` is listed in `_HOT_RELOADABLE`; config edits apply without a restart. Entries pointing at non-existent directories are skipped with a warning.
- **Zero-cost when unused.** An empty/absent map means the resolver returns `None` for every request — behavior is byte-identical to current main.
- When the override applies, a short system-prompt note points the agent back at the shared workspace (`memory_system/`, `tools/`) so bot-level memory conventions keep working.

## Migration note

Existing sessions in a topic that becomes mapped were created with the old cwd; `--resume` keeps that cwd until the session is reset. Run `/reset` once in each newly mapped topic to start a session in the project root.

## Test coverage

- `tests/workspace/test_project_roots.py` — resolver: key priority, `~` expansion, missing-directory skip.
- `tests/cli/test_service.py` — `_make_cli` override plumbing, Docker guard, no-resolver default.
- `tests/test_config_reload.py` — hot-reload of `project_roots`.

Full suite: 3999 passed; the 21 failures on this machine are identical on current `main` (pre-existing, environment-specific `tests/workspace/test_init.py` et al.), none introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
