### PR TITLE
docs(rules): do not background shell commands for later results

### DIFF
--- a/ductor_bot/_home_defaults/workspace/RULES.md
+++ b/ductor_bot/_home_defaults/workspace/RULES.md
@@ -143,6 +143,7 @@ This creates a clean conversation layer: user ↔ you ↔ task agent.
 ### Critical rules
 
 - Do NOT attempt long-running work yourself — delegate it
+- Do NOT background a shell command (e.g. Bash `run_in_background`) for results you need later — the turn's process exits and the notification is lost; use `create_task.py`
 - Do NOT wait silently for a task to finish — keep talking with the user
 - Do NOT present task results unchecked — verify them first
 - If a task fails, tell the user and offer to retry


### PR DESCRIPTION
## Problem

A shell command started in the background (e.g. Claude Code's `Bash` tool with `run_in_background`) outlives the agent turn, but the CLI process that would deliver its completion does not: every provider turn runs as a fresh subprocess that exits once the turn completes (`ductor_bot/cli/executor.py` — both the one-shot and streaming paths spawn a process and await its exit).

The command still runs to completion, but its completion notification fires into a dead process and is lost. Nobody is notified, and the result only surfaces if someone happens to ask about it later.

## Change

One bullet in the "Critical rules" list of the Work Delegation section, pointing agents at `create_task.py` — the durable path, whose result is delivered back to the chat on completion.

The existing ">30 seconds -> delegate to a background task" rule is framed as *agent delegation*, which doesn't obviously map to "I have a shell command to run in the background", so the failure mode recurs.

Docs only, no behaviour change.
