### PR TITLE
fix(model): persist topic reasoning-effort for same-model change without an active session

### DIFF
--- a/ductor_bot/orchestrator/selectors/model_selector.py
+++ b/ductor_bot/orchestrator/selectors/model_selector.py
@@ -391,9 +391,17 @@ async def _persist_switch_target(
                 model=ctx.model_id,
                 reasoning_effort=effort,
             )
-    elif ctx.is_topic and active_session is not None and effort is not None:
+    elif ctx.is_topic and effort is not None:
         # effort-only change inside a topic: persist to the topic session only.
-        await orch._sessions.sync_session_target(active_session, reasoning_effort=effort)
+        if active_session is not None:
+            await orch._sessions.sync_session_target(active_session, reasoning_effort=effort)
+        else:
+            await orch._sessions.resolve_session_target(
+                key,
+                provider=ctx.new_provider,
+                model=ctx.model_id,
+                reasoning_effort=effort,
+            )
 
     return _resume_state_for_provider(resume_source, ctx.new_provider)
 

--- a/tests/orchestrator/test_model_selector.py
+++ b/tests/orchestrator/test_model_selector.py
@@ -357,6 +357,45 @@ async def test_callback_reasoning_topic_without_session_targets_next_message(
     assert request.provider_override == "codex"
 
 
+async def test_callback_reasoning_same_model_topic_without_session_persists_effort(
+    orch: Orchestrator,
+) -> None:
+    orch._config.model = "opus"
+    orch._config.provider = "claude"
+    orch._config.reasoning_effort = "medium"
+    main = SessionKey(chat_id=-100)
+    await orch._sessions.resolve_session(
+        main,
+        provider="claude",
+        model="opus",
+        reasoning_effort="medium",
+    )
+    key = SessionKey(chat_id=-100, topic_id=44)
+    mock_execute = AsyncMock(
+        return_value=AgentResponse(result="ok", session_id="claude-topic-session")
+    )
+    object.__setattr__(orch._cli_service, "execute", mock_execute)
+
+    await handle_model_callback(orch, key, "ms:r:xhigh:opus")
+
+    topic = await orch._sessions.get_active(key)
+    assert topic is not None
+    assert topic.model == "opus"
+    assert topic.reasoning_effort == "xhigh"
+    assert orch._config.model == "opus"
+    assert orch._config.reasoning_effort == "medium"
+    main_after = await orch._sessions.get_active(main)
+    assert main_after is not None
+    assert main_after.reasoning_effort == "medium"
+
+    await normal(orch, key, "hello", model_override=None)
+
+    request = mock_execute.call_args.args[0]
+    assert request.model_override == "opus"
+    assert request.provider_override == "claude"
+    assert request.effort_override == "xhigh"
+
+
 async def test_callback_reasoning_stale_topic_targets_next_message(orch: Orchestrator) -> None:
     key = SessionKey(chat_id=-100, topic_id=43)
     orch._config.max_session_messages = 1


### PR DESCRIPTION
## Problem
When a topic has no active session yet and the user picks the **same model** as the configured default while changing **only the reasoning effort** (e.g. `opus/medium` → `opus/xhigh`) via the `/model` wizard, the chosen effort is silently dropped. `_persist_switch_target` only handled the same-model effort case when an active session already existed, so the first message created a fresh session at the config default instead of the picked effort.

## Fix
In `_persist_switch_target`, the same-model + topic + effort-only branch now also creates the session when none exists yet (via `resolve_session_target`), mirroring the existing different-model topic path. It never touches the global config default, and DM effort stays independent of topic effort.

## Tests
Added a regression test for the same-model + no-session topic case (the existing test only covered the different-model path).
