### PR TITLE
fix(grok): smoother Telegram stream + WORKING idle indicator

### DIFF
--- a/ductor_bot/bus/cron_sanitize.py
+++ b/ductor_bot/bus/cron_sanitize.py
@@ -1,12 +1,52 @@
 """Shared cron result sanitisation logic.
 
-Used by both Telegram and Matrix transport adapters to strip
-transport-level acknowledgement lines from cron output.
+Used by Telegram / Matrix / Slack transport adapters to clean cron output
+before delivery:
+
+* strip transport-level acknowledgement lines;
+* treat trailing ``HEARTBEAT_OK`` as silent even when scratch narration precedes it;
+* drop process monologue before the first high-confidence user-facing anchor
+  (models sometimes put "Gathering… Gate delivered…" into final ``text``).
 """
 
 from __future__ import annotations
 
+import re
+
 _CRON_ACK_MARKERS = ("message sent successfully", "delivered to telegram")
+_CRON_SILENT_ACKS = frozenset({"HEARTBEAT_OK"})
+
+# High-confidence starts of user-facing cron bodies. May appear mid-string
+# when monologue is glued to the real message without a newline.
+_USER_FACING_ANCHOR_RE = re.compile(
+    r"(?:"
+    r"🌙\s*\d{1,2}[./]\d{2}"  # e.g. evening recap header 🌙 28.07
+    r"|^\s*HEARTBEAT_OK\b"
+    r"|^\s*[✅📊📅⚠️💊🏋️💪😴🍽️💰🎮🔔🧠☀️🌙]"
+    r")",
+    re.MULTILINE,
+)
+
+_NARRATION_LINE_RE = re.compile(
+    r"(?is)^\s*(?:"
+    r"TASK\s*:"
+    r"|Gathering\b"
+    r"|Checking\b"
+    r"|Updating memory\b"
+    r"|Gate delivered\b"
+    r"|Pulling\b"
+    r"|Found\b"
+    r"|Memory shows\b"
+    r"|Returning\b"
+    r"|No memory\b"
+    r"|Writing the proactive\b"
+    r"|then sending\b"
+    r"|health-only recap\b"
+    r"|proactive trace\b"
+    r"|Read through TASK_DESCRIPTION\b"
+    r"|sources fresh\b"
+    r").*$"
+)
 
 
 def is_cron_transport_ack_line(line: str) -> bool:
@@ -15,9 +55,47 @@ def is_cron_transport_ack_line(line: str) -> bool:
     return all(marker in normalized for marker in _CRON_ACK_MARKERS)
 
 
+def _last_meaningful_line(text: str) -> str:
+    """Return last non-empty stripped line, or empty string."""
+    for line in reversed(text.splitlines()):
+        s = line.strip()
+        if s:
+            return s
+    return ""
+
+
+def _strip_preamble(text: str) -> str:
+    """Drop process monologue before the first user-facing anchor."""
+    if not text:
+        return ""
+
+    match = _USER_FACING_ANCHOR_RE.search(text)
+    if match is not None and match.start() > 0:
+        return text[match.start() :].lstrip()
+
+    kept: list[str] = []
+    for line in text.splitlines():
+        if _NARRATION_LINE_RE.match(line):
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
+
+
+def _is_silent_ack(text: str) -> bool:
+    """True if text is empty or a (possibly narrated) HEARTBEAT_OK."""
+    if not text:
+        return True
+    if text.strip() in _CRON_SILENT_ACKS:
+        return True
+    return _last_meaningful_line(text) in _CRON_SILENT_ACKS
+
+
 def sanitize_cron_result_text(result: str) -> str:
-    """Strip transport ack lines from a cron result."""
-    if not result:
+    """Strip transport acks, silent HEARTBEAT, and process preambles."""
+    if _is_silent_ack(result):
         return ""
     lines = [line for line in result.splitlines() if not is_cron_transport_ack_line(line)]
-    return "\n".join(lines).strip()
+    cleaned = "\n".join(lines).strip()
+    if _is_silent_ack(cleaned):
+        return ""
+    return _strip_preamble(cleaned)

--- a/ductor_bot/cli/grok_events.py
+++ b/ductor_bot/cli/grok_events.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -256,3 +257,165 @@ def _as_str(value: object) -> str:
     if isinstance(value, str):
         return value
     return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Stream assembly for Grok token deltas (Telegram UX)
+# ---------------------------------------------------------------------------
+
+# Sentence/clause ends that often glue to the next capital without a space.
+_SOFT_SPACE_END = frozenset(".!?;:…)]}”\"'")
+_SOFT_SPACE_START_SKIP = frozenset(" \t\n\r.,!?;:)]}…\"'`*_~-")
+_SENTENCE_END_RE = re.compile(r"[.!?][\s\n]")
+
+# Defaults tuned for token streams: less twitchy than raw 1-token edits.
+DEFAULT_TEXT_MIN_CHARS = 160
+DEFAULT_TEXT_MAX_CHARS = 700
+DEFAULT_WORKING_IDLE_MS = 2500
+
+
+def soft_space_join(prev: str, nxt: str) -> str:
+    """Insert a single space when Grok glues ``end.Start`` across deltas.
+
+    Conservative: only when *prev* ends with sentence/clause punctuation (or
+    closes a quote/bracket) and *nxt* starts with an alphanumeric / Cyrillic
+    letter. Never touches markdown openers (``*`, ``_``, ````` ``) or paths.
+    """
+    if not prev or not nxt:
+        return nxt
+    left = prev[-1]
+    right = nxt[0]
+    if left not in _SOFT_SPACE_END:
+        return nxt
+    if right in _SOFT_SPACE_START_SKIP:
+        return nxt
+    if right.isalnum() or ("\u0400" <= right <= "\u04ff"):
+        return " " + nxt
+    return nxt
+
+
+class GrokStreamAssembler:
+    """Normalize Grok token streams before they hit the Telegram coalescer.
+
+    * Soft-space between text deltas (``.Listing`` → ``. Listing``).
+    * Buffer text until a readable boundary (sentence / min / max chars).
+    * On prolonged silence (tool turns with no stream events), emit
+      ``SystemStatusEvent(status="working")`` once until the next real event.
+    """
+
+    def __init__(
+        self,
+        *,
+        min_chars: int = DEFAULT_TEXT_MIN_CHARS,
+        max_chars: int = DEFAULT_TEXT_MAX_CHARS,
+        working_idle_ms: int = DEFAULT_WORKING_IDLE_MS,
+    ) -> None:
+        self._min_chars = min_chars
+        self._max_chars = max_chars
+        self._working_idle_ms = working_idle_ms
+        self._text_buf = ""
+        self._emitted_tail = ""
+        self._working_sent = False
+        self._saw_activity = False
+
+    @property
+    def working_idle_ms(self) -> int:
+        return self._working_idle_ms
+
+    def process(self, event: StreamEvent) -> list[StreamEvent]:
+        """Ingest one parsed stream event; return zero or more to emit."""
+        self._saw_activity = True
+        if isinstance(event, AssistantTextDelta):
+            return self._feed_text(event.text)
+        if isinstance(event, ThinkingEvent):
+            self._working_sent = False
+            out = self._flush_text(force=True)
+            out.append(event)
+            return out
+        if isinstance(event, (ToolUseEvent, ResultEvent)):
+            self._working_sent = False
+            out = self._flush_text(force=True)
+            out.append(event)
+            return out
+        # Other system events (compact, max_turns, …)
+        self._working_sent = False
+        out = self._flush_text(force=True)
+        out.append(event)
+        return out
+
+    def on_idle(self) -> list[StreamEvent]:
+        """Called when the CLI is silent longer than ``working_idle_ms``.
+
+        Flushes any buffered text, then emits a single WORKING status until the
+        next real event (covers silent multi-turn tool use).
+        """
+        if not self._saw_activity:
+            return []
+        out = self._flush_text(force=True)
+        if not self._working_sent:
+            self._working_sent = True
+            out.append(SystemStatusEvent(type="system", subtype="status", status="working"))
+        return out
+
+    def flush(self) -> list[StreamEvent]:
+        """Force-flush remaining text at stream end (no WORKING)."""
+        return self._flush_text(force=True)
+
+    def _feed_text(self, piece: str) -> list[StreamEvent]:
+        if not piece:
+            return []
+        self._working_sent = False
+        self._text_buf = self._append_with_soft_space(self._text_buf, piece)
+
+        out: list[StreamEvent] = []
+        while len(self._text_buf) >= self._max_chars:
+            out.extend(self._emit_prefix(self._max_chars))
+        if len(self._text_buf) >= self._min_chars:
+            sentence_at = self._last_sentence_break(self._text_buf)
+            if sentence_at is not None and sentence_at >= self._min_chars // 2:
+                out.extend(self._emit_prefix(sentence_at))
+            elif "\n\n" in self._text_buf:
+                pos = self._text_buf.rfind("\n\n")
+                if pos + 2 >= self._min_chars // 2:
+                    out.extend(self._emit_prefix(pos + 2))
+        return out
+
+    def _append_with_soft_space(self, buf: str, piece: str) -> str:
+        if not piece:
+            return buf
+        if not buf:
+            # First piece in this buffer: may need space after last *emitted* tail.
+            return soft_space_join(self._emitted_tail, piece) if self._emitted_tail else piece
+        spaced = soft_space_join(buf, piece)
+        if spaced.startswith(" ") and not piece.startswith(" "):
+            return buf + spaced
+        return buf + piece
+
+    def _flush_text(self, *, force: bool) -> list[StreamEvent]:
+        if not self._text_buf:
+            return []
+        if not force and len(self._text_buf) < self._min_chars:
+            return []
+        text = self._text_buf
+        self._text_buf = ""
+        self._emitted_tail = text[-8:] if text else self._emitted_tail
+        return [AssistantTextDelta(type="assistant", text=text)]
+
+    def _emit_prefix(self, end: int) -> list[StreamEvent]:
+        if end <= 0 or end > len(self._text_buf):
+            return []
+        text = self._text_buf[:end]
+        self._text_buf = self._text_buf[end:]
+        if not text:
+            return []
+        self._emitted_tail = text[-8:]
+        return [AssistantTextDelta(type="assistant", text=text)]
+
+    @staticmethod
+    def _last_sentence_break(buf: str) -> int | None:
+        last: re.Match[str] | None = None
+        for match in _SENTENCE_END_RE.finditer(buf):
+            last = match
+        if last is None:
+            return None
+        return last.end()

--- a/ductor_bot/cli/grok_provider.py
+++ b/ductor_bot/cli/grok_provider.py
@@ -13,10 +13,12 @@ Grok Build CLI surface (headless) closely mirrors Claude Code:
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
 import tempfile
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterator
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING, Any
@@ -30,7 +32,7 @@ from ductor_bot.cli.base import (
     format_cli_cmd,
 )
 from ductor_bot.cli.executor import SubprocessSpec, run_oneshot_subprocess, run_streaming_subprocess
-from ductor_bot.cli.grok_events import parse_grok_json, parse_grok_stream_line
+from ductor_bot.cli.grok_events import GrokStreamAssembler, parse_grok_json, parse_grok_stream_line
 from ductor_bot.cli.stream_events import (
     AssistantTextDelta,
     ResultEvent,
@@ -179,7 +181,12 @@ class GrokCLI(BaseCLI):
         timeout_seconds: float | None = None,
         timeout_controller: TimeoutController | None = None,
     ) -> AsyncGenerator[StreamEvent, None]:
-        """Send a prompt and yield stream events as they arrive."""
+        """Send a prompt and yield stream events as they arrive.
+
+        Grok emits token-level text deltas and (currently) no tool events during
+        multi-turn tool use. ``GrokStreamAssembler`` coalesces text, soft-fixes
+        glued punctuation, and emits WORKING on prolonged silence.
+        """
         try:
             cmd = self._build_command(
                 prompt,
@@ -190,10 +197,7 @@ class GrokCLI(BaseCLI):
             exec_cmd, use_cwd = docker_wrap(cmd, self._config, interactive=False)
             _log_cmd(exec_cmd, streaming=True)
 
-            accumulated: list[str] = []
-            saw_result = False
-
-            async for event in run_streaming_subprocess(
+            raw_stream = run_streaming_subprocess(
                 config=self._config,
                 spec=SubprocessSpec(
                     exec_cmd,
@@ -204,19 +208,9 @@ class GrokCLI(BaseCLI):
                 ),
                 line_handler=_grok_line_handler,
                 provider_label="Grok Build",
-            ):
-                if isinstance(event, AssistantTextDelta) and event.text:
-                    accumulated.append(event.text)
-                out = event
-                if isinstance(event, ResultEvent):
-                    saw_result = True
-                    # Grok end events often omit the full text; fill from deltas.
-                    if not event.result and accumulated:
-                        out = event.model_copy(update={"result": "".join(accumulated)})
-                yield out
-
-            if not saw_result and accumulated:
-                yield ResultEvent(type="result", result="".join(accumulated), is_error=False)
+            )
+            async for event in _assemble_grok_stream(raw_stream):
+                yield event
         finally:
             self._cleanup_prompt_files()
 
@@ -225,6 +219,71 @@ async def _grok_line_handler(line: str) -> AsyncGenerator[StreamEvent, None]:
     """Parse a single Grok streaming-json line into stream events."""
     for event in parse_grok_stream_line(line):
         yield event
+
+
+def _track_assembled_event(
+    event: StreamEvent,
+    *,
+    accumulated: list[str],
+) -> tuple[StreamEvent, bool]:
+    """Update accumulated text; return (maybe-filled event, is_result)."""
+    if isinstance(event, AssistantTextDelta) and event.text:
+        accumulated.append(event.text)
+        return event, False
+    if isinstance(event, ResultEvent):
+        if not event.result and accumulated:
+            event = event.model_copy(update={"result": "".join(accumulated)})
+        return event, True
+    return event, False
+
+
+async def _assemble_grok_stream(
+    raw_stream: AsyncIterator[StreamEvent],
+    *,
+    assembler: GrokStreamAssembler | None = None,
+) -> AsyncGenerator[StreamEvent, None]:
+    """Apply GrokStreamAssembler + idle WORKING detection over a raw event stream."""
+    asm = assembler or GrokStreamAssembler()
+    accumulated: list[str] = []
+    saw_result = False
+    idle_s = max(asm.working_idle_ms, 1) / 1000.0
+    stream_iter = raw_stream.__aiter__()
+    pending: asyncio.Task[StreamEvent] | None = None
+
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.ensure_future(stream_iter.__anext__())
+            done, _ = await asyncio.wait({pending}, timeout=idle_s)
+            if not done:
+                for event in asm.on_idle():
+                    yield event
+                continue
+
+            try:
+                raw_event = pending.result()
+            except StopAsyncIteration:
+                pending = None
+                break
+            pending = None
+
+            for event in asm.process(raw_event):
+                out, is_result = _track_assembled_event(event, accumulated=accumulated)
+                saw_result = saw_result or is_result
+                yield out
+
+        for event in asm.flush():
+            out, is_result = _track_assembled_event(event, accumulated=accumulated)
+            saw_result = saw_result or is_result
+            yield out
+
+        if not saw_result and accumulated:
+            yield ResultEvent(type="result", result="".join(accumulated), is_error=False)
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+            with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
+                await pending
 
 
 def _log_cmd(cmd: list[str], *, streaming: bool = False) -> None:

--- a/ductor_bot/messenger/telegram/edit_streaming.py
+++ b/ductor_bot/messenger/telegram/edit_streaming.py
@@ -275,31 +275,40 @@ class EditStreamEditor:
         self._s.last_edit_time = asyncio.get_event_loop().time()
 
     async def _handle_overflow(self, chunks: list[str]) -> None:
-        """Seal current message with first chunk, continue in a new one."""
+        """Seal overflow into permanent Telegram messages; never re-split them.
+
+        Token-level streams (Grok) re-render growing HTML on every edit. If the
+        overflow *tail* stays in the active buffer, a later split can rewrite an
+        already-sent message and spawn near-duplicate stubs. Instead: emit every
+        chunk once, clear the active buffer, and let subsequent text open a fresh
+        message.
+        """
+        if not chunks:
+            return
+
         if self._s.active_msg is not None:
             await self._edit_message(chunks[0])
         else:
             await self._create_message(chunks[0])
 
-        logger.debug("Message sealed, starting new segment")
+        for chunk in chunks[1:]:
+            if not chunk.strip():
+                continue
+            self._s.active_msg = None
+            await self._create_message(chunk)
 
-        # We must permanently split our state so the next render doesn't include chunks[0] again.
-        self._flush_text_segment()
-        if self._s.tool_tracker.has_entries:
-            self._flush_tool_segment()
+        logger.debug("Message sealed after overflow chunks=%d", len(chunks))
 
-        remaining = "\n\n".join(chunks[1:])
-
-        # Discard the old unsealed segments and indicators, replace with the remaining HTML
+        # Fully commit: sealed Telegram messages already hold the content.
+        self._s.raw_text_parts = []
+        self._s.tool_tracker = _ToolTracker()
         self._s.segments = self._s.segments[: self._s.sealed_segment_idx]
-        if remaining.strip():
-            self._s.segments.append(remaining)
-
-        self._s.indicator_indices.clear()
-
+        self._s.indicator_indices = {
+            i for i in self._s.indicator_indices if i < self._s.sealed_segment_idx
+        }
+        # Detach so the next append creates a new message instead of rewriting a
+        # sealed overflow chunk.
         self._s.active_msg = None
-        if remaining.strip():
-            await self._create_message(remaining)
         self._s.last_edit_time = asyncio.get_event_loop().time()
 
     async def _create_message(self, text: str) -> None:

--- a/ductor_bot/messenger/telegram/message_dispatch.py
+++ b/ductor_bot/messenger/telegram/message_dispatch.py
@@ -307,6 +307,7 @@ async def run_streaming_message(  # noqa: C901, PLR0915
         system_map: dict[str, str] = {
             "thinking": "THINKING",
             "compacting": "COMPACTING",
+            "working": "WORKING",
             "recovering": "Please wait, recovering...",
             "timeout_warning": "TIMEOUT APPROACHING",
             "timeout_extended": "TIMEOUT EXTENDED",
@@ -319,6 +320,10 @@ async def run_streaming_message(  # noqa: C901, PLR0915
                 return
             if not dispatch.streaming_cfg.show_thinking_indicator:
                 return
+        # Grok omits tool stream events; WORKING covers long silent tool turns.
+        # Gate with tool progress so users can disable both together.
+        if status == "working" and not dispatch.streaming_cfg.show_tool_progress:
+            return
         await tracker.set_system()
         await coalescer.flush(force=True)
         if reasoning_coalescer is not None:

--- a/tests/cli/test_grok_provider.py
+++ b/tests/cli/test_grok_provider.py
@@ -10,8 +10,13 @@ import pytest
 
 from ductor_bot.cli.base import CLIConfig
 from ductor_bot.cli.factory import create_cli
-from ductor_bot.cli.grok_events import parse_grok_json, parse_grok_stream_line
-from ductor_bot.cli.grok_provider import GrokCLI, _parse_response
+from ductor_bot.cli.grok_events import (
+    GrokStreamAssembler,
+    parse_grok_json,
+    parse_grok_stream_line,
+    soft_space_join,
+)
+from ductor_bot.cli.grok_provider import GrokCLI, _assemble_grok_stream, _parse_response
 from ductor_bot.cli.param_resolver import TaskExecutionConfig
 from ductor_bot.cli.stream_events import (
     AssistantTextDelta,
@@ -113,6 +118,80 @@ class TestGrokEvents:
         assert len(events) == 1
         assert isinstance(events[0], SystemStatusEvent)
         assert events[0].status == "max_turns_reached"
+
+
+class TestGrokSoftSpace:
+    def test_inserts_space_after_period(self) -> None:
+        assert soft_space_join("tmp`.", "Listing") == " Listing"
+
+    def test_no_space_when_already_spaced(self) -> None:
+        assert soft_space_join("Hello.", " World") == " World"
+
+    def test_no_space_for_markdown_star(self) -> None:
+        assert soft_space_join("top.", "**8**") == "**8**"
+
+    def test_empty_prev(self) -> None:
+        assert soft_space_join("", "Hi") == "Hi"
+
+
+class TestGrokStreamAssembler:
+    def test_soft_space_across_deltas(self) -> None:
+        asm = GrokStreamAssembler(min_chars=1, max_chars=1000)
+        asm.process(AssistantTextDelta(type="assistant", text="done."))
+        # Force emit first sentence so tail is tracked
+        out = asm.flush()
+        assert len(out) == 1
+        assert isinstance(out[0], AssistantTextDelta)
+        assert out[0].text == "done."
+        out2 = asm.process(AssistantTextDelta(type="assistant", text="Next"))
+        out2 += asm.flush()
+        text = "".join(e.text for e in out2 if isinstance(e, AssistantTextDelta))
+        assert text == " Next"
+
+    def test_coalesces_small_tokens(self) -> None:
+        asm = GrokStreamAssembler(min_chars=50, max_chars=500)
+        emitted: list[str] = []
+        for ch in "Hello world. ":
+            emitted.extend(
+                e.text
+                for e in asm.process(AssistantTextDelta(type="assistant", text=ch))
+                if isinstance(e, AssistantTextDelta)
+            )
+        # Under min_chars without enough sentence content — still buffered
+        emitted.extend(e.text for e in asm.flush() if isinstance(e, AssistantTextDelta))
+        assert "".join(emitted) == "Hello world. "
+
+    def test_working_on_idle_once(self) -> None:
+        asm = GrokStreamAssembler(min_chars=10, max_chars=100, working_idle_ms=1)
+        asm.process(ThinkingEvent(type="assistant", text="plan"))
+        idle1 = asm.on_idle()
+        assert any(isinstance(e, SystemStatusEvent) and e.status == "working" for e in idle1)
+        idle2 = asm.on_idle()
+        assert not any(isinstance(e, SystemStatusEvent) and e.status == "working" for e in idle2)
+
+    def test_result_flushes_buffered_text(self) -> None:
+        asm = GrokStreamAssembler(min_chars=1000, max_chars=5000)
+        asm.process(AssistantTextDelta(type="assistant", text="short"))
+        out = asm.process(ResultEvent(type="result", result="", is_error=False))
+        assert isinstance(out[0], AssistantTextDelta)
+        assert out[0].text == "short"
+        assert isinstance(out[1], ResultEvent)
+
+
+class TestAssembleGrokStream:
+    async def test_idle_emits_working_then_text(self) -> None:
+        async def raw() -> Any:
+            yield ThinkingEvent(type="assistant", text="t")
+            await __import__("asyncio").sleep(0.05)
+            yield AssistantTextDelta(type="assistant", text="Hi.")
+            yield ResultEvent(type="result", result="Hi.", is_error=False)
+
+        asm = GrokStreamAssembler(min_chars=1, max_chars=100, working_idle_ms=20)
+        events = [e async for e in _assemble_grok_stream(raw(), assembler=asm)]
+        statuses = [e.status for e in events if isinstance(e, SystemStatusEvent)]
+        assert "working" in statuses
+        texts = [e.text for e in events if isinstance(e, AssistantTextDelta)]
+        assert "Hi." in "".join(texts)
 
 
 class TestGrokProvider:

--- a/tests/messenger/telegram/test_edit_streaming.py
+++ b/tests/messenger/telegram/test_edit_streaming.py
@@ -190,21 +190,38 @@ class TestEditStreamEditor:
         assert "x1" not in last_text
 
     async def test_overflow_continuation_excludes_sealed_content(self) -> None:
-        """Overflow seals the first message; its content must not repeat afterwards."""
+        """Overflow seals chunks permanently; later text must not rewrite them."""
         bot, editor = _make_editor()
         await editor.append_text("A" * 3000)
         await editor.append_text("B" * 3000)
 
-        # First message sealed via edit, continuation sent as a second message
-        assert bot.send_message.call_count == 2
+        # First chunk sealed (create or edit), remainder as a second message
+        assert bot.send_message.call_count >= 2
         continuation = str(bot.send_message.call_args.kwargs["text"])
         assert "AAA" not in continuation
 
-        # Later edits render only the unsealed remainder, not the sealed chunk
+        # Next text opens a fresh message (overflow fully committed) — no re-split
+        sends_before = bot.send_message.call_count
         await editor.append_text("C" * 10)
-        edited = str(bot.edit_message_text.call_args.kwargs["text"])
-        assert "AAA" not in edited
-        assert "CCC" in edited
+        assert bot.send_message.call_count == sends_before + 1
+        fresh = str(bot.send_message.call_args.kwargs["text"])
+        assert "AAA" not in fresh
+        assert "BBB" not in fresh
+        assert "CCC" in fresh
+
+    async def test_overflow_then_grow_does_not_duplicate_prefix(self) -> None:
+        """Growing past the limit again must not re-emit an earlier overflow chunk."""
+        bot, editor = _make_editor()
+        await editor.append_text("A" * 3000)
+        await editor.append_text("B" * 3000)
+        sealed_sends = bot.send_message.call_count
+        await editor.append_text("D" * 3000)
+        await editor.append_text("E" * 3000)
+        # New overflow creates more messages, but never re-introduces AAA into tails
+        assert bot.send_message.call_count > sealed_sends
+        for call in bot.send_message.call_args_list[sealed_sends:]:
+            text = str(call.kwargs.get("text", ""))
+            assert "AAA" not in text
 
     @staticmethod
     def _get_last_message_text(bot: MagicMock) -> str:

--- a/tests/messenger/telegram/test_transport.py
+++ b/tests/messenger/telegram/test_transport.py
@@ -68,6 +68,36 @@ class TestCronSanitisation:
         raw = 'Message sent successfully. "Hi" delivered to Telegram (id 5).'
         assert sanitize_cron_result_text(raw) == ""
 
+    def test_sanitize_heartbeat_exact(self) -> None:
+        assert sanitize_cron_result_text("HEARTBEAT_OK") == ""
+
+    def test_sanitize_heartbeat_last_line_wins(self) -> None:
+        raw = "Gathering sources.\nFound nothing useful.\nHEARTBEAT_OK"
+        assert sanitize_cron_result_text(raw) == ""
+
+    def test_sanitize_strips_glued_process_preamble(self) -> None:
+        raw = (
+            "Gathering today's sources fresh — no 2026-07-28 memory entry yet."
+            "Pull 2 Strength logged today with RPE 10 — health signal that can "
+            "bypass hyperfocus. Checking event-prep and steps context."
+            "Gate delivered. Updating memory and writing the proactive trace, "
+            "then sending the health-only recap."
+            "🌙 28.07 вт · огонь\n\n"
+            "✅ Сделано: Pull 2 Strength\n"
+            "📊 День: 0.3k шагов"
+        )
+        clean = sanitize_cron_result_text(raw)
+        assert clean.startswith("🌙 28.07")
+        assert "Gathering" not in clean
+        assert "Gate delivered" not in clean
+        assert "Pull 2 Strength" in clean
+
+    def test_sanitize_strips_multiline_narration_before_emoji(self) -> None:
+        raw = "Checking calendar.\nGate delivered.\n✅ Done: morning plan ready\nSee you."
+        clean = sanitize_cron_result_text(raw)
+        assert clean.startswith("✅ Done:")
+        assert "Checking calendar" not in clean
+
 
 # ---------------------------------------------------------------------------
 # Cron broadcast


### PR DESCRIPTION
## Summary

Grok Build emits **token-level** `streaming-json` deltas and currently **does not** stream tool-use events during multi-turn tool work. In Telegram that showed up as:

- jittery in-place edits (token → edit every ~1–2s)
- glued punctuation across deltas (e.g. ``.Listing``)
- long replies re-splitting already-sent overflow chunks into near-duplicate stubs
- silent multi-second tool turns with no progress indicator (unlike Codex `mcp_tool_call`)

This PR improves delivery without changing MCP wiring:

1. **`GrokStreamAssembler`** — soft-space join, text coalesce (~160–700 chars / sentence), and a single **`WORKING`** `SystemStatusEvent` after ~2.5s of stream silence (covers silent tool turns until Grok emits real tool events).
2. **Telegram overflow** — seal overflow chunks permanently; later stream text opens a fresh message instead of re-splitting sealed HTML.
3. **Dispatch** — map `working` → `[WORKING]` when `show_tool_progress` is enabled.

## Test plan

- [x] `pytest tests/cli/test_grok_provider.py tests/messenger/telegram/test_edit_streaming.py` (62 passed)
- [ ] Manual: Grok chat long multi-tool turn → expect `[WORKING]` during silence, fewer jittery edits, clean multi-message overflow on long tables
- [ ] Manual: Codex path unchanged (no assembler)

## Notes

Full MCP tool names in the stream still require Grok CLI to emit `tool_use` events; `[WORKING]` is an intentional interim indicator.