### PR TITLE
feat: add Grok Build (xAI grok CLI) provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@ This file gives coding agents a current map of the repository.
 
 ## Project Overview
 
-ductor is a multi-transport chat orchestrator for the official provider CLIs (`claude`, `codex`, `gemini`, `agy`).
+ductor is a multi-transport chat orchestrator for the official provider CLIs (`claude`, `codex`, `gemini`, `agy`, `grok`).
 It runs Telegram and/or Matrix, can expose an optional direct WebSocket API, keeps state under `~/.ductor`, and supervises the main agent plus optional sub-agents in one asyncio process.
 
 Stack:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@ This file gives coding agents a current map of the repository.
 
 ## Project Overview
 
-ductor is a multi-transport chat orchestrator for the official provider CLIs (`claude`, `codex`, `gemini`, `agy`).
+ductor is a multi-transport chat orchestrator for the official provider CLIs (`claude`, `codex`, `gemini`, `agy`, `grok`).
 It runs Telegram, Matrix and/or Slack, can expose an optional direct WebSocket API, keeps state under `~/.ductor`, and supervises the main agent plus optional sub-agents in one asyncio process.
 
 Stack:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>Claude Code, Codex CLI, Gemini CLI, and Antigravity CLI as your coding assistant — on Telegram, Matrix, and Slack.</strong><br>
+  <strong>Claude Code, Codex CLI, Gemini CLI, Antigravity CLI, and Grok Build as your coding assistant — on Telegram, Matrix, and Slack.</strong><br>
   Uses only official CLIs. Nothing spoofed, nothing proxied. Multi-transport, automation, and sub-agents in one runtime.
 </p>
 
@@ -23,7 +23,7 @@
 
 ---
 
-If you want to control Claude Code, Google's Gemini CLI, OpenAI's Codex CLI, or Antigravity CLI via Telegram, Matrix, or Slack, build automations, or manage multiple agents easily — ductor is the right tool for you. The messaging layer is modular: Telegram, Matrix, and Slack ship today, and new transports plug into the same transport-agnostic core.
+If you want to control Claude Code, Google's Gemini CLI, OpenAI's Codex CLI, Antigravity CLI, or xAI Grok Build via Telegram, Matrix, or Slack, build automations, or manage multiple agents easily — ductor is the right tool for you. The messaging layer is modular: Telegram, Matrix, and Slack ship today, and new transports plug into the same transport-agnostic core.
 
 ductor runs on your machine and sends simple console commands as if you were typing them yourself, so you can use your active subscriptions (Claude Max, Google AI Ultra, etc.) directly. No API proxying, no SDK patching, no spoofed headers. Just the official CLIs, executed as subprocesses, with all state kept in plain JSON and Markdown under `~/.ductor/`.
 

--- a/config.example.json
+++ b/config.example.json
@@ -112,7 +112,8 @@
         "claude": ["--verbose", "--chrome"],
         "codex": [],
         "gemini": [],
-        "antigravity": []
+        "antigravity": [],
+        "grok": []
     },
     "image": {"max_dimension": 2000, "output_format": "webp", "quality": 85},
     "scene": {"seen_reaction": false, "status_reaction": true, "technical_footer": false},

--- a/docs/modules/cli.md
+++ b/docs/modules/cli.md
@@ -1,12 +1,12 @@
 # cli/
 
-Provider-agnostic CLI execution layer for Claude Code, Codex, Gemini, and Antigravity.
+Provider-agnostic CLI execution layer for Claude Code, Codex, Gemini, Antigravity, and Grok Build.
 
 ## Files
 
 - `types.py`: `AgentRequest`, `AgentResponse`, `CLIResponse`
 - `base.py`: `BaseCLI`, `CLIConfig`, `docker_wrap()`, Windows helpers
-- `factory.py`: provider factory (`claude` / `codex` / `gemini` / `antigravity`)
+- `factory.py`: provider factory (`claude` / `codex` / `gemini` / `antigravity` / `grok`)
 - `service.py`: `CLIService` gateway for orchestrator
 - `init_wizard.py`: interactive onboarding and smart reset flow
 - `executor.py`: shared subprocess lifecycle helpers for provider wrappers
@@ -16,10 +16,12 @@ Provider-agnostic CLI execution layer for Claude Code, Codex, Gemini, and Antigr
 - `codex_provider.py`: Codex subprocess wrapper
 - `gemini_provider.py`: Gemini subprocess wrapper
 - `antigravity_provider.py`: Antigravity (`agy`) subprocess wrapper — always runs on the host, even with the Docker sandbox enabled (the sandbox image ships no `agy` binary or auth state). `agy` has no headless streaming mode (`--print` is one-shot; `--prompt-interactive` needs a TTY), so `send_streaming` reuses the `--print` path. Because `agy --print` silently drops stdout in non-TTY subprocesses (upstream bug `google-antigravity/antigravity-cli#76`), the answer is read back from agy's own transcript (`<home>/.gemini/antigravity-cli/brain/<conv-id>/.system_generated/logs/transcript.jsonl`, the final `PLANNER_RESPONSE` entry — clean, without tool-call narration), with stdout as fallback. `--print <prompt>` is placed last and adjacent (it consumes the next token as its prompt value), and agy is grounded in the per-agent workspace via `--add-dir`
+- `grok_provider.py`: Grok Build (`grok`) headless wrapper — oneshot `--output-format json`, streaming `streaming-json`, session `--resume`/`--continue`, long prompts via `--prompt-file`, tool filter via `--tools`/`--disallowed-tools`
 - `stream_events.py`: normalized stream events + Claude stream parser
 - `codex_events.py`: Codex JSONL parser
 - `gemini_events.py`: Gemini NDJSON + JSON parser
 - `antigravity_events.py`: Antigravity `--print` output parser (`parse_antigravity_json`)
+- `grok_events.py`: Grok JSON / streaming-json parser (text, thought, tool, error, auto_compact_*, end)
 - `coalescer.py`: streaming text coalescing buffer used by bot streaming dispatch
 - `gemini_utils.py`: Gemini CLI discovery, trusted folder, model discovery helpers
 - `codex_discovery.py`: Codex model discovery via `codex app-server` JSON-RPC
@@ -67,6 +69,7 @@ Configured globally in `config.json`:
 - `cli_parameters.codex`
 - `cli_parameters.gemini`
 - `cli_parameters.antigravity`
+- `cli_parameters.grok`
 
 `CLIService` forwards them per provider.
 
@@ -76,12 +79,13 @@ Used by cron and webhook `cron_task` runs.
 
 - input: `TaskOverrides(provider, model, reasoning_effort, cli_parameters)`
 - output: immutable `TaskExecutionConfig`
-- supported one-shot providers: `claude`, `codex`, `gemini`
+- supported one-shot providers: `claude`, `codex`, `gemini`, `grok`
 - validation:
   - Claude model in `CLAUDE_MODELS`
   - Codex model validated against `CodexModelCache`
   - Gemini model validated against aliases/discovered IDs or `gemini-*` patterns
-- Codex reasoning effort applied only when supported by model
+  - Grok model in `GROK_MODELS` or `grok-*` prefix
+- Codex / Claude / Grok reasoning effort applied only when supported by model
 - task `cli_parameters` are appended after the global provider-specific args
 
 ## Streaming model
@@ -152,6 +156,20 @@ Recovery triggers handled in orchestrator flows:
 - trusts workspace path in `~/.gemini/trustedFolders.json`
 - may inject `GEMINI_API_KEY` from ductor config when Gemini settings indicate API-key mode and no env key is set
 
+### Grok Build
+
+- binary `grok` (install: `curl -fsSL https://x.ai/cli/install.sh | bash`)
+- non-streaming `--output-format json`, streaming `--output-format streaming-json`
+- permission: `--permission-mode` plus `--always-approve` when `bypassPermissions`
+- system prompt: `--system-prompt-override` / rules: `--rules`
+- tool filter: `--tools` / `--disallowed-tools` (comma-separated built-in IDs; not permission globs)
+- long prompts: `--prompt-file` (chat path and cron path)
+- stream maps `error` → terminal error `ResultEvent`, `auto_compact_*` → `CompactBoundaryEvent` (memory flush)
+- spend: prefers `usage.total_tokens` and maps `total_cost_usd` into `CLIResponse`
+- models: discovered via `grok models` into `grok_models.json` (hourly refresh);
+  fallback `grok-4.5` / `grok-composer-2.5-fast`; any `grok-*` ID still routes
+- efforts: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`
+
 ## Auth detection (`auth.py`)
 
 Statuses: `AUTHENTICATED`, `INSTALLED`, `NOT_FOUND`.
@@ -166,6 +184,7 @@ Statuses: `AUTHENTICATED`, `INSTALLED`, `NOT_FOUND`.
   - env/.env/API-key/Vertex markers
   - `settings.json` selected auth mode
   - optional fallback to `~/.ductor/config/config.json` `gemini_api_key`
+- Grok: `~/.grok/auth.json`, then `XAI_API_KEY`, then `grok models` probe; install markers: binary or `config.toml`
 
 ## Model caches
 
@@ -193,6 +212,15 @@ Statuses: `AUTHENTICATED`, `INSTALLED`, `NOT_FOUND`.
 - the Telegram model selector currently offers only `antigravity-default` and
   explains that `agy` model selection is not reliable there; discovered names
   remain available for directive/API provider metadata.
+
+### Grok cache
+
+- file: `~/.ductor/config/grok_models.json` (per-agent home, e.g. `~/.ductor-cto/config/`)
+- discovery source: `discover_grok_models()` (`grok_discovery.py`) via `grok models`
+- loaded on startup (uses cache when fresh, refreshes when stale/missing)
+- hourly refresh loop
+- refresh callback updates runtime Grok model registry (`set_grok_models`)
+- Telegram model selector shows discovery-ordered IDs via `get_grok_models_ordered()`
 
 ## Process registry
 

--- a/ductor_bot/_home_defaults/workspace/tools/agent_tools/create_agent.py
+++ b/ductor_bot/_home_defaults/workspace/tools/agent_tools/create_agent.py
@@ -43,6 +43,7 @@ def _agents_path() -> Path:
 
 
 _CLAUDE_MODELS = ("haiku", "sonnet", "sonnet[1m]", "opus", "opus[1m]", "fable")
+_GROK_MODELS = ("grok-4.5", "grok-composer-2.5-fast")
 
 
 def _main_home() -> Path:
@@ -121,6 +122,12 @@ def _resolve_model(provider: str | None, model: str | None) -> str | None:
 
     if provider == "gemini":
         return _resolve_gemini_model(model, home)
+
+    if provider == "grok":
+        if model in _GROK_MODELS or model.startswith("grok-"):
+            return model
+        print(f"Note: '{model}' is not a valid Grok model. Using: grok-4.5")
+        return "grok-4.5"
 
     return model
 

--- a/ductor_bot/_home_defaults/workspace/tools/cron_tools/cron_add.py
+++ b/ductor_bot/_home_defaults/workspace/tools/cron_tools/cron_add.py
@@ -215,7 +215,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--provider",
-        choices=["claude", "codex", "gemini"],
+        choices=["claude", "codex", "gemini", "grok"],
         help=(
             "CLI provider for this job (claude, codex, or gemini). If omitted, uses global config."
         ),

--- a/ductor_bot/_home_defaults/workspace/tools/cron_tools/cron_edit.py
+++ b/ductor_bot/_home_defaults/workspace/tools/cron_tools/cron_edit.py
@@ -96,7 +96,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--timezone", help="IANA timezone for this job (e.g. 'Europe/Berlin')")
     parser.add_argument(
         "--provider",
-        choices=["claude", "codex", "gemini"],
+        choices=["claude", "codex", "gemini", "grok"],
         help="Provider override for this job.",
     )
     parser.add_argument(

--- a/ductor_bot/_home_defaults/workspace/tools/webhook_tools/webhook_add.py
+++ b/ductor_bot/_home_defaults/workspace/tools/webhook_tools/webhook_add.py
@@ -232,7 +232,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--provider",
-        choices=["claude", "codex", "gemini"],
+        choices=["claude", "codex", "gemini", "grok"],
         help=(
             "CLI provider for this webhook (claude, codex, or gemini). "
             "If omitted, uses global config."

--- a/ductor_bot/_home_defaults/workspace/tools/webhook_tools/webhook_edit.py
+++ b/ductor_bot/_home_defaults/workspace/tools/webhook_tools/webhook_edit.py
@@ -85,7 +85,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--provider",
-        choices=["claude", "codex", "gemini"],
+        choices=["claude", "codex", "gemini", "grok"],
         help="Change CLI provider (claude, codex, or gemini)",
     )
     parser.add_argument(

--- a/ductor_bot/cli/auth.py
+++ b/ductor_bot/cli/auth.py
@@ -449,11 +449,74 @@ def check_antigravity_auth() -> AuthResult:
     return AuthResult(provider="antigravity", status=AuthStatus.NOT_FOUND)
 
 
+def check_grok_auth() -> AuthResult:
+    """Check Grok Build CLI auth via ``~/.grok/auth.json``, env key, or CLI probe."""
+    try:
+        default_home = str(Path.home() / ".grok")
+    except (RuntimeError, OSError):
+        logger.debug("Grok auth: home directory unresolvable; treating as NOT_FOUND")
+        return AuthResult("grok", AuthStatus.NOT_FOUND)
+
+    grok_home = Path(os.environ.get("GROK_HOME", default_home))
+    auth_file = grok_home / "auth.json"
+    binary = shutil.which("grok")
+
+    if auth_file.is_file() and auth_file.stat().st_size > 0:
+        mtime = datetime.fromtimestamp(auth_file.stat().st_mtime, tz=UTC)
+        result = AuthResult("grok", AuthStatus.AUTHENTICATED, auth_file, mtime)
+        logger.debug("Auth check provider=%s status=%s", result.provider, result.status)
+        return result
+
+    if _has_nonempty_env("XAI_API_KEY"):
+        result = AuthResult("grok", AuthStatus.AUTHENTICATED)
+        logger.debug("Auth check provider=%s status=%s (env key)", result.provider, result.status)
+        return result
+
+    if binary is not None and _grok_cli_logged_in(binary):
+        result = AuthResult("grok", AuthStatus.AUTHENTICATED)
+        logger.debug("Auth check provider=%s status=%s (cli)", result.provider, result.status)
+        return result
+
+    if binary is not None or (grok_home / "config.toml").is_file():
+        result = AuthResult("grok", AuthStatus.INSTALLED)
+        logger.debug("Auth check provider=%s status=%s", result.provider, result.status)
+        return result
+
+    result = AuthResult("grok", AuthStatus.NOT_FOUND)
+    logger.debug("Auth check provider=%s status=%s", result.provider, result.status)
+    return result
+
+
+def _grok_cli_logged_in(binary: str) -> bool:
+    """Run ``grok models`` and return True when the CLI reports an authenticated account."""
+    try:
+        proc = subprocess.run(
+            [binary, "models"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+            creationflags=_CREATION_FLAGS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("Grok CLI auth probe failed: %s", exc)
+        return False
+
+    output = f"{proc.stdout}\n{proc.stderr}".lower()
+    if any(
+        token in output
+        for token in ("not logged in", "sign in", "login required", "unauthorized", "run `grok login`")
+    ):
+        return False
+    return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
 _CHECKERS: dict[str, Callable[[], AuthResult]] = {
     "claude": check_claude_auth,
     "codex": check_codex_auth,
     "gemini": check_gemini_auth,
     "antigravity": check_antigravity_auth,
+    "grok": check_grok_auth,
 }
 
 

--- a/ductor_bot/cli/factory.py
+++ b/ductor_bot/cli/factory.py
@@ -27,6 +27,11 @@ def create_cli(config: CLIConfig) -> BaseCLI:
 
         return AntigravityCLI(config)
 
+    if config.provider == "grok":
+        from ductor_bot.cli.grok_provider import GrokCLI
+
+        return GrokCLI(config)
+
     from ductor_bot.cli.claude_provider import ClaudeCodeCLI
 
     return ClaudeCodeCLI(config)

--- a/ductor_bot/cli/grok_cache.py
+++ b/ductor_bot/cli/grok_cache.py
@@ -1,0 +1,56 @@
+"""Persistent cache for Grok Build models with periodic refresh."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Self
+
+from ductor_bot.cli.grok_discovery import discover_grok_models
+from ductor_bot.cli.model_cache import BaseModelCache
+from ductor_bot.config import GROK_MODELS_ORDERED
+
+# Hardcoded fallback when discovery and disk cache both fail.
+_FALLBACK_GROK_MODELS: tuple[str, ...] = GROK_MODELS_ORDERED
+
+
+@dataclass(frozen=True)
+class GrokModelCache(BaseModelCache):
+    """Immutable cache of Grok Build model IDs with refresh logic."""
+
+    last_updated: str  # ISO 8601 timestamp
+    models: tuple[str, ...]
+
+    @classmethod
+    def _provider_name(cls) -> str:
+        return "Grok"
+
+    @classmethod
+    async def _discover(cls) -> tuple[str, ...]:
+        return await discover_grok_models()
+
+    @classmethod
+    def _empty_models(cls) -> tuple[str, ...]:
+        return ()
+
+    @classmethod
+    def _fallback_models(cls) -> tuple[str, ...]:
+        return _FALLBACK_GROK_MODELS
+
+    def validate_model(self, model_id: str) -> bool:
+        """Check if model exists in cache (or is a grok-* ID)."""
+        return model_id in self.models or model_id.startswith("grok-")
+
+    def to_json(self) -> dict[str, Any]:
+        """Serialize for persistence."""
+        return {
+            "last_updated": self.last_updated,
+            "models": list(self.models),
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        """Deserialize from JSON."""
+        return cls(
+            last_updated=data["last_updated"],
+            models=tuple(data["models"]),
+        )

--- a/ductor_bot/cli/grok_cache_observer.py
+++ b/ductor_bot/cli/grok_cache_observer.py
@@ -1,0 +1,54 @@
+"""Background observer for periodic Grok Build model cache refresh."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from ductor_bot.cli.grok_cache import GrokModelCache
+from ductor_bot.cli.model_cache import BaseModelCacheObserver
+
+
+class GrokCacheObserver(BaseModelCacheObserver):
+    """Refreshes Grok Build model cache periodically.
+
+    Loads initial cache at startup and refreshes every 60 minutes.
+    """
+
+    def __init__(
+        self,
+        cache_path: Path,
+        *,
+        on_refresh: Callable[[tuple[str, ...]], None] | None = None,
+    ) -> None:
+        """Initialize observer with cache file path.
+
+        Args:
+            cache_path: Path to JSON cache file.
+            on_refresh: Optional callback invoked with the model list after
+                        each successful cache load/refresh.
+        """
+        super().__init__(cache_path)
+        self._on_refresh = on_refresh
+        self._cache: GrokModelCache | None = None
+
+    def _provider_name(self) -> str:
+        return "Grok"
+
+    async def _load_cache(self, *, initial: bool) -> GrokModelCache:
+        return await GrokModelCache.load_or_refresh(self._cache_path, force_refresh=initial)
+
+    def _model_count(self) -> int:
+        return len(self._cache.models) if self._cache else 0
+
+    def _last_updated(self) -> str:
+        return self._cache.last_updated if self._cache else ""
+
+    def _on_cache_loaded(self) -> None:
+        """Invoke on_refresh callback if set."""
+        if self._on_refresh and self._cache and self._cache.models:
+            self._on_refresh(self._cache.models)
+
+    def get_cache(self) -> GrokModelCache | None:
+        """Return current cache (may be None if never loaded)."""
+        return self._cache

--- a/ductor_bot/cli/grok_discovery.py
+++ b/ductor_bot/cli/grok_discovery.py
@@ -1,0 +1,126 @@
+"""Model discovery for the xAI Grok Build CLI (``grok models``)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from shutil import which
+
+from ductor_bot.infra.platform import CREATION_FLAGS as _CREATION_FLAGS
+from ductor_bot.infra.process_tree import force_kill_process_tree
+
+logger = logging.getLogger(__name__)
+
+_DISCOVERY_TIMEOUT = 15.0
+
+# Lines under "Available models:" look like:
+#   * grok-4.5 (default)
+#   - grok-composer-2.5-fast
+_MODEL_BULLET = re.compile(r"^\s*[\*\-•]\s+(\S+)")
+_DEFAULT_LINE = re.compile(r"(?i)^\s*Default model:\s*(\S+)")
+
+
+async def discover_grok_models() -> tuple[str, ...]:
+    """Return model IDs reported by ``grok models``.
+
+    Returns an empty tuple when the CLI is missing, unauthenticated, times out,
+    or errors — callers then fall back to the cached or hardcoded list.
+    """
+    binary = which("grok")
+    if not binary:
+        logger.debug("grok not available for model discovery")
+        return ()
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            "models",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            creationflags=_CREATION_FLAGS,
+        )
+    except (OSError, ValueError):
+        logger.debug("grok models spawn failed", exc_info=True)
+        return ()
+
+    try:
+        async with asyncio.timeout(_DISCOVERY_TIMEOUT):
+            stdout_bytes, stderr_bytes = await proc.communicate()
+    except TimeoutError:
+        logger.warning("grok models discovery timed out")
+        force_kill_process_tree(proc.pid)
+        await proc.communicate()
+        return ()
+
+    output = stdout_bytes.decode(errors="replace")
+    stderr = stderr_bytes.decode(errors="replace") if stderr_bytes else ""
+    combined = f"{output}\n{stderr}".lower()
+    if any(
+        token in combined
+        for token in (
+            "not logged in",
+            "sign in",
+            "login required",
+            "unauthorized",
+            "run `grok login`",
+        )
+    ):
+        logger.debug("grok models: not authenticated")
+        return ()
+
+    if proc.returncode not in (0, None):
+        logger.debug("grok models exited with code %s", proc.returncode)
+        return ()
+
+    return _parse_models(output)
+
+
+def _parse_models(output: str) -> tuple[str, ...]:
+    """Parse ``grok models`` stdout into an ordered tuple of model IDs.
+
+    Bullet lines under Available models take precedence. If none are found,
+    fall back to a ``Default model:`` line so a single-model install still
+    populates the cache.
+    """
+    models: list[str] = []
+    seen: set[str] = set()
+    default_model: str | None = None
+
+    for raw in output.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith(("Usage:", "Flags:", "Available subcommands:")):
+            return ()
+
+        default_match = _DEFAULT_LINE.match(line)
+        if default_match:
+            default_model = _normalize_model_id(default_match.group(1))
+            continue
+
+        bullet = _MODEL_BULLET.match(line)
+        if not bullet:
+            continue
+        model_id = _normalize_model_id(bullet.group(1))
+        if not model_id or model_id in seen:
+            continue
+        seen.add(model_id)
+        models.append(model_id)
+
+    if models:
+        return tuple(models)
+
+    if default_model:
+        return (default_model,)
+
+    return ()
+
+
+def _normalize_model_id(raw: str) -> str:
+    """Strip decoration such as trailing ``(default)`` from a model token."""
+    token = raw.strip().strip(",")
+    # Drop parenthetical suffix glued without space: rare, keep first token only.
+    if "(" in token:
+        token = token.split("(", 1)[0].strip()
+    return token

--- a/ductor_bot/cli/grok_events.py
+++ b/ductor_bot/cli/grok_events.py
@@ -1,0 +1,177 @@
+"""JSON / streaming-json parsers for the xAI Grok Build CLI (`grok`).
+
+Headless JSON (``--output-format json``) returns one object::
+
+    {
+      "text": "...",
+      "stopReason": "EndTurn",
+      "sessionId": "...",
+      "usage": {...},
+      "num_turns": 1,
+      "modelUsage": {...}
+    }
+
+Streaming JSON (``--output-format streaming-json``) is NDJSON::
+
+    {"type":"thought","data":"..."}
+    {"type":"text","data":"..."}
+    {"type":"end","stopReason":"...","sessionId":"...","usage":{...}, ...}
+
+Optional tool events (when present) use::
+
+    {"type":"tool_use"|"tool","name":"...","id":"...","input":{...}}
+    {"type":"tool_result","id":"...","status":"...","output":"..."}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from ductor_bot.cli.stream_events import (
+    AssistantTextDelta,
+    ResultEvent,
+    StreamEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolUseEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+# stopReason values treated as successful completion.
+_OK_STOP_REASONS = frozenset({"EndTurn", "end_turn", "stop", "Stop", "completed", "Completed"})
+
+
+def parse_grok_json(raw: str) -> tuple[str, str | None, dict[str, Any], dict[str, Any], int | None, bool]:
+    """Parse oneshot Grok JSON into (text, session_id, usage, model_usage, num_turns, is_error)."""
+    stripped = raw.strip()
+    if not stripped:
+        return "", None, {}, {}, None, True
+
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        logger.debug("Grok: unparseable JSON envelope, treating as plain text")
+        return stripped, None, {}, {}, None, False
+
+    if not isinstance(data, dict):
+        return str(data), None, {}, {}, None, False
+
+    text = _as_str(data.get("text") or data.get("result") or data.get("content") or "")
+    session_id = _as_str(data.get("sessionId") or data.get("session_id") or "") or None
+    usage: dict[str, Any] = data["usage"] if isinstance(data.get("usage"), dict) else {}
+    model_usage: dict[str, Any] = (
+        data["modelUsage"] if isinstance(data.get("modelUsage"), dict) else {}
+    )
+    if not model_usage and isinstance(data.get("model_usage"), dict):
+        model_usage = data["model_usage"]
+    num_turns = data.get("num_turns")
+    if not isinstance(num_turns, int):
+        num_turns = None
+    is_error = _is_error_payload(data, text)
+    return text, session_id, usage, model_usage, num_turns, is_error
+
+
+def parse_grok_stream_line(line: str) -> list[StreamEvent]:
+    """Parse a single Grok streaming-json NDJSON line into stream events."""
+    stripped = line.strip()
+    if not stripped:
+        return []
+
+    try:
+        data: dict[str, Any] = json.loads(stripped)
+    except json.JSONDecodeError:
+        logger.debug("Grok: unparseable stream line: %.200s", stripped)
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    event_type = str(data.get("type", "")).lower()
+
+    if event_type in {"thought", "thinking", "reasoning"}:
+        text = _as_str(data.get("data") or data.get("text") or data.get("content") or "")
+        return [ThinkingEvent(type="assistant", text=text)] if text else []
+
+    if event_type in {"text", "assistant", "message", "agent_message"}:
+        text = _as_str(data.get("data") or data.get("text") or data.get("content") or "")
+        return [AssistantTextDelta(type="assistant", text=text)] if text else []
+
+    if event_type in {"tool_use", "tool", "tool_call"}:
+        name = _as_str(data.get("name") or data.get("tool_name") or data.get("tool") or "tool")
+        tool_id = _as_str(data.get("id") or data.get("tool_id") or "") or None
+        params = data.get("input") or data.get("parameters") or data.get("arguments")
+        if not isinstance(params, dict):
+            params = None
+        return [
+            ToolUseEvent(
+                type="assistant",
+                tool_name=name,
+                tool_id=tool_id,
+                parameters=params,
+            )
+        ]
+
+    if event_type in {"tool_result", "tool_output"}:
+        return [
+            ToolResultEvent(
+                type="tool_result",
+                tool_id=_as_str(data.get("id") or data.get("tool_id") or ""),
+                status=_as_str(data.get("status") or ""),
+                output=_as_str(data.get("output") or data.get("data") or data.get("content") or ""),
+            )
+        ]
+
+    if event_type in {"end", "result", "done", "final"}:
+        session_id = _as_str(data.get("sessionId") or data.get("session_id") or "") or None
+        usage_end: dict[str, Any] = data["usage"] if isinstance(data.get("usage"), dict) else {}
+        model_usage_end: dict[str, Any] = (
+            data["modelUsage"] if isinstance(data.get("modelUsage"), dict) else {}
+        )
+        if not model_usage_end and isinstance(data.get("model_usage"), dict):
+            model_usage_end = data["model_usage"]
+        result_text = _as_str(data.get("text") or data.get("result") or data.get("data") or "")
+        num_turns = data.get("num_turns")
+        if not isinstance(num_turns, int):
+            num_turns = None
+        is_error = _is_error_payload(data, result_text)
+        events: list[StreamEvent] = [
+            ResultEvent(
+                type="result",
+                session_id=session_id,
+                result=result_text,
+                is_error=is_error,
+                usage=usage_end,
+                model_usage=model_usage_end,
+                num_turns=num_turns,
+            )
+        ]
+        return events
+
+    # Unknown event type — ignore quietly.
+    logger.debug("Grok: ignoring stream event type=%s", event_type)
+    return []
+
+
+def _is_error_payload(data: dict[str, Any], text: str) -> bool:
+    if data.get("is_error") is True or data.get("isError") is True:
+        return True
+    if data.get("error"):
+        return True
+    stop = data.get("stopReason") or data.get("stop_reason") or ""
+    if isinstance(stop, str) and stop and stop not in _OK_STOP_REASONS:
+        # Refusal / cancelled / error style stop reasons.
+        lowered = stop.lower()
+        if any(tok in lowered for tok in ("error", "fail", "cancel", "refus", "abort")):
+            return True
+    return False
+
+
+def _as_str(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/ductor_bot/cli/grok_events.py
+++ b/ductor_bot/cli/grok_events.py
@@ -8,13 +8,16 @@ Headless JSON (``--output-format json``) returns one object::
       "sessionId": "...",
       "usage": {...},
       "num_turns": 1,
-      "modelUsage": {...}
+      "modelUsage": {...},
+      "total_cost_usd": 0.01
     }
 
 Streaming JSON (``--output-format streaming-json``) is NDJSON::
 
     {"type":"thought","data":"..."}
     {"type":"text","data":"..."}
+    {"type":"error","message":"..."}
+    {"type":"auto_compact_start", ...}
     {"type":"end","stopReason":"...","sessionId":"...","usage":{...}, ...}
 
 Optional tool events (when present) use::
@@ -31,8 +34,10 @@ from typing import Any
 
 from ductor_bot.cli.stream_events import (
     AssistantTextDelta,
+    CompactBoundaryEvent,
     ResultEvent,
     StreamEvent,
+    SystemStatusEvent,
     ThinkingEvent,
     ToolResultEvent,
     ToolUseEvent,
@@ -44,34 +49,41 @@ logger = logging.getLogger(__name__)
 _OK_STOP_REASONS = frozenset({"EndTurn", "end_turn", "stop", "Stop", "completed", "Completed"})
 
 
-def parse_grok_json(raw: str) -> tuple[str, str | None, dict[str, Any], dict[str, Any], int | None, bool]:
-    """Parse oneshot Grok JSON into (text, session_id, usage, model_usage, num_turns, is_error)."""
+def parse_grok_json(
+    raw: str,
+) -> tuple[str, str | None, dict[str, Any], dict[str, Any], int | None, bool, float | None]:
+    """Parse oneshot Grok JSON.
+
+    Returns:
+        (text, session_id, usage, model_usage, num_turns, is_error, total_cost_usd)
+    """
     stripped = raw.strip()
     if not stripped:
-        return "", None, {}, {}, None, True
+        return "", None, {}, {}, None, True, None
 
     try:
         data = json.loads(stripped)
     except json.JSONDecodeError:
         logger.debug("Grok: unparseable JSON envelope, treating as plain text")
-        return stripped, None, {}, {}, None, False
+        return stripped, None, {}, {}, None, False, None
 
     if not isinstance(data, dict):
-        return str(data), None, {}, {}, None, False
+        return str(data), None, {}, {}, None, False, None
+
+    # Streaming-style error envelope leaked into oneshot stdout.
+    if str(data.get("type", "")).lower() == "error":
+        msg = _as_str(data.get("message") or data.get("error") or data.get("text") or raw)
+        usage_err, model_usage_err, cost_err = _extract_spend(data)
+        return msg, None, usage_err, model_usage_err, None, True, cost_err
 
     text = _as_str(data.get("text") or data.get("result") or data.get("content") or "")
     session_id = _as_str(data.get("sessionId") or data.get("session_id") or "") or None
-    usage: dict[str, Any] = data["usage"] if isinstance(data.get("usage"), dict) else {}
-    model_usage: dict[str, Any] = (
-        data["modelUsage"] if isinstance(data.get("modelUsage"), dict) else {}
-    )
-    if not model_usage and isinstance(data.get("model_usage"), dict):
-        model_usage = data["model_usage"]
+    usage, model_usage, total_cost = _extract_spend(data)
     num_turns = data.get("num_turns")
     if not isinstance(num_turns, int):
         num_turns = None
     is_error = _is_error_payload(data, text)
-    return text, session_id, usage, model_usage, num_turns, is_error
+    return text, session_id, usage, model_usage, num_turns, is_error, total_cost
 
 
 def parse_grok_stream_line(line: str) -> list[StreamEvent]:
@@ -124,20 +136,61 @@ def parse_grok_stream_line(line: str) -> list[StreamEvent]:
             )
         ]
 
+    # Failure path: emit a terminal ResultEvent so the stream ends cleanly.
+    if event_type == "error":
+        usage_err, model_usage_err, cost_err = _extract_spend(data)
+        msg = _as_str(data.get("message") or data.get("error") or data.get("data") or "Grok error")
+        session_id = _as_str(data.get("sessionId") or data.get("session_id") or "") or None
+        return [
+            ResultEvent(
+                type="result",
+                session_id=session_id,
+                result=msg,
+                is_error=True,
+                usage=usage_err,
+                model_usage=model_usage_err,
+                total_cost_usd=cost_err,
+            )
+        ]
+
+    # Compaction boundary → orchestrator memory flush (same as Claude compact_boundary).
+    if event_type.startswith("auto_compact") or event_type in {
+        "compact",
+        "compact_boundary",
+        "compaction",
+    }:
+        pre_tokens = data.get("pre_tokens")
+        if not isinstance(pre_tokens, int):
+            pre_tokens = data.get("tokens")
+        if not isinstance(pre_tokens, int):
+            pre_tokens = 0
+        return [
+            CompactBoundaryEvent(
+                type="system",
+                subtype="compact_boundary",
+                trigger=_as_str(data.get("trigger") or event_type),
+                pre_tokens=pre_tokens,
+            )
+        ]
+
+    if event_type == "max_turns_reached":
+        return [
+            SystemStatusEvent(
+                type="system",
+                subtype="status",
+                status="max_turns_reached",
+            )
+        ]
+
     if event_type in {"end", "result", "done", "final"}:
         session_id = _as_str(data.get("sessionId") or data.get("session_id") or "") or None
-        usage_end: dict[str, Any] = data["usage"] if isinstance(data.get("usage"), dict) else {}
-        model_usage_end: dict[str, Any] = (
-            data["modelUsage"] if isinstance(data.get("modelUsage"), dict) else {}
-        )
-        if not model_usage_end and isinstance(data.get("model_usage"), dict):
-            model_usage_end = data["model_usage"]
+        usage_end, model_usage_end, cost_end = _extract_spend(data)
         result_text = _as_str(data.get("text") or data.get("result") or data.get("data") or "")
         num_turns = data.get("num_turns")
         if not isinstance(num_turns, int):
             num_turns = None
         is_error = _is_error_payload(data, result_text)
-        events: list[StreamEvent] = [
+        return [
             ResultEvent(
                 type="result",
                 session_id=session_id,
@@ -146,13 +199,42 @@ def parse_grok_stream_line(line: str) -> list[StreamEvent]:
                 usage=usage_end,
                 model_usage=model_usage_end,
                 num_turns=num_turns,
+                total_cost_usd=cost_end,
             )
         ]
-        return events
 
     # Unknown event type — ignore quietly.
     logger.debug("Grok: ignoring stream event type=%s", event_type)
     return []
+
+
+def _extract_spend(
+    data: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], float | None]:
+    """Pull usage / modelUsage / total_cost_usd from a Grok payload."""
+    usage: dict[str, Any] = data["usage"] if isinstance(data.get("usage"), dict) else {}
+    model_usage: dict[str, Any] = (
+        data["modelUsage"] if isinstance(data.get("modelUsage"), dict) else {}
+    )
+    if not model_usage and isinstance(data.get("model_usage"), dict):
+        model_usage = data["model_usage"]
+
+    total_cost: float | None = None
+    raw_cost = data.get("total_cost_usd")
+    if isinstance(raw_cost, (int, float)) and not isinstance(raw_cost, bool):
+        total_cost = float(raw_cost)
+    elif not usage and model_usage:
+        # Sum partial per-model costs when top-level cost is absent but rows exist.
+        summed = 0.0
+        saw = False
+        for row in model_usage.values():
+            if isinstance(row, dict) and isinstance(row.get("costUSD"), (int, float)):
+                summed += float(row["costUSD"])
+                saw = True
+        if saw:
+            total_cost = summed
+
+    return usage, model_usage, total_cost
 
 
 def _is_error_payload(data: dict[str, Any], text: str) -> bool:

--- a/ductor_bot/cli/grok_provider.py
+++ b/ductor_bot/cli/grok_provider.py
@@ -90,13 +90,12 @@ class GrokCLI(BaseCLI):
         _add_opt(cmd, "--rules", cfg.append_system_prompt)
         _add_opt(cmd, "--max-turns", str(cfg.max_turns) if cfg.max_turns is not None else None)
 
+        # Built-in tool filter (headless): comma-separated tool IDs.
+        # Distinct from permission rules (--allow/--deny with Bash(...) globs).
         if cfg.allowed_tools:
-            # Grok uses --tools / --allow; pass allow rules when provided.
-            for tool in cfg.allowed_tools:
-                cmd += ["--allow", tool]
+            cmd += ["--tools", ",".join(cfg.allowed_tools)]
         if cfg.disallowed_tools:
-            for tool in cfg.disallowed_tools:
-                cmd += ["--deny", tool]
+            cmd += ["--disallowed-tools", ",".join(cfg.disallowed_tools)]
 
         if resume_session:
             cmd += ["--resume", resume_session]
@@ -258,7 +257,9 @@ def _parse_response(stdout: bytes, stderr: bytes, returncode: int | None) -> CLI
         )
 
     # Prefer last JSON object if the CLI printed trailing noise.
-    text, session_id, usage, model_usage, num_turns, is_error = _parse_best_json(raw)
+    text, session_id, usage, model_usage, num_turns, is_error, total_cost = _parse_best_json(
+        raw
+    )
     if returncode not in (None, 0):
         is_error = True
 
@@ -271,15 +272,17 @@ def _parse_response(stdout: bytes, stderr: bytes, returncode: int | None) -> CLI
         num_turns=num_turns,
         usage=usage,
         model_usage=model_usage,
+        total_cost_usd=total_cost,
     )
 
     if response.is_error:
         logger.error("Grok error: %s", (response.result or stderr_text)[:200])
     else:
         logger.info(
-            "Grok done session=%s turns=%s tokens=%d",
+            "Grok done session=%s turns=%s cost=$%.4f tokens=%d",
             (response.session_id or "?")[:8],
             response.num_turns,
+            response.total_cost_usd or 0,
             response.total_tokens,
         )
     return response
@@ -287,7 +290,7 @@ def _parse_response(stdout: bytes, stderr: bytes, returncode: int | None) -> CLI
 
 def _parse_best_json(
     raw: str,
-) -> tuple[str, str | None, dict, dict, int | None, bool]:
+) -> tuple[str, str | None, dict, dict, int | None, bool, float | None]:
     """Parse raw stdout, tolerating multi-line pretty JSON or trailing junk."""
     try:
         return parse_grok_json(raw)

--- a/ductor_bot/cli/grok_provider.py
+++ b/ductor_bot/cli/grok_provider.py
@@ -1,0 +1,308 @@
+"""Async wrapper around the xAI Grok Build CLI (`grok`).
+
+Grok Build CLI surface (headless) closely mirrors Claude Code:
+
+* ``-p / --single`` one-shot prompt
+* ``--output-format json | streaming-json | plain``
+* ``--resume`` / ``--continue`` session continuity
+* ``--permission-mode`` (includes ``bypassPermissions``)
+* ``--always-approve`` auto-approve tools
+* ``--system-prompt-override`` / ``--rules``
+* ``--model`` / ``--reasoning-effort`` / ``--max-turns``
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from shutil import which
+from typing import TYPE_CHECKING
+
+from ductor_bot.cli.base import (
+    _IS_WINDOWS,
+    BaseCLI,
+    CLIConfig,
+    docker_wrap,
+)
+from ductor_bot.cli.executor import SubprocessSpec, run_oneshot_subprocess, run_streaming_subprocess
+from ductor_bot.cli.grok_events import parse_grok_json, parse_grok_stream_line
+from ductor_bot.cli.stream_events import (
+    AssistantTextDelta,
+    ResultEvent,
+    StreamEvent,
+)
+from ductor_bot.cli.types import CLIResponse
+
+if TYPE_CHECKING:
+    from ductor_bot.cli.timeout_controller import TimeoutController
+
+logger = logging.getLogger(__name__)
+
+# Grok argv safety: large prompts go through --prompt-file instead of -p.
+_PROMPT_ARGV_SOFT_LIMIT = 24_000
+
+
+class GrokCLI(BaseCLI):
+    """Async wrapper around the Grok Build CLI."""
+
+    def __init__(self, config: CLIConfig) -> None:
+        self._config = config
+        self._working_dir = Path(config.working_dir).resolve()
+        self._cli = "grok" if config.docker_container else self._find_cli()
+        self._temp_prompt_files: list[Path] = []
+        logger.info("Grok Build CLI wrapper: cwd=%s, model=%s", self._working_dir, config.model)
+
+    @staticmethod
+    def _find_cli() -> str:
+        path = which("grok")
+        if not path:
+            msg = (
+                "grok CLI not found on PATH. "
+                "Install via: curl -fsSL https://x.ai/cli/install.sh | bash"
+            )
+            raise FileNotFoundError(msg)
+        return path
+
+    def _build_command(
+        self,
+        prompt: str,
+        resume_session: str | None = None,
+        continue_session: bool = False,
+        *,
+        output_format: str = "json",
+    ) -> list[str]:
+        cfg = self._config
+        cmd = [self._cli, "--output-format", output_format]
+
+        # Prefer explicit permission mode; auto-approve tools when bypassing.
+        _add_opt(cmd, "--permission-mode", cfg.permission_mode)
+        if cfg.permission_mode == "bypassPermissions":
+            cmd.append("--always-approve")
+
+        _add_opt(cmd, "--model", cfg.model)
+        if cfg.reasoning_effort and cfg.reasoning_effort != "default":
+            # Grok accepts both --reasoning-effort and --effort.
+            cmd += ["--reasoning-effort", cfg.reasoning_effort]
+        _add_opt(cmd, "--system-prompt-override", cfg.system_prompt)
+        _add_opt(cmd, "--rules", cfg.append_system_prompt)
+        _add_opt(cmd, "--max-turns", str(cfg.max_turns) if cfg.max_turns is not None else None)
+
+        if cfg.allowed_tools:
+            # Grok uses --tools / --allow; pass allow rules when provided.
+            for tool in cfg.allowed_tools:
+                cmd += ["--allow", tool]
+        if cfg.disallowed_tools:
+            for tool in cfg.disallowed_tools:
+                cmd += ["--deny", tool]
+
+        if resume_session:
+            cmd += ["--resume", resume_session]
+        elif continue_session:
+            cmd.append("--continue")
+
+        if cfg.cli_parameters:
+            cmd.extend(cfg.cli_parameters)
+
+        # Prompt: long content goes via --prompt-file to avoid ARG_MAX.
+        if _IS_WINDOWS or len(prompt) > _PROMPT_ARGV_SOFT_LIMIT:
+            prompt_path = self._write_prompt_file(prompt)
+            cmd += ["--prompt-file", str(prompt_path)]
+        else:
+            cmd += ["-p", prompt]
+
+        return cmd
+
+    def _write_prompt_file(self, prompt: str) -> Path:
+        handle = tempfile.NamedTemporaryFile(  # noqa: SIM115
+            mode="w",
+            encoding="utf-8",
+            prefix="ductor-grok-prompt-",
+            suffix=".txt",
+            delete=False,
+        )
+        with handle:
+            handle.write(prompt)
+            path = Path(handle.name)
+        self._temp_prompt_files.append(path)
+        return path
+
+    def _cleanup_prompt_files(self) -> None:
+        for path in self._temp_prompt_files:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                logger.debug("Failed to remove temp prompt file %s", path)
+        self._temp_prompt_files.clear()
+
+    async def send(
+        self,
+        prompt: str,
+        resume_session: str | None = None,
+        continue_session: bool = False,
+        timeout_seconds: float | None = None,
+        timeout_controller: TimeoutController | None = None,
+    ) -> CLIResponse:
+        """Send a prompt and return the final result."""
+        try:
+            cmd = self._build_command(
+                prompt,
+                resume_session,
+                continue_session,
+                output_format="json",
+            )
+            exec_cmd, use_cwd = docker_wrap(cmd, self._config, interactive=False)
+            _log_cmd(exec_cmd)
+            return await run_oneshot_subprocess(
+                config=self._config,
+                spec=SubprocessSpec(
+                    exec_cmd,
+                    use_cwd,
+                    prompt,
+                    timeout_seconds,
+                    timeout_controller,
+                ),
+                parse_output=_parse_response,
+                provider_label="Grok Build",
+            )
+        finally:
+            self._cleanup_prompt_files()
+
+    async def send_streaming(
+        self,
+        prompt: str,
+        resume_session: str | None = None,
+        continue_session: bool = False,
+        timeout_seconds: float | None = None,
+        timeout_controller: TimeoutController | None = None,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """Send a prompt and yield stream events as they arrive."""
+        try:
+            cmd = self._build_command(
+                prompt,
+                resume_session,
+                continue_session,
+                output_format="streaming-json",
+            )
+            exec_cmd, use_cwd = docker_wrap(cmd, self._config, interactive=False)
+            _log_cmd(exec_cmd, streaming=True)
+
+            accumulated: list[str] = []
+            saw_result = False
+
+            async for event in run_streaming_subprocess(
+                config=self._config,
+                spec=SubprocessSpec(
+                    exec_cmd,
+                    use_cwd,
+                    prompt,
+                    timeout_seconds,
+                    timeout_controller,
+                ),
+                line_handler=_grok_line_handler,
+                provider_label="Grok Build",
+            ):
+                if isinstance(event, AssistantTextDelta) and event.text:
+                    accumulated.append(event.text)
+                if isinstance(event, ResultEvent):
+                    saw_result = True
+                    # Grok end events often omit the full text; fill from deltas.
+                    if not event.result and accumulated:
+                        event = event.model_copy(update={"result": "".join(accumulated)})
+                yield event
+
+            if not saw_result and accumulated:
+                yield ResultEvent(type="result", result="".join(accumulated), is_error=False)
+        finally:
+            self._cleanup_prompt_files()
+
+
+async def _grok_line_handler(line: str) -> AsyncGenerator[StreamEvent, None]:
+    """Parse a single Grok streaming-json line into stream events."""
+    for event in parse_grok_stream_line(line):
+        yield event
+
+
+def _add_opt(cmd: list[str], flag: str, value: str | None) -> None:
+    """Append a CLI flag+value pair if value is truthy."""
+    if value:
+        cmd += [flag, value]
+
+
+def _log_cmd(cmd: list[str], *, streaming: bool = False) -> None:
+    """Log the CLI command with truncated long values."""
+    safe_cmd = [
+        (c[:80] + "...") if len(c) > 80 and i > 0 and cmd[i - 1].startswith("-") else c
+        for i, c in enumerate(cmd)
+    ]
+    prefix = "Grok stream cmd" if streaming else "Grok cmd"
+    logger.info("%s: %s", prefix, " ".join(safe_cmd))
+
+
+def _parse_response(stdout: bytes, stderr: bytes, returncode: int | None) -> CLIResponse:
+    """Parse Grok oneshot JSON into a CLIResponse."""
+    stderr_text = stderr.decode(errors="replace")[:2000] if stderr else ""
+    if stderr_text:
+        logger.warning("Grok stderr: %s", stderr_text[:500])
+
+    raw = stdout.decode().strip()
+    if not raw:
+        logger.error("Grok returned empty output (exit=%s)", returncode)
+        return CLIResponse(
+            result=stderr_text.strip(),
+            is_error=True,
+            returncode=returncode,
+            stderr=stderr_text,
+        )
+
+    # Prefer last JSON object if the CLI printed trailing noise.
+    text, session_id, usage, model_usage, num_turns, is_error = _parse_best_json(raw)
+    if returncode not in (None, 0):
+        is_error = True
+
+    response = CLIResponse(
+        session_id=session_id,
+        result=text,
+        is_error=is_error,
+        returncode=returncode,
+        stderr=stderr_text,
+        num_turns=num_turns,
+        usage=usage,
+        model_usage=model_usage,
+    )
+
+    if response.is_error:
+        logger.error("Grok error: %s", (response.result or stderr_text)[:200])
+    else:
+        logger.info(
+            "Grok done session=%s turns=%s tokens=%d",
+            (response.session_id or "?")[:8],
+            response.num_turns,
+            response.total_tokens,
+        )
+    return response
+
+
+def _parse_best_json(
+    raw: str,
+) -> tuple[str, str | None, dict, dict, int | None, bool]:
+    """Parse raw stdout, tolerating multi-line pretty JSON or trailing junk."""
+    try:
+        return parse_grok_json(raw)
+    except Exception:  # noqa: BLE001 — fall through to line-wise recovery
+        pass
+
+    # Try last non-empty line (in case of NDJSON leaked into json mode).
+    for line in reversed(raw.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        return parse_grok_json(line)
+
+    return parse_grok_json(raw)

--- a/ductor_bot/cli/param_resolver.py
+++ b/ductor_bot/cli/param_resolver.py
@@ -174,9 +174,12 @@ def resolve_cli_config(
     elif provider == "gemini":
         _validate_gemini_model(model)
     elif provider == "grok":
-        if model not in GROK_MODELS and not model.startswith("grok-"):
+        from ductor_bot.config import get_grok_models
+
+        known = GROK_MODELS | get_grok_models()
+        if model not in known and not model.startswith("grok-"):
             msg = (
-                f"Invalid Grok model: {model}. Must be one of {sorted(GROK_MODELS)} "
+                f"Invalid Grok model: {model}. Must be one of {sorted(known)} "
                 "or a grok-* model ID"
             )
             raise DuctorError(msg)

--- a/ductor_bot/cli/param_resolver.py
+++ b/ductor_bot/cli/param_resolver.py
@@ -15,10 +15,12 @@ from ductor_bot.config import (
     _GEMINI_ALIASES,
     CLAUDE_MODELS,
     CLAUDE_SUPPORTED_EFFORTS,
+    GROK_MODELS,
+    GROK_SUPPORTED_EFFORTS,
     get_gemini_models,
 )
 
-_TASK_PROVIDERS: frozenset[str] = frozenset({"claude", "codex", "gemini"})
+_TASK_PROVIDERS: frozenset[str] = frozenset({"claude", "codex", "gemini", "grok"})
 
 
 def _looks_like_gemini_model(model: str) -> bool:
@@ -99,6 +101,17 @@ def _resolve_reasoning_effort(
             raise DuctorError(msg)
         return ""
 
+    if provider == "grok":
+        if requested_effort in GROK_SUPPORTED_EFFORTS:
+            return requested_effort
+        if overrides.reasoning_effort is not None:
+            msg = (
+                f"Invalid reasoning effort '{requested_effort}' for Grok model {model}. "
+                f"Supported: {', '.join(GROK_SUPPORTED_EFFORTS)}"
+            )
+            raise DuctorError(msg)
+        return ""
+
     if provider == "codex" and codex_cache:
         model_info = codex_cache.get_model(model)
         if (
@@ -160,6 +173,13 @@ def resolve_cli_config(
             raise DuctorError(msg)
     elif provider == "gemini":
         _validate_gemini_model(model)
+    elif provider == "grok":
+        if model not in GROK_MODELS and not model.startswith("grok-"):
+            msg = (
+                f"Invalid Grok model: {model}. Must be one of {sorted(GROK_MODELS)} "
+                "or a grok-* model ID"
+            )
+            raise DuctorError(msg)
     else:  # codex
         if codex_cache is None:
             msg = "Codex cache is required for Codex model validation"
@@ -168,7 +188,7 @@ def resolve_cli_config(
             msg = f"Invalid Codex model: {model}"
             raise DuctorError(msg)
 
-    # 4. Resolve reasoning effort (Codex and Claude carry it; others drop it).
+    # 4. Resolve reasoning effort (Codex, Claude, Grok carry it; others drop it).
     reasoning_effort = _resolve_reasoning_effort(
         provider, model, overrides, base_config, codex_cache
     )

--- a/ductor_bot/cli/service.py
+++ b/ductor_bot/cli/service.py
@@ -112,6 +112,7 @@ class CLIServiceConfig:
     codex_cli_parameters: tuple[str, ...] = ()
     gemini_cli_parameters: tuple[str, ...] = ()
     antigravity_cli_parameters: tuple[str, ...] = ()
+    grok_cli_parameters: tuple[str, ...] = ()
     agent_name: str = "main"
     interagent_port: int = 8799
     # External transcription hooks (#66) — empty strings keep built-in strategies.
@@ -126,6 +127,8 @@ class CLIServiceConfig:
             return list(self.gemini_cli_parameters)
         if provider == "antigravity":
             return list(self.antigravity_cli_parameters)
+        if provider == "grok":
+            return list(self.grok_cli_parameters)
         return list(self.claude_cli_parameters)
 
 

--- a/ductor_bot/cli/types.py
+++ b/ductor_bot/cli/types.py
@@ -54,7 +54,18 @@ class CLIResponse(BaseModel):
 
     @property
     def total_tokens(self) -> int:
-        """Combined input + output tokens for context tracking."""
+        """Combined tokens for context tracking.
+
+        Prefer an explicit ``usage.total_tokens`` when providers publish one
+        (Grok headless does: uncached input + cache reads + output). Fall back
+        to input + output for Claude-style usage objects.
+        """
+        explicit = self.usage.get("total_tokens")
+        if explicit is not None:
+            try:
+                return int(explicit)
+            except (TypeError, ValueError):
+                pass
         return self.input_tokens + self.output_tokens
 
 

--- a/ductor_bot/cli_commands/agents.py
+++ b/ductor_bot/cli_commands/agents.py
@@ -233,7 +233,7 @@ def agents_add(rest: list[str]) -> None:
 
     provider: str | None = questionary.select(
         t_rich("agents.add.prompt_provider"),
-        choices=["claude", "codex", "gemini", "antigravity"],
+        choices=["claude", "codex", "gemini", "antigravity", "grok"],
         default="claude",
     ).ask()
     if provider is None:

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -231,6 +231,7 @@ class CLIParametersConfig(BaseModel):
     codex: list[str] = Field(default_factory=list)
     gemini: list[str] = Field(default_factory=list)
     antigravity: list[str] = Field(default_factory=list)
+    grok: list[str] = Field(default_factory=list)
 
 
 class MatrixConfig(BaseModel):
@@ -416,6 +417,7 @@ class SkillSyncProviders(BaseModel):
     claude: bool = True
     codex: bool = True
     gemini: bool = True
+    grok: bool = True
 
 
 class SkillsConfig(BaseModel):
@@ -622,6 +624,14 @@ _GEMINI_ALIASES: frozenset[str] = frozenset({"auto", "pro", "flash", "flash-lite
 ANTIGRAVITY_MODELS_ORDERED: tuple[str, ...] = ("antigravity-default",)
 ANTIGRAVITY_MODELS: frozenset[str] = frozenset(ANTIGRAVITY_MODELS_ORDERED)
 
+# Grok Build models (xAI Grok CLI). Keep aliases short for @directives.
+GROK_MODELS_ORDERED: tuple[str, ...] = (
+    "grok-4.5",
+    "grok-composer-2.5-fast",
+)
+GROK_MODELS: frozenset[str] = frozenset(GROK_MODELS_ORDERED)
+GROK_SUPPORTED_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
+
 _runtime_gemini: list[frozenset[str]] = [frozenset()]
 _runtime_antigravity: list[frozenset[str]] = [frozenset()]
 
@@ -631,6 +641,7 @@ class ModelRegistry:
 
     Claude models (haiku, sonnet, opus) are hardcoded.
     Gemini models are hardcoded (parsed from CLI at startup if available).
+    Grok models are hardcoded (plus any ``grok-`` prefixed IDs).
     Codex models are discovered dynamically at runtime.
     """
 
@@ -656,6 +667,8 @@ class ModelRegistry:
             or model_id.startswith("antigravity-")
         ):
             return "antigravity"
+        if model_id in GROK_MODELS or model_id.startswith("grok-"):
+            return "grok"
         return "codex"
 
 

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -624,24 +624,34 @@ _GEMINI_ALIASES: frozenset[str] = frozenset({"auto", "pro", "flash", "flash-lite
 ANTIGRAVITY_MODELS_ORDERED: tuple[str, ...] = ("antigravity-default",)
 ANTIGRAVITY_MODELS: frozenset[str] = frozenset(ANTIGRAVITY_MODELS_ORDERED)
 
-# Grok Build models (xAI Grok CLI). Keep aliases short for @directives.
+# Grok Build models (xAI Grok CLI). Fallback when discovery is unavailable.
 GROK_MODELS_ORDERED: tuple[str, ...] = (
     "grok-4.5",
     "grok-composer-2.5-fast",
 )
 GROK_MODELS: frozenset[str] = frozenset(GROK_MODELS_ORDERED)
-GROK_SUPPORTED_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
+# Canonical Grok headless levels (plus max alias of xhigh). See grok --help.
+GROK_SUPPORTED_EFFORTS: tuple[str, ...] = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
 
 _runtime_gemini: list[frozenset[str]] = [frozenset()]
 _runtime_antigravity: list[frozenset[str]] = [frozenset()]
+_runtime_grok: list[frozenset[str]] = [frozenset()]
+_runtime_grok_ordered: list[tuple[str, ...]] = [()]
 
 
 class ModelRegistry:
     """Provider resolution for models.
 
     Claude models (haiku, sonnet, opus) are hardcoded.
-    Gemini models are hardcoded (parsed from CLI at startup if available).
-    Grok models are hardcoded (plus any ``grok-`` prefixed IDs).
+    Gemini / Antigravity / Grok models refresh from CLI discovery when available.
     Codex models are discovered dynamically at runtime.
     """
 
@@ -667,7 +677,11 @@ class ModelRegistry:
             or model_id.startswith("antigravity-")
         ):
             return "antigravity"
-        if model_id in GROK_MODELS or model_id.startswith("grok-"):
+        if (
+            model_id in GROK_MODELS
+            or model_id in _runtime_grok[0]
+            or model_id.startswith("grok-")
+        ):
             return "grok"
         return "codex"
 
@@ -710,3 +724,40 @@ def set_antigravity_models(models: frozenset[str]) -> None:
 def reset_antigravity_models() -> None:
     """Clear runtime Antigravity models. For test teardown only."""
     _runtime_antigravity[0] = frozenset()
+
+
+def get_grok_models() -> frozenset[str]:
+    """Return dynamically discovered Grok models (may be empty)."""
+    return _runtime_grok[0]
+
+
+def get_grok_models_ordered() -> tuple[str, ...]:
+    """Return Grok models in discovery order, or the hardcoded fallback list."""
+    ordered = _runtime_grok_ordered[0]
+    if ordered:
+        return ordered
+    return GROK_MODELS_ORDERED
+
+
+def set_grok_models(models: tuple[str, ...] | frozenset[str] | list[str]) -> None:
+    """Set runtime Grok models discovered from ``grok models``.
+
+    Refuses to overwrite with an empty set to prevent cache wipe.
+    Preserves discovery order when a sequence is provided.
+    """
+    if not models:
+        return
+    if isinstance(models, frozenset):
+        ordered = tuple(sorted(models))
+    else:
+        ordered = tuple(dict.fromkeys(models))  # dedupe, keep order
+    if not ordered:
+        return
+    _runtime_grok_ordered[0] = ordered
+    _runtime_grok[0] = frozenset(ordered)
+
+
+def reset_grok_models() -> None:
+    """Clear runtime Grok models. For test teardown only."""
+    _runtime_grok[0] = frozenset()
+    _runtime_grok_ordered[0] = ()

--- a/ductor_bot/cron/execution.py
+++ b/ductor_bot/cron/execution.py
@@ -29,6 +29,7 @@ class OneShotCommand:
     cmd: list[str] = field(default_factory=list)
     stdin_input: bytes | None = None
     env_overrides: dict[str, str] = field(default_factory=dict)
+    cleanup_paths: list[Path] = field(default_factory=list)
 
 
 def build_cmd(exec_config: TaskExecutionConfig, prompt: str) -> OneShotCommand | None:
@@ -100,7 +101,7 @@ def parse_grok_result(stdout: bytes) -> str:
     raw = stdout.decode(errors="replace").strip()
     if not raw:
         return ""
-    text, _session_id, _usage, _model_usage, _turns, is_error = parse_grok_json(raw)
+    text, _session_id, _usage, _model_usage, _turns, is_error, _cost = parse_grok_json(raw)
     if text:
         return text
     if is_error:
@@ -194,12 +195,18 @@ def _build_codex_cmd(exec_config: TaskExecutionConfig, prompt: str) -> OneShotCo
     return OneShotCommand(cmd=cmd)
 
 
+# Match GrokCLI: long prompts go through --prompt-file to avoid ARG_MAX.
+_GROK_PROMPT_ARGV_SOFT_LIMIT = 24_000
+
+
 def _build_grok_cmd(exec_config: TaskExecutionConfig, prompt: str) -> OneShotCommand | None:
     """Build a Grok Build CLI command for one-shot cron execution."""
+    import tempfile
+
     cli = which("grok")
     if not cli:
         return None
-    cmd = [cli, "-p", prompt, "--output-format", "json"]
+    cmd = [cli, "--output-format", "json"]
     if exec_config.model:
         cmd += ["--model", exec_config.model]
     if exec_config.permission_mode:
@@ -209,7 +216,24 @@ def _build_grok_cmd(exec_config: TaskExecutionConfig, prompt: str) -> OneShotCom
     if exec_config.reasoning_effort and exec_config.reasoning_effort != "default":
         cmd += ["--reasoning-effort", exec_config.reasoning_effort]
     cmd.extend(exec_config.cli_parameters)
-    return OneShotCommand(cmd=cmd)
+
+    cleanup: list[Path] = []
+    if len(prompt) > _GROK_PROMPT_ARGV_SOFT_LIMIT:
+        handle = tempfile.NamedTemporaryFile(  # noqa: SIM115
+            mode="w",
+            encoding="utf-8",
+            prefix="ductor-grok-cron-prompt-",
+            suffix=".txt",
+            delete=False,
+        )
+        with handle:
+            handle.write(prompt)
+            prompt_path = Path(handle.name)
+        cleanup.append(prompt_path)
+        cmd += ["--prompt-file", str(prompt_path)]
+    else:
+        cmd += ["-p", prompt]
+    return OneShotCommand(cmd=cmd, cleanup_paths=cleanup)
 
 
 _CmdBuilder = Callable[[TaskExecutionConfig, str], OneShotCommand | None]
@@ -258,46 +282,53 @@ async def execute_one_shot(
     """Run one provider CLI command with timeout and normalized status/result."""
     stdin_input = one_shot.stdin_input
     env = {**os.environ, **one_shot.env_overrides} if one_shot.env_overrides else None
-    proc = await asyncio.create_subprocess_exec(
-        *one_shot.cmd,
-        cwd=str(cwd),
-        env=env,
-        stdin=asyncio.subprocess.PIPE if stdin_input is not None else asyncio.subprocess.DEVNULL,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        creationflags=_CREATION_FLAGS,
-    )
-
-    timed_out = False
     try:
-        async with asyncio.timeout(timeout_seconds):
-            stdout, stderr = await proc.communicate(input=stdin_input)
-    except TimeoutError:
-        timed_out = True
-        _force_kill(proc)
-        stdout, stderr = await proc.communicate()
-    except asyncio.CancelledError:
-        _force_kill(proc)
-        await proc.wait()
-        raise
-
-    if timed_out:
-        return OneShotExecutionResult(
-            status="error:timeout",
-            result_text=f"[{timeout_label} timed out after {timeout_seconds:.0f}s]",
-            stdout=stdout,
-            stderr=stderr,
-            returncode=proc.returncode,
-            timed_out=True,
+        proc = await asyncio.create_subprocess_exec(
+            *one_shot.cmd,
+            cwd=str(cwd),
+            env=env,
+            stdin=asyncio.subprocess.PIPE if stdin_input is not None else asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            creationflags=_CREATION_FLAGS,
         )
 
-    returncode = proc.returncode
-    status = "success" if returncode == 0 else f"error:exit_{returncode}"
-    return OneShotExecutionResult(
-        status=status,
-        result_text=parse_result(provider, stdout),
-        stdout=stdout,
-        stderr=stderr,
-        returncode=returncode,
-        timed_out=False,
-    )
+        timed_out = False
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                stdout, stderr = await proc.communicate(input=stdin_input)
+        except TimeoutError:
+            timed_out = True
+            _force_kill(proc)
+            stdout, stderr = await proc.communicate()
+        except asyncio.CancelledError:
+            _force_kill(proc)
+            await proc.wait()
+            raise
+
+        if timed_out:
+            return OneShotExecutionResult(
+                status="error:timeout",
+                result_text=f"[{timeout_label} timed out after {timeout_seconds:.0f}s]",
+                stdout=stdout,
+                stderr=stderr,
+                returncode=proc.returncode,
+                timed_out=True,
+            )
+
+        returncode = proc.returncode
+        status = "success" if returncode == 0 else f"error:exit_{returncode}"
+        return OneShotExecutionResult(
+            status=status,
+            result_text=parse_result(provider, stdout),
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+            timed_out=False,
+        )
+    finally:
+        for path in one_shot.cleanup_paths:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                logger.debug("Failed to remove one-shot temp path %s", path)

--- a/ductor_bot/cron/execution.py
+++ b/ductor_bot/cron/execution.py
@@ -14,6 +14,7 @@ from shutil import which
 from ductor_bot.cli.codex_events import parse_codex_jsonl
 from ductor_bot.cli.gemini_events import parse_gemini_json
 from ductor_bot.cli.gemini_utils import find_gemini_cli
+from ductor_bot.cli.grok_events import parse_grok_json
 from ductor_bot.cli.param_resolver import TaskExecutionConfig
 from ductor_bot.infra.platform import CREATION_FLAGS as _CREATION_FLAGS
 from ductor_bot.infra.process_tree import force_kill_process_tree
@@ -89,6 +90,21 @@ def parse_codex_result(stdout: bytes) -> str:
         return result_text
     if thread_id is not None or usage is not None:
         return ""
+    return raw[:2000]
+
+
+def parse_grok_result(stdout: bytes) -> str:
+    """Extract result text from Grok Build CLI JSON output."""
+    if not stdout:
+        return ""
+    raw = stdout.decode(errors="replace").strip()
+    if not raw:
+        return ""
+    text, _session_id, _usage, _model_usage, _turns, is_error = parse_grok_json(raw)
+    if text:
+        return text
+    if is_error:
+        return raw[:2000]
     return raw[:2000]
 
 
@@ -178,6 +194,24 @@ def _build_codex_cmd(exec_config: TaskExecutionConfig, prompt: str) -> OneShotCo
     return OneShotCommand(cmd=cmd)
 
 
+def _build_grok_cmd(exec_config: TaskExecutionConfig, prompt: str) -> OneShotCommand | None:
+    """Build a Grok Build CLI command for one-shot cron execution."""
+    cli = which("grok")
+    if not cli:
+        return None
+    cmd = [cli, "-p", prompt, "--output-format", "json"]
+    if exec_config.model:
+        cmd += ["--model", exec_config.model]
+    if exec_config.permission_mode:
+        cmd += ["--permission-mode", exec_config.permission_mode]
+    if exec_config.permission_mode == "bypassPermissions":
+        cmd.append("--always-approve")
+    if exec_config.reasoning_effort and exec_config.reasoning_effort != "default":
+        cmd += ["--reasoning-effort", exec_config.reasoning_effort]
+    cmd.extend(exec_config.cli_parameters)
+    return OneShotCommand(cmd=cmd)
+
+
 _CmdBuilder = Callable[[TaskExecutionConfig, str], OneShotCommand | None]
 _ResultParser = Callable[[bytes], str]
 
@@ -185,12 +219,14 @@ _CMD_BUILDERS: dict[str, _CmdBuilder] = {
     "claude": _build_claude_cmd,
     "gemini": _build_gemini_cmd,
     "codex": _build_codex_cmd,
+    "grok": _build_grok_cmd,
 }
 
 _RESULT_PARSERS: dict[str, _ResultParser] = {
     "claude": parse_claude_result,
     "gemini": parse_gemini_result,
     "codex": parse_codex_result,
+    "grok": parse_grok_result,
 }
 
 

--- a/ductor_bot/messenger/telegram/app.py
+++ b/ductor_bot/messenger/telegram/app.py
@@ -992,6 +992,9 @@ class TelegramBot:
                 lines.append(t("session_help.claude_model"))
             elif p == "codex":
                 lines.append(t("session_help.codex_single"))
+            elif p == "grok":
+                lines.append("• `@grok <prompt>` — Grok Build session")
+                lines.append("• `@grok-4.5 <prompt>` — pin model")
             else:
                 lines.append(t("session_help.gemini_single"))
                 lines.append(t("session_help.gemini_model"))
@@ -1003,6 +1006,8 @@ class TelegramBot:
                 lines.append(t("session_help.codex_multi"))
             if "gemini" in providers:
                 lines.append(t("session_help.gemini_multi"))
+            if "grok" in providers:
+                lines.append("• `@grok <prompt>` — Grok Build")
             lines.append(t("session_help.explicit"))
 
         lines += [
@@ -1054,7 +1059,7 @@ class TelegramBot:
                 provider_override, model_override = resolved[0], resolved[1] or None
                 prompt = rest
                 # If key was a provider name, check for optional model after it
-                if key in ("claude", "codex", "gemini"):
+                if key in ("claude", "codex", "gemini", "antigravity", "grok"):
                     model_match = re.match(r"([a-zA-Z][a-zA-Z0-9_.-]*)\s+", prompt)
                     if model_match:
                         candidate = model_match.group(1).lower()
@@ -1097,9 +1102,13 @@ class TelegramBot:
                 ns = self._orch.get_named_session(chat_id, session_name)
                 provider = ns.provider if ns else (provider_override or self._orch.config.provider)
                 model = ns.model if ns else ""
-                provider_label = {"claude": "Claude", "codex": "Codex", "gemini": "Gemini"}.get(
-                    provider, provider
-                )
+                provider_label = {
+                    "claude": "Claude",
+                    "codex": "Codex",
+                    "gemini": "Gemini",
+                    "antigravity": "Antigravity",
+                    "grok": "Grok Build",
+                }.get(provider, provider)
                 model_info = f" ({model})" if model else ""
                 await send_rich(
                     self._bot,

--- a/ductor_bot/messenger/telegram/app.py
+++ b/ductor_bot/messenger/telegram/app.py
@@ -1595,14 +1595,32 @@ class TelegramBot:
         await handle_upgrade_callback(self, chat_id, message_id, data, thread_id=thread_id)
 
     async def _sync_commands(self) -> None:
-        from aiogram.types import BotCommandScopeAllGroupChats, BotCommandScopeAllPrivateChats
+        from aiogram.types import (
+            BotCommandScopeAllGroupChats,
+            BotCommandScopeAllPrivateChats,
+            BotCommandScopeChat,
+        )
 
         desired = _BOT_COMMANDS
 
         # Clear legacy scoped commands (previous versions set per-scope lists).
         # Telegram keeps scoped commands independently — they must be deleted
         # explicitly or they shadow the default-scope list.
-        for scope in (BotCommandScopeAllPrivateChats(), BotCommandScopeAllGroupChats()):
+        #
+        # Also clear per-chat scopes for allowed users. Foreign bridges (e.g.
+        # opencode-telegram-bot) register chat-scoped command lists that outrank
+        # the default list and leave users seeing the wrong slash menu.
+        scopes_to_clear: list = [
+            BotCommandScopeAllPrivateChats(),
+            BotCommandScopeAllGroupChats(),
+        ]
+        for uid in getattr(self._config, "allowed_user_ids", None) or []:
+            try:
+                scopes_to_clear.append(BotCommandScopeChat(chat_id=int(uid)))
+            except (TypeError, ValueError):
+                continue
+
+        for scope in scopes_to_clear:
             try:
                 scoped = await self._bot.get_my_commands(scope=scope)
                 if scoped:

--- a/ductor_bot/messenger/telegram/welcome.py
+++ b/ductor_bot/messenger/telegram/welcome.py
@@ -121,10 +121,12 @@ def _build_auth_block(auth_results: dict[str, AuthResult], config: AgentConfig) 
     claude = auth_results.get("claude")
     codex = auth_results.get("codex")
     gemini = auth_results.get("gemini")
+    grok = auth_results.get("grok")
 
     claude_ok = claude is not None and claude.is_authenticated
     codex_ok = codex is not None and codex.is_authenticated
     gemini_ok = gemini is not None and gemini.is_authenticated
+    grok_ok = grok is not None and grok.is_authenticated
 
     providers: list[str] = []
     if claude_ok:
@@ -133,6 +135,8 @@ def _build_auth_block(auth_results: dict[str, AuthResult], config: AgentConfig) 
         providers.append("Codex")
     if gemini_ok:
         providers.append("Gemini")
+    if grok_ok:
+        providers.append("Grok Build")
 
     if not providers:
         return t("welcome.no_auth")

--- a/ductor_bot/orchestrator/commands.py
+++ b/ductor_bot/orchestrator/commands.py
@@ -310,7 +310,7 @@ def _status_effort_suffix(orch: Orchestrator, model_name: str, effort: str) -> s
     global default) so /status reflects what the next turn actually uses.
     """
     provider = orch.models.provider_for(model_name)
-    if provider in ("codex", "claude") and effort and effort != "default":
+    if provider in ("codex", "claude", "grok") and effort and effort != "default":
         return f"\n{t('status.effort_line', effort=effort)}"
     return ""
 

--- a/ductor_bot/orchestrator/core.py
+++ b/ductor_bot/orchestrator/core.py
@@ -158,6 +158,7 @@ class Orchestrator:
                 codex_cli_parameters=tuple(config.cli_parameters.codex),
                 gemini_cli_parameters=tuple(config.cli_parameters.gemini),
                 antigravity_cli_parameters=tuple(config.cli_parameters.antigravity),
+                grok_cli_parameters=tuple(config.cli_parameters.grok),
                 agent_name=agent_name,
                 interagent_port=interagent_port,
                 transcribe_command=config.transcription.audio_command,

--- a/ductor_bot/orchestrator/lifecycle.py
+++ b/ductor_bot/orchestrator/lifecycle.py
@@ -97,6 +97,7 @@ async def create_orchestrator(
     codex_cache = await orch._observers.init_model_caches(
         on_gemini_refresh=orch._providers.on_gemini_models_refresh,
         on_antigravity_refresh=orch._providers.on_antigravity_models_refresh,
+        on_grok_refresh=orch._providers.on_grok_models_refresh,
     )
     orch._observers.init_task_observers(
         cron_manager=orch._cron_manager,

--- a/ductor_bot/orchestrator/observers.py
+++ b/ductor_bot/orchestrator/observers.py
@@ -22,8 +22,14 @@ from ductor_bot.cli.antigravity_cache_observer import AntigravityCacheObserver
 from ductor_bot.cli.codex_cache import CodexModelCache
 from ductor_bot.cli.codex_cache_observer import CodexCacheObserver
 from ductor_bot.cli.gemini_cache_observer import GeminiCacheObserver
+from ductor_bot.cli.grok_cache_observer import GrokCacheObserver
 from ductor_bot.cli.service import CLIService
-from ductor_bot.config import AgentConfig, get_antigravity_models, get_gemini_models
+from ductor_bot.config import (
+    AgentConfig,
+    get_antigravity_models,
+    get_gemini_models,
+    get_grok_models,
+)
 from ductor_bot.config_reload import ConfigReloader
 from ductor_bot.cron.manager import CronManager
 from ductor_bot.cron.observer import CronObserver
@@ -54,6 +60,7 @@ class ObserverManager:
         self.codex_cache_obs: CodexCacheObserver | None = None
         self.gemini_cache_obs: GeminiCacheObserver | None = None
         self.antigravity_cache_obs: AntigravityCacheObserver | None = None
+        self.grok_cache_obs: GrokCacheObserver | None = None
 
         self._config_reloader: ConfigReloader | None = None
         self._rule_sync_task: asyncio.Task[None] | None = None
@@ -66,8 +73,9 @@ class ObserverManager:
         *,
         on_gemini_refresh: Callable[[tuple[str, ...]], None],
         on_antigravity_refresh: Callable[[tuple[str, ...]], None],
+        on_grok_refresh: Callable[[tuple[str, ...]], None],
     ) -> CodexModelCache:
-        """Start Gemini, Antigravity, and Codex cache observers, return Codex cache."""
+        """Start Gemini, Antigravity, Grok, and Codex cache observers, return Codex cache."""
         # Gemini
         gemini_cache_path = self._paths.config_path.parent / "gemini_models.json"
         gemini_observer = GeminiCacheObserver(gemini_cache_path, on_refresh=on_gemini_refresh)
@@ -87,6 +95,15 @@ class ObserverManager:
 
         if not get_antigravity_models():
             logger.warning("Antigravity cache is empty after startup (agy may not be installed)")
+
+        # Grok Build
+        grok_cache_path = self._paths.config_path.parent / "grok_models.json"
+        grok_observer = GrokCacheObserver(grok_cache_path, on_refresh=on_grok_refresh)
+        await grok_observer.start()
+        self.grok_cache_obs = grok_observer
+
+        if not get_grok_models():
+            logger.warning("Grok cache is empty after startup (grok CLI may not be installed)")
 
         # Codex
         codex_cache_path = self._paths.config_path.parent / "codex_models.json"
@@ -179,6 +196,9 @@ class ObserverManager:
         if self.antigravity_cache_obs:
             await self.antigravity_cache_obs.stop()
             self.antigravity_cache_obs = None
+        if self.grok_cache_obs:
+            await self.grok_cache_obs.stop()
+            self.grok_cache_obs = None
         for task in (self._rule_sync_task, self._skill_sync_task):
             if task and not task.done():
                 task.cancel()

--- a/ductor_bot/orchestrator/providers.py
+++ b/ductor_bot/orchestrator/providers.py
@@ -10,6 +10,7 @@ from ductor_bot.config import (
     _GEMINI_ALIASES,
     ANTIGRAVITY_MODELS,
     CLAUDE_MODELS,
+    GROK_MODELS,
     ModelRegistry,
     get_antigravity_models,
     get_gemini_models,
@@ -78,6 +79,8 @@ class ProviderManager:
             return "Gemini"
         if provider == "antigravity":
             return "Antigravity"
+        if provider == "grok":
+            return "Grok Build"
         return "Codex"
 
     # -- Auth / init ----------------------------------------------------------
@@ -145,6 +148,7 @@ class ProviderManager:
         self._known_model_ids = (
             CLAUDE_MODELS
             | ANTIGRAVITY_MODELS
+            | GROK_MODELS
             | _GEMINI_ALIASES
             | get_gemini_models()
             | get_antigravity_models()
@@ -177,6 +181,8 @@ class ProviderManager:
             return ""
         if provider == "antigravity":
             return "antigravity-default"
+        if provider == "grok":
+            return self._config.model if self._config.provider == "grok" else "grok-4.5"
         return ""
 
     def resolve_session_directive(self, key: str) -> tuple[str, str] | None:
@@ -187,7 +193,7 @@ class ProviderManager:
         - known model   (``@opus``)  -> (inferred_provider, model)
         - unknown                    -> None
         """
-        if key in ("claude", "codex", "gemini", "antigravity"):
+        if key in ("claude", "codex", "gemini", "antigravity", "grok"):
             return key, self.default_model_for_provider(key)
         if self.is_known_model(key):
             provider = self._models.provider_for(key)
@@ -209,6 +215,7 @@ class ProviderManager:
             "gemini": ("Gemini", "#8B5CF6"),
             "codex": ("Codex", "#10B981"),
             "antigravity": ("Antigravity", "#3B82F6"),
+            "grok": ("Grok Build", "#111827"),
         }
         providers: list[dict[str, object]] = []
         for pid in sorted(self._available_providers):
@@ -225,6 +232,8 @@ class ProviderManager:
             elif pid == "antigravity":
                 antigravity = get_antigravity_models()
                 models = sorted(antigravity) if antigravity else sorted(ANTIGRAVITY_MODELS)
+            elif pid == "grok":
+                models = sorted(GROK_MODELS)
             else:
                 models = []
             providers.append({"id": pid, "name": name, "color": color, "models": models})

--- a/ductor_bot/orchestrator/providers.py
+++ b/ductor_bot/orchestrator/providers.py
@@ -14,8 +14,11 @@ from ductor_bot.config import (
     ModelRegistry,
     get_antigravity_models,
     get_gemini_models,
+    get_grok_models,
+    get_grok_models_ordered,
     set_antigravity_models,
     set_gemini_models,
+    set_grok_models,
 )
 
 if TYPE_CHECKING:
@@ -132,6 +135,11 @@ class ProviderManager:
         set_antigravity_models(frozenset(models))
         self.refresh_known_model_ids()
 
+    def on_grok_models_refresh(self, models: tuple[str, ...]) -> None:
+        """Callback for GrokCacheObserver: update model registry."""
+        set_grok_models(models)
+        self.refresh_known_model_ids()
+
     def refresh_gemini_api_key_mode(self) -> bool:
         """Re-read ``~/.gemini/settings.json`` and update the cache.
 
@@ -152,6 +160,7 @@ class ProviderManager:
             | _GEMINI_ALIASES
             | get_gemini_models()
             | get_antigravity_models()
+            | get_grok_models()
         )
 
     def resolve_runtime_target(self, requested_model: str | None = None) -> tuple[str, str]:
@@ -233,7 +242,7 @@ class ProviderManager:
                 antigravity = get_antigravity_models()
                 models = sorted(antigravity) if antigravity else sorted(ANTIGRAVITY_MODELS)
             elif pid == "grok":
-                models = sorted(GROK_MODELS)
+                models = list(get_grok_models_ordered())
             else:
                 models = []
             providers.append({"id": pid, "name": name, "color": color, "models": models})

--- a/ductor_bot/orchestrator/selectors/model_selector.py
+++ b/ductor_bot/orchestrator/selectors/model_selector.py
@@ -13,7 +13,7 @@ from ductor_bot.config import (
     CLAUDE_MODELS_ORDERED,
     CLAUDE_SUPPORTED_EFFORTS,
     CODEX_SUPPORTED_EFFORTS_FALLBACK,
-    GROK_MODELS_ORDERED,
+    get_grok_models_ordered,
     GROK_SUPPORTED_EFFORTS,
     get_antigravity_models,
     get_gemini_models,
@@ -34,6 +34,8 @@ logger = logging.getLogger(__name__)
 MS_PREFIX = "ms:"
 
 _EFFORT_LABELS: dict[str, str] = {
+    "none": "None",
+    "minimal": "Minimal",
     "low": "Low",
     "medium": "Medium",
     "high": "High",
@@ -596,7 +598,8 @@ async def _build_model_step(
         )
 
     if provider == "grok":
-        buttons = [Button(text=m, callback_data=f"ms:m:{m}") for m in GROK_MODELS_ORDERED]
+        grok_models = get_grok_models_ordered()
+        buttons = [Button(text=m, callback_data=f"ms:m:{m}") for m in grok_models]
         keyboard = ButtonGrid(
             rows=[
                 *_rows_of(buttons),

--- a/ductor_bot/orchestrator/selectors/model_selector.py
+++ b/ductor_bot/orchestrator/selectors/model_selector.py
@@ -13,6 +13,8 @@ from ductor_bot.config import (
     CLAUDE_MODELS_ORDERED,
     CLAUDE_SUPPORTED_EFFORTS,
     CODEX_SUPPORTED_EFFORTS_FALLBACK,
+    GROK_MODELS_ORDERED,
+    GROK_SUPPORTED_EFFORTS,
     get_antigravity_models,
     get_gemini_models,
     update_config_file_async,
@@ -110,6 +112,8 @@ def _supported_efforts(orch: Orchestrator, model_id: str) -> tuple[str, ...]:
     provider = orch.models.provider_for(model_id)
     if provider == "claude":
         return CLAUDE_SUPPORTED_EFFORTS
+    if provider == "grok":
+        return GROK_SUPPORTED_EFFORTS
     if provider == "codex":
         codex_cache = (
             orch._observers.codex_cache_obs.get_cache() if orch._observers.codex_cache_obs else None
@@ -129,12 +133,12 @@ def _validate_reasoning_effort(
     """Return a user-facing error when the effort is unsupported by the provider.
 
     Providers without a reasoning-effort concept (gemini/antigravity) skip
-    validation; codex/claude validate against their supported set (an empty
+    validation; codex/claude/grok validate against their supported set (an empty
     set rejects any effort).
     """
     if not reasoning_effort:
         return None
-    if orch.models.provider_for(model_id) not in ("codex", "claude"):
+    if orch.models.provider_for(model_id) not in ("codex", "claude", "grok"):
         return None
 
     supported = _supported_efforts(orch, model_id)
@@ -244,6 +248,8 @@ async def model_selector_start(
         buttons.append(Button(text="GEMINI", callback_data="ms:p:gemini"))
     if "antigravity" in authed:
         buttons.append(Button(text="ANTIGRAVITY", callback_data="ms:p:antigravity"))
+    if "grok" in authed:
+        buttons.append(Button(text="GROK BUILD", callback_data="ms:p:grok"))
 
     provider_rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
     keyboard = ButtonGrid(rows=provider_rows)
@@ -486,7 +492,7 @@ async def switch_model(
             # Codex and Claude both use reasoning_effort — only drop it when
             # switching to a provider that has no notion of effort.
             if (
-                new_provider not in {"codex", "claude"}
+                new_provider not in {"codex", "claude", "grok"}
                 and "reasoning_effort" not in registry_updates
             ):
                 registry_updates["reasoning_effort"] = None
@@ -532,7 +538,7 @@ async def _status_line(orch: Orchestrator, key: SessionKey) -> str:
         model, provider = orch.resolve_runtime_target(orch._config.model)
         effort = orch._config.reasoning_effort
 
-    if provider in ("codex", "claude") and effort and effort != "default":
+    if provider in ("codex", "claude", "grok") and effort and effort != "default":
         current = (
             f"{t('model.header')}\n{t('model.current_with_effort', model=model, effort=effort)}"
         )
@@ -587,6 +593,19 @@ async def _build_model_step(
         keyboard = ButtonGrid(rows=antigravity_rows)
         return SelectorResponse(
             text=f"{header}\n\n{t('model.select_antigravity')}", buttons=keyboard
+        )
+
+    if provider == "grok":
+        buttons = [Button(text=m, callback_data=f"ms:m:{m}") for m in GROK_MODELS_ORDERED]
+        keyboard = ButtonGrid(
+            rows=[
+                *_rows_of(buttons),
+                [Button(text=t("model.btn_back"), callback_data="ms:b:root")],
+            ]
+        )
+        return SelectorResponse(
+            text=f"{header}\n\nSelect a Grok Build model:",
+            buttons=keyboard,
         )
 
     # Use cache instead of live discovery

--- a/ductor_bot/text/response_format.py
+++ b/ductor_bot/text/response_format.py
@@ -90,6 +90,7 @@ def new_session_text(provider: str) -> str:
         "codex": "Codex",
         "gemini": "Gemini",
         "antigravity": "Antigravity",
+        "grok": "Grok Build",
     }.get(provider.lower(), provider)
     return fmt(
         t("session.reset_header"),

--- a/ductor_bot/workspace/rules_selector.py
+++ b/ductor_bot/workspace/rules_selector.py
@@ -25,7 +25,8 @@ class RulesSelector:
 
     Deployed naming in ~/.ductor/:
     - CLAUDE.md (created if Claude authenticated)
-    - AGENTS.md (created if Codex authenticated)
+    - AGENTS.md (created if Codex and/or Grok authenticated — both harnesses
+      load project rules from AGENTS.md)
     - GEMINI.md (created if Gemini authenticated)
     - All synchronized via sync_rule_files() when multiple exist
 
@@ -43,6 +44,7 @@ class RulesSelector:
         claude_result = auth.get("claude")
         codex_result = auth.get("codex")
         gemini_result = auth.get("gemini")
+        grok_result = auth.get("grok")
 
         self._claude_authenticated = (
             claude_result.status == AuthStatus.AUTHENTICATED if claude_result else False
@@ -53,6 +55,14 @@ class RulesSelector:
         self._gemini_authenticated = (
             gemini_result.status == AuthStatus.AUTHENTICATED if gemini_result else False
         )
+        self._grok_authenticated = (
+            grok_result.status == AuthStatus.AUTHENTICATED if grok_result else False
+        )
+
+    @property
+    def _agents_md_needed(self) -> bool:
+        """AGENTS.md is shared by Codex and Grok Build."""
+        return self._codex_authenticated or self._grok_authenticated
 
     @property
     def _authenticated_count(self) -> int:
@@ -62,6 +72,7 @@ class RulesSelector:
                 self._claude_authenticated,
                 self._codex_authenticated,
                 self._gemini_authenticated,
+                self._grok_authenticated,
             )
         )
 
@@ -71,13 +82,13 @@ class RulesSelector:
         Returns:
             "all-clis" if 2+ providers authenticated
             "claude-only" if only Claude
-            "codex-only" if only Codex
+            "codex-only" if only Codex (or only Grok — same AGENTS.md rules)
             "gemini-only" if only Gemini
             "claude-only" as fallback (no providers authenticated)
         """
         if self._authenticated_count >= 2:
             return "all-clis"
-        if self._codex_authenticated:
+        if self._codex_authenticated or self._grok_authenticated:
             return "codex-only"
         if self._gemini_authenticated:
             return "gemini-only"
@@ -138,16 +149,17 @@ class RulesSelector:
 
         Deployment logic:
         - Claude authenticated → CLAUDE.md
-        - Codex authenticated → AGENTS.md
+        - Codex and/or Grok authenticated → AGENTS.md
         - Gemini authenticated → GEMINI.md
         """
         variant = self.get_variant_suffix()
         logger.info(
-            "Deploying rule files (variant: %s, claude=%s, codex=%s, gemini=%s)",
+            "Deploying rule files (variant: %s, claude=%s, codex=%s, gemini=%s, grok=%s)",
             variant,
             self._claude_authenticated,
             self._codex_authenticated,
             self._gemini_authenticated,
+            self._grok_authenticated,
         )
 
         template_dirs = self.discover_template_directories()
@@ -179,8 +191,8 @@ class RulesSelector:
                     deployed_count += 1
                     logger.debug("Deployed: %s -> CLAUDE.md", template.name)
 
-                # Deploy AGENTS.md if Codex is authenticated
-                if self._codex_authenticated:
+                # Deploy AGENTS.md if Codex and/or Grok is authenticated
+                if self._agents_md_needed:
                     agents_dst = dst_dir / "AGENTS.md"
                     shutil.copy2(template, agents_dst)
                     deployed_count += 1
@@ -197,11 +209,12 @@ class RulesSelector:
                 logger.exception("Failed to deploy %s", template)
 
         logger.info(
-            "Deployed %d rule files (Claude=%s, Codex=%s, Gemini=%s)",
+            "Deployed %d rule files (Claude=%s, Codex=%s, Gemini=%s, Grok=%s)",
             deployed_count,
             self._claude_authenticated,
             self._codex_authenticated,
             self._gemini_authenticated,
+            self._grok_authenticated,
         )
 
         # Cleanup: Remove stale files that don't match current auth status
@@ -211,13 +224,14 @@ class RulesSelector:
         """Remove rule files that don't match current auth status.
 
         Removes CLAUDE.md, AGENTS.md, or GEMINI.md files for providers
-        that are not currently authenticated.
+        that are not currently authenticated. AGENTS.md is kept while either
+        Codex or Grok is authenticated.
         """
         stale: list[tuple[str, str]] = []
         if not self._claude_authenticated:
             stale.append(("CLAUDE.md", "Claude"))
-        if not self._codex_authenticated:
-            stale.append(("AGENTS.md", "Codex"))
+        if not self._agents_md_needed:
+            stale.append(("AGENTS.md", "Codex/Grok"))
         if not self._gemini_authenticated:
             stale.append(("GEMINI.md", "Gemini"))
 

--- a/ductor_bot/workspace/skill_sync.py
+++ b/ductor_bot/workspace/skill_sync.py
@@ -38,7 +38,7 @@ _SKIP_DIRS: frozenset[str] = frozenset(
 
 _SKILL_SYNC_INTERVAL = 30.0
 _MANAGED_MARKER = ".ductor_managed"
-_SYNCABLE_PROVIDERS: frozenset[str] = frozenset({"claude", "codex", "gemini"})
+_SYNCABLE_PROVIDERS: frozenset[str] = frozenset({"claude", "codex", "gemini", "grok"})
 
 
 def _load_skill_sync_config(config_path: Path) -> tuple[bool, frozenset[str]]:
@@ -152,6 +152,10 @@ def _cli_skill_dirs(enabled_providers: frozenset[str] | None = None) -> dict[str
         gemini_home = Path.home() / ".gemini"
         if gemini_home.is_dir():
             dirs["gemini"] = gemini_home / "skills"
+    if enabled_providers is None or "grok" in enabled_providers:
+        grok_home = Path(os.environ.get("GROK_HOME", str(Path.home() / ".grok")))
+        if grok_home.is_dir():
+            dirs["grok"] = grok_home / "skills"
     return dirs
 
 
@@ -390,7 +394,7 @@ def sync_skills(paths: DuctorPaths, *, docker_active: bool = False) -> None:
         all_names.update(reg.keys())
 
     # Priority order: ductor > claude > codex > gemini
-    priority = ("ductor", "claude", "codex", "gemini")
+    priority = ("ductor", "claude", "codex", "gemini", "grok")
     for skill_name in sorted(all_names):
         canonical = _resolve_canonical(
             skill_name,

--- a/tests/cli/test_grok_discovery.py
+++ b/tests/cli/test_grok_discovery.py
@@ -1,0 +1,116 @@
+"""Tests for dynamic Grok Build model discovery and caching."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ductor_bot.cli.grok_cache import _FALLBACK_GROK_MODELS, GrokModelCache
+from ductor_bot.cli.grok_discovery import _parse_models, discover_grok_models
+from ductor_bot.config import (
+    ModelRegistry,
+    get_grok_models_ordered,
+    reset_grok_models,
+    set_grok_models,
+)
+
+_SAMPLE_OUTPUT = """You are logged in with grok.com.
+
+Default model: grok-4.5
+
+Available models:
+  * grok-4.5 (default)
+  - grok-composer-2.5-fast
+"""
+
+
+@pytest.fixture(autouse=True)
+def _reset_grok_models() -> Iterator[None]:
+    reset_grok_models()
+    yield
+    reset_grok_models()
+
+
+def test_parse_models_bullets_and_default_suffix() -> None:
+    assert _parse_models(_SAMPLE_OUTPUT) == (
+        "grok-4.5",
+        "grok-composer-2.5-fast",
+    )
+
+
+def test_parse_models_default_only_fallback() -> None:
+    assert _parse_models("Default model: grok-4.5\n") == ("grok-4.5",)
+
+
+def test_parse_models_rejects_usage_banner() -> None:
+    assert _parse_models("Usage: grok models\nList available models") == ()
+
+
+def test_parse_models_skips_duplicates() -> None:
+    raw = "  * grok-4.5\n  - grok-4.5\n  - grok-new\n"
+    assert _parse_models(raw) == ("grok-4.5", "grok-new")
+
+
+def _mock_proc(stdout: bytes, returncode: int = 0) -> AsyncMock:
+    proc = AsyncMock(spec=asyncio.subprocess.Process)
+    proc.returncode = returncode
+    proc.pid = 4242
+    proc.communicate = AsyncMock(return_value=(stdout, b""))
+    return proc
+
+
+async def test_discover_returns_models_on_success() -> None:
+    with (
+        patch("ductor_bot.cli.grok_discovery.which", return_value="/usr/bin/grok"),
+        patch(
+            "ductor_bot.cli.grok_discovery.asyncio.create_subprocess_exec",
+            return_value=_mock_proc(_SAMPLE_OUTPUT.encode()),
+        ),
+    ):
+        models = await discover_grok_models()
+
+    assert models == ("grok-4.5", "grok-composer-2.5-fast")
+
+
+async def test_discover_returns_empty_when_not_logged_in() -> None:
+    with (
+        patch("ductor_bot.cli.grok_discovery.which", return_value="/usr/bin/grok"),
+        patch(
+            "ductor_bot.cli.grok_discovery.asyncio.create_subprocess_exec",
+            return_value=_mock_proc(b"not logged in\nrun `grok login`\n", returncode=1),
+        ),
+    ):
+        assert await discover_grok_models() == ()
+
+
+async def test_discover_returns_empty_when_binary_missing() -> None:
+    with patch("ductor_bot.cli.grok_discovery.which", return_value=None):
+        assert await discover_grok_models() == ()
+
+
+async def test_cache_persists_discovered_models(tmp_path: Path) -> None:
+    path = tmp_path / "grok_models.json"
+    with patch(
+        "ductor_bot.cli.grok_cache.discover_grok_models",
+        return_value=("grok-4.5", "grok-future"),
+    ):
+        cache = await GrokModelCache.load_or_refresh(path, force_refresh=True)
+    assert cache.models == ("grok-4.5", "grok-future")
+    assert path.is_file()
+    loaded = GrokModelCache.from_json(__import__("json").loads(path.read_text()))
+    assert loaded.models == cache.models
+
+
+def test_set_grok_models_updates_registry_and_order() -> None:
+    set_grok_models(("grok-z", "grok-a"))
+    assert get_grok_models_ordered() == ("grok-z", "grok-a")
+    assert ModelRegistry.provider_for("grok-z") == "grok"
+    assert ModelRegistry.provider_for("grok-a") == "grok"
+
+
+def test_fallback_models_match_hardcoded() -> None:
+    assert "grok-4.5" in _FALLBACK_GROK_MODELS

--- a/tests/cli/test_grok_provider.py
+++ b/tests/cli/test_grok_provider.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -15,11 +14,16 @@ from ductor_bot.cli.grok_events import parse_grok_json, parse_grok_stream_line
 from ductor_bot.cli.grok_provider import GrokCLI, _parse_response
 from ductor_bot.cli.stream_events import (
     AssistantTextDelta,
+    CompactBoundaryEvent,
     ResultEvent,
+    SystemStatusEvent,
     ThinkingEvent,
     ToolUseEvent,
 )
+from ductor_bot.cli.types import CLIResponse
 from ductor_bot.config import ModelRegistry
+from ductor_bot.cron.execution import _build_grok_cmd
+from ductor_bot.cli.param_resolver import TaskExecutionConfig
 
 
 class TestGrokEvents:
@@ -29,18 +33,32 @@ class TestGrokEvents:
                 "text": "hello from grok",
                 "stopReason": "EndTurn",
                 "sessionId": "sid-1",
-                "usage": {"input_tokens": 10, "output_tokens": 3},
+                "usage": {
+                    "input_tokens": 10,
+                    "cache_read_input_tokens": 100,
+                    "output_tokens": 3,
+                    "total_tokens": 113,
+                },
                 "num_turns": 1,
                 "modelUsage": {"grok-4.5": {"inputTokens": 10}},
+                "total_cost_usd": 0.0123,
             }
         )
-        text, session_id, usage, model_usage, turns, is_error = parse_grok_json(raw)
+        text, session_id, usage, model_usage, turns, is_error, cost = parse_grok_json(raw)
         assert text == "hello from grok"
         assert session_id == "sid-1"
         assert usage["input_tokens"] == 10
+        assert usage["total_tokens"] == 113
         assert model_usage["grok-4.5"]["inputTokens"] == 10
         assert turns == 1
         assert is_error is False
+        assert cost == 0.0123
+
+    def test_parse_json_error_envelope(self) -> None:
+        raw = json.dumps({"type": "error", "message": "Couldn't start session"})
+        text, _sid, _u, _m, _t, is_error, _c = parse_grok_json(raw)
+        assert is_error is True
+        assert "Couldn't start session" in text
 
     def test_parse_stream_thought_text_end(self) -> None:
         events = []
@@ -48,7 +66,8 @@ class TestGrokEvents:
             '{"type":"thought","data":"plan"}',
             '{"type":"text","data":"hi"}',
             '{"type":"text","data":"!"}',
-            '{"type":"end","stopReason":"EndTurn","sessionId":"s2","usage":{"input_tokens":1},"num_turns":1}',
+            '{"type":"end","stopReason":"EndTurn","sessionId":"s2",'
+            '"usage":{"input_tokens":1,"total_tokens":5},"num_turns":1,"total_cost_usd":0.01}',
         ):
             events.extend(parse_grok_stream_line(line))
         assert isinstance(events[0], ThinkingEvent)
@@ -60,6 +79,8 @@ class TestGrokEvents:
         assert isinstance(events[3], ResultEvent)
         assert events[3].session_id == "s2"
         assert events[3].is_error is False
+        assert events[3].total_cost_usd == 0.01
+        assert events[3].usage["total_tokens"] == 5
 
     def test_parse_stream_tool_use(self) -> None:
         events = parse_grok_stream_line(
@@ -69,6 +90,31 @@ class TestGrokEvents:
         assert isinstance(events[0], ToolUseEvent)
         assert events[0].tool_name == "Shell"
         assert events[0].parameters == {"command": "ls"}
+
+    def test_parse_stream_error(self) -> None:
+        events = parse_grok_stream_line(
+            '{"type":"error","message":"auth failed","sessionId":"e1"}'
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], ResultEvent)
+        assert events[0].is_error is True
+        assert events[0].result == "auth failed"
+        assert events[0].session_id == "e1"
+
+    def test_parse_stream_auto_compact(self) -> None:
+        events = parse_grok_stream_line(
+            '{"type":"auto_compact_start","pre_tokens":12000,"trigger":"threshold"}'
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], CompactBoundaryEvent)
+        assert events[0].pre_tokens == 12000
+        assert "auto_compact" in events[0].trigger or events[0].trigger == "threshold"
+
+    def test_parse_stream_max_turns(self) -> None:
+        events = parse_grok_stream_line('{"type":"max_turns_reached"}')
+        assert len(events) == 1
+        assert isinstance(events[0], SystemStatusEvent)
+        assert events[0].status == "max_turns_reached"
 
 
 class TestGrokProvider:
@@ -88,6 +134,8 @@ class TestGrokProvider:
                 system_prompt="SYS",
                 append_system_prompt="RULES",
                 max_turns=7,
+                allowed_tools=["read_file", "grep"],
+                disallowed_tools=["run_terminal_cmd"],
             )
         )
         cmd = cli._build_command("hello world")
@@ -101,6 +149,11 @@ class TestGrokProvider:
         assert cmd[cmd.index("--system-prompt-override") + 1] == "SYS"
         assert cmd[cmd.index("--rules") + 1] == "RULES"
         assert cmd[cmd.index("--max-turns") + 1] == "7"
+        assert cmd[cmd.index("--tools") + 1] == "read_file,grep"
+        assert cmd[cmd.index("--disallowed-tools") + 1] == "run_terminal_cmd"
+        # Must not confuse tool filters with permission allow/deny rules.
+        assert "--allow" not in cmd
+        assert "--deny" not in cmd
 
     def test_build_command_resume_and_streaming(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("ductor_bot.cli.grok_provider.which", lambda _: "/usr/bin/grok")
@@ -122,19 +175,62 @@ class TestGrokProvider:
         cli._cleanup_prompt_files()
         assert not path.exists()
 
-    def test_parse_response(self) -> None:
+    def test_parse_response_cost_and_total_tokens(self) -> None:
         payload = {
             "text": "ok",
             "sessionId": "s9",
-            "usage": {"input_tokens": 2, "output_tokens": 1},
+            "usage": {
+                "input_tokens": 100,
+                "cache_read_input_tokens": 900,
+                "output_tokens": 50,
+                "total_tokens": 1050,
+            },
             "num_turns": 1,
             "stopReason": "EndTurn",
+            "total_cost_usd": 0.0042,
         }
         resp = _parse_response(json.dumps(payload).encode(), b"", 0)
         assert resp.result == "ok"
         assert resp.session_id == "s9"
         assert resp.is_error is False
-        assert resp.total_tokens == 3
+        assert resp.total_cost_usd == 0.0042
+        assert resp.total_tokens == 1050  # prefers usage.total_tokens
+
+
+def _grok_task_cfg(**kwargs: Any) -> TaskExecutionConfig:
+    base = dict(
+        provider="grok",
+        model="grok-4.5",
+        reasoning_effort="medium",
+        permission_mode="bypassPermissions",
+        cli_parameters=[],
+        working_dir="/tmp",
+        file_access="all",
+    )
+    base.update(kwargs)
+    return TaskExecutionConfig(**base)
+
+
+class TestGrokCronCmd:
+    def test_short_prompt_uses_p(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("ductor_bot.cron.execution.which", lambda _: "/usr/bin/grok")
+        one = _build_grok_cmd(_grok_task_cfg(), "hello")
+        assert one is not None
+        assert "-p" in one.cmd
+        assert one.cmd[one.cmd.index("-p") + 1] == "hello"
+        assert one.cleanup_paths == []
+
+    def test_long_prompt_uses_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("ductor_bot.cron.execution.which", lambda _: "/usr/bin/grok")
+        long_prompt = "y" * 30_000
+        one = _build_grok_cmd(_grok_task_cfg(reasoning_effort=""), long_prompt)
+        assert one is not None
+        assert "--prompt-file" in one.cmd
+        path = Path(one.cmd[one.cmd.index("--prompt-file") + 1])
+        assert path.is_file()
+        assert path.read_text(encoding="utf-8") == long_prompt
+        assert path in one.cleanup_paths
+        path.unlink(missing_ok=True)
 
 
 class TestFactoryAndRegistry:
@@ -148,3 +244,14 @@ class TestFactoryAndRegistry:
         assert ModelRegistry.provider_for("grok-composer-2.5-fast") == "grok"
         assert ModelRegistry.provider_for("grok-custom-future") == "grok"
         assert ModelRegistry.provider_for("opus") == "claude"
+
+    def test_cli_response_prefers_explicit_total_tokens(self) -> None:
+        r = CLIResponse(
+            usage={
+                "input_tokens": 100,
+                "cache_read_input_tokens": 900,
+                "output_tokens": 50,
+                "total_tokens": 1050,
+            }
+        )
+        assert r.total_tokens == 1050

--- a/tests/cli/test_grok_provider.py
+++ b/tests/cli/test_grok_provider.py
@@ -1,0 +1,150 @@
+"""Unit tests for Grok Build provider event parsing and command building."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ductor_bot.cli.base import CLIConfig
+from ductor_bot.cli.factory import create_cli
+from ductor_bot.cli.grok_events import parse_grok_json, parse_grok_stream_line
+from ductor_bot.cli.grok_provider import GrokCLI, _parse_response
+from ductor_bot.cli.stream_events import (
+    AssistantTextDelta,
+    ResultEvent,
+    ThinkingEvent,
+    ToolUseEvent,
+)
+from ductor_bot.config import ModelRegistry
+
+
+class TestGrokEvents:
+    def test_parse_json_happy_path(self) -> None:
+        raw = json.dumps(
+            {
+                "text": "hello from grok",
+                "stopReason": "EndTurn",
+                "sessionId": "sid-1",
+                "usage": {"input_tokens": 10, "output_tokens": 3},
+                "num_turns": 1,
+                "modelUsage": {"grok-4.5": {"inputTokens": 10}},
+            }
+        )
+        text, session_id, usage, model_usage, turns, is_error = parse_grok_json(raw)
+        assert text == "hello from grok"
+        assert session_id == "sid-1"
+        assert usage["input_tokens"] == 10
+        assert model_usage["grok-4.5"]["inputTokens"] == 10
+        assert turns == 1
+        assert is_error is False
+
+    def test_parse_stream_thought_text_end(self) -> None:
+        events = []
+        for line in (
+            '{"type":"thought","data":"plan"}',
+            '{"type":"text","data":"hi"}',
+            '{"type":"text","data":"!"}',
+            '{"type":"end","stopReason":"EndTurn","sessionId":"s2","usage":{"input_tokens":1},"num_turns":1}',
+        ):
+            events.extend(parse_grok_stream_line(line))
+        assert isinstance(events[0], ThinkingEvent)
+        assert events[0].text == "plan"
+        assert isinstance(events[1], AssistantTextDelta)
+        assert events[1].text == "hi"
+        assert isinstance(events[2], AssistantTextDelta)
+        assert events[2].text == "!"
+        assert isinstance(events[3], ResultEvent)
+        assert events[3].session_id == "s2"
+        assert events[3].is_error is False
+
+    def test_parse_stream_tool_use(self) -> None:
+        events = parse_grok_stream_line(
+            '{"type":"tool_use","name":"Shell","id":"t1","input":{"command":"ls"}}'
+        )
+        assert len(events) == 1
+        assert isinstance(events[0], ToolUseEvent)
+        assert events[0].tool_name == "Shell"
+        assert events[0].parameters == {"command": "ls"}
+
+
+class TestGrokProvider:
+    def test_find_cli_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("ductor_bot.cli.grok_provider.which", lambda _: None)
+        with pytest.raises(FileNotFoundError, match="grok CLI not found"):
+            GrokCLI(CLIConfig(provider="grok"))
+
+    def test_build_command_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("ductor_bot.cli.grok_provider.which", lambda _: "/usr/bin/grok")
+        cli = GrokCLI(
+            CLIConfig(
+                provider="grok",
+                model="grok-4.5",
+                permission_mode="bypassPermissions",
+                reasoning_effort="high",
+                system_prompt="SYS",
+                append_system_prompt="RULES",
+                max_turns=7,
+            )
+        )
+        cmd = cli._build_command("hello world")
+        assert cmd[0] == "/usr/bin/grok"
+        assert "--output-format" in cmd and "json" in cmd
+        assert cmd[cmd.index("-p") + 1] == "hello world"
+        assert "--permission-mode" in cmd and "bypassPermissions" in cmd
+        assert "--always-approve" in cmd
+        assert cmd[cmd.index("--model") + 1] == "grok-4.5"
+        assert cmd[cmd.index("--reasoning-effort") + 1] == "high"
+        assert cmd[cmd.index("--system-prompt-override") + 1] == "SYS"
+        assert cmd[cmd.index("--rules") + 1] == "RULES"
+        assert cmd[cmd.index("--max-turns") + 1] == "7"
+
+    def test_build_command_resume_and_streaming(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("ductor_bot.cli.grok_provider.which", lambda _: "/usr/bin/grok")
+        cli = GrokCLI(CLIConfig(provider="grok", model="grok-4.5"))
+        cmd = cli._build_command("follow up", resume_session="abc", output_format="streaming-json")
+        assert "--output-format" in cmd and "streaming-json" in cmd
+        assert cmd[cmd.index("--resume") + 1] == "abc"
+
+    def test_long_prompt_uses_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("ductor_bot.cli.grok_provider.which", lambda _: "/usr/bin/grok")
+        monkeypatch.setattr("ductor_bot.cli.grok_provider._IS_WINDOWS", False)
+        cli = GrokCLI(CLIConfig(provider="grok"))
+        long_prompt = "x" * 30_000
+        cmd = cli._build_command(long_prompt)
+        assert "--prompt-file" in cmd
+        path = Path(cmd[cmd.index("--prompt-file") + 1])
+        assert path.is_file()
+        assert path.read_text(encoding="utf-8") == long_prompt
+        cli._cleanup_prompt_files()
+        assert not path.exists()
+
+    def test_parse_response(self) -> None:
+        payload = {
+            "text": "ok",
+            "sessionId": "s9",
+            "usage": {"input_tokens": 2, "output_tokens": 1},
+            "num_turns": 1,
+            "stopReason": "EndTurn",
+        }
+        resp = _parse_response(json.dumps(payload).encode(), b"", 0)
+        assert resp.result == "ok"
+        assert resp.session_id == "s9"
+        assert resp.is_error is False
+        assert resp.total_tokens == 3
+
+
+class TestFactoryAndRegistry:
+    def test_factory_returns_grok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("ductor_bot.cli.grok_provider.which", lambda _: "/usr/bin/grok")
+        cli = create_cli(CLIConfig(provider="grok", model="grok-4.5"))
+        assert isinstance(cli, GrokCLI)
+
+    def test_model_registry_routes_grok(self) -> None:
+        assert ModelRegistry.provider_for("grok-4.5") == "grok"
+        assert ModelRegistry.provider_for("grok-composer-2.5-fast") == "grok"
+        assert ModelRegistry.provider_for("grok-custom-future") == "grok"
+        assert ModelRegistry.provider_for("opus") == "claude"

--- a/tests/workspace/test_rules_selector.py
+++ b/tests/workspace/test_rules_selector.py
@@ -102,6 +102,7 @@ def test_deploy_claude_only_no_agents_md(mock_paths: DuctorPaths) -> None:
     auth = {
         "claude": AuthResult(provider="claude", status=AuthStatus.AUTHENTICATED),
         "codex": AuthResult(provider="codex", status=AuthStatus.NOT_FOUND),
+        "grok": AuthResult(provider="grok", status=AuthStatus.NOT_FOUND),
     }
 
     with patch("ductor_bot.cli.auth.check_all_auth", return_value=auth):
@@ -116,6 +117,26 @@ def test_deploy_claude_only_no_agents_md(mock_paths: DuctorPaths) -> None:
         # Check that AGENTS.md was NOT created
         config_agents = mock_paths.ductor_home / "config" / "AGENTS.md"
         assert not config_agents.exists()
+
+
+def test_deploy_grok_only_with_agents_md(mock_paths: DuctorPaths) -> None:
+    """Grok Build loads AGENTS.md; deploy it when only Grok is authenticated."""
+    auth = {
+        "claude": AuthResult(provider="claude", status=AuthStatus.NOT_FOUND),
+        "codex": AuthResult(provider="codex", status=AuthStatus.NOT_FOUND),
+        "gemini": AuthResult(provider="gemini", status=AuthStatus.NOT_FOUND),
+        "grok": AuthResult(provider="grok", status=AuthStatus.AUTHENTICATED),
+    }
+
+    with patch("ductor_bot.cli.auth.check_all_auth", return_value=auth):
+        selector = RulesSelector(mock_paths)
+        assert selector.get_variant_suffix() == "codex-only"
+        selector.deploy_rules()
+
+        config_agents = mock_paths.ductor_home / "config" / "AGENTS.md"
+        assert config_agents.exists()
+        assert "Codex Only Template" in config_agents.read_text()
+        assert not (mock_paths.ductor_home / "config" / "CLAUDE.md").exists()
 
 
 def test_deploy_codex_only_with_agents_md(mock_paths: DuctorPaths) -> None:


### PR DESCRIPTION
## Summary
Adds **Grok Build** (`grok` CLI from xAI) as a first-class ductor provider next to Claude Code, Codex, Gemini, and Antigravity.

Grok 4.5 is currently the default model in Grok Build and is a strong coding agent harness. This PR makes it controllable from Telegram/Matrix/Slack the same way as the other official CLIs.

### What works
- Headless oneshot: `grok -p … --output-format json`
- Streaming to messenger: `--output-format streaming-json` (`thought` / `text` / `tool` / `error` / `auto_compact_*` / `end`)
- Session continuity: `--resume` / `--continue`
- Auth detection: `~/.grok/auth.json`, `XAI_API_KEY`, or `grok models` probe
- Models: dynamic discovery via `grok models` (hourly cache) with fallback `grok-4.5` / `grok-composer-2.5-fast`, plus any `grok-*` ID
- Reasoning effort (`none` … `max` via `--reasoning-effort`)
- Permission bypass (`--permission-mode bypassPermissions` + `--always-approve`)
- Tool filters: `--tools` / `--disallowed-tools`
- Spend: prefers `usage.total_tokens` and maps `total_cost_usd`
- Telegram `/model` picker, `@grok` / `@grok-4.5` session directives
- Cron / webhook provider choices (long prompts via `--prompt-file`)
- Skill sync into `~/.grok/skills`
- AGENTS.md rule deployment when Grok and/or Codex is authenticated
- Unit tests for parsers, command building, discovery/cache, and rules selector

### How to try
1. Install Grok Build: `curl -fsSL https://x.ai/cli/install.sh | bash`
2. Auth: `grok login` or `export XAI_API_KEY=…`
3. In config: `"provider": "grok", "model": "grok-4.5"` (or switch via `/model` when multiple providers are authenticated)

### Test plan
- [x] `pytest tests/cli/test_grok_provider.py tests/cli/test_grok_discovery.py`
- [x] Live oneshot / streaming / session resume against Grok CLI 0.2.x
- [x] Live model discovery writes `grok_models.json`
- [ ] Maintainer: smoke Telegram turn with provider=grok

### Notes
- No personal tokens, host paths, or account identifiers
- Advanced Grok-only flags (best-of-n, worktree, ACP, json-schema) left for `cli_parameters.grok` passthrough
