### PR TITLE
fix(grok): discover per-model reasoning-effort menus

### DIFF
--- a/ductor_bot/cli/grok_cache.py
+++ b/ductor_bot/cli/grok_cache.py
@@ -1,56 +1,121 @@
-"""Persistent cache for Grok Build models with periodic refresh."""
+"""Persistent cache for Grok Build models with per-model effort menus."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Self
 
-from ductor_bot.cli.grok_discovery import discover_grok_models
+from ductor_bot.cli.grok_discovery import GrokModelInfo, discover_grok_models, order_efforts
 from ductor_bot.cli.model_cache import BaseModelCache
-from ductor_bot.config import GROK_MODELS_ORDERED
+from ductor_bot.config import GROK_MODELS_ORDERED, GROK_SUPPORTED_EFFORTS
 
 # Hardcoded fallback when discovery and disk cache both fail.
-_FALLBACK_GROK_MODELS: tuple[str, ...] = GROK_MODELS_ORDERED
+_FALLBACK_GROK_MODELS: list[GrokModelInfo] = [
+    GrokModelInfo(
+        id=model_id,
+        supported_efforts=GROK_SUPPORTED_EFFORTS,
+        default_effort="medium" if "medium" in GROK_SUPPORTED_EFFORTS else GROK_SUPPORTED_EFFORTS[0],
+    )
+    for model_id in GROK_MODELS_ORDERED
+]
 
 
 @dataclass(frozen=True)
 class GrokModelCache(BaseModelCache):
-    """Immutable cache of Grok Build model IDs with refresh logic."""
+    """Immutable cache of Grok Build models (IDs + effort menus) with refresh logic."""
 
     last_updated: str  # ISO 8601 timestamp
-    models: tuple[str, ...]
+    models: list[GrokModelInfo]
 
     @classmethod
     def _provider_name(cls) -> str:
         return "Grok"
 
     @classmethod
-    async def _discover(cls) -> tuple[str, ...]:
+    async def _discover(cls) -> list[GrokModelInfo]:
         return await discover_grok_models()
 
     @classmethod
-    def _empty_models(cls) -> tuple[str, ...]:
-        return ()
+    def _empty_models(cls) -> list[GrokModelInfo]:
+        return []
 
     @classmethod
-    def _fallback_models(cls) -> tuple[str, ...]:
-        return _FALLBACK_GROK_MODELS
+    def _fallback_models(cls) -> list[GrokModelInfo]:
+        return list(_FALLBACK_GROK_MODELS)
+
+    def model_ids(self) -> tuple[str, ...]:
+        """Ordered model IDs (for registry / /model list)."""
+        return tuple(m.id for m in self.models)
+
+    def get_model(self, model_id: str) -> GrokModelInfo | None:
+        """Look up model by ID."""
+        for model in self.models:
+            if model.id == model_id:
+                return model
+        return None
 
     def validate_model(self, model_id: str) -> bool:
         """Check if model exists in cache (or is a grok-* ID)."""
-        return model_id in self.models or model_id.startswith("grok-")
+        return self.get_model(model_id) is not None or model_id.startswith("grok-")
+
+    def validate_reasoning_effort(self, model_id: str, effort: str) -> bool:
+        """Check if effort is supported by the model (or conservative fallback)."""
+        model = self.get_model(model_id)
+        if model is not None:
+            return bool(model.supported_efforts) and effort in model.supported_efforts
+        # Unknown grok-* ID: allow only the conservative fallback set.
+        return effort in GROK_SUPPORTED_EFFORTS
 
     def to_json(self) -> dict[str, Any]:
         """Serialize for persistence."""
         return {
             "last_updated": self.last_updated,
-            "models": list(self.models),
+            "models": [
+                {
+                    "id": m.id,
+                    "supported_efforts": list(m.supported_efforts),
+                    "default_effort": m.default_effort,
+                }
+                for m in self.models
+            ],
         }
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> Self:
-        """Deserialize from JSON."""
+        """Deserialize from JSON (supports legacy ID-only caches)."""
+        models: list[GrokModelInfo] = []
+        for entry in data.get("models", []):
+            if isinstance(entry, str):
+                # Legacy format: bare model ID strings without effort menus.
+                models.append(
+                    GrokModelInfo(
+                        id=entry,
+                        supported_efforts=GROK_SUPPORTED_EFFORTS,
+                        default_effort="medium",
+                    )
+                )
+                continue
+            if not isinstance(entry, dict):
+                continue
+            model_id = str(entry.get("id", "")).strip()
+            if not model_id:
+                continue
+            raw_efforts = entry.get("supported_efforts") or list(GROK_SUPPORTED_EFFORTS)
+            efforts = order_efforts(tuple(str(e) for e in raw_efforts))
+            if not efforts:
+                efforts = GROK_SUPPORTED_EFFORTS
+            default = str(entry.get("default_effort") or "")
+            if default not in efforts:
+                default = "medium" if "medium" in efforts else efforts[0]
+            models.append(
+                GrokModelInfo(
+                    id=model_id,
+                    supported_efforts=efforts,
+                    default_effort=default,
+                )
+            )
+
         return cls(
-            last_updated=data["last_updated"],
-            models=tuple(data["models"]),
+            last_updated=str(data.get("last_updated", "")),
+            models=models,
         )

--- a/ductor_bot/cli/grok_discovery.py
+++ b/ductor_bot/cli/grok_discovery.py
@@ -1,10 +1,11 @@
-"""Model discovery for the xAI Grok Build CLI (``grok models``)."""
+"""Model + per-model reasoning-effort discovery for the xAI Grok Build CLI."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
 import re
+from dataclasses import dataclass
 from shutil import which
 
 from ductor_bot.infra.platform import CREATION_FLAGS as _CREATION_FLAGS
@@ -13,6 +14,7 @@ from ductor_bot.infra.process_tree import force_kill_process_tree
 logger = logging.getLogger(__name__)
 
 _DISCOVERY_TIMEOUT = 15.0
+_EFFORT_PROBE_TIMEOUT = 8.0
 
 # Lines under "Available models:" look like:
 #   * grok-4.5 (default)
@@ -20,13 +22,86 @@ _DISCOVERY_TIMEOUT = 15.0
 _MODEL_BULLET = re.compile(r"^\s*[\*\-•]\s+(\S+)")
 _DEFAULT_LINE = re.compile(r"(?i)^\s*Default model:\s*(\S+)")
 
+# Grok rejects unknown effort levels with:
+#   unknown effort level 'X'; use one of: high, medium, low
+_USE_ONE_OF = re.compile(r"use one of:\s*([^\n\"'}]+)", re.IGNORECASE)
 
-async def discover_grok_models() -> tuple[str, ...]:
-    """Return model IDs reported by ``grok models``.
+# Canonical display / button order (CLI vocabulary is a superset of any one model).
+_EFFORT_ORDER: tuple[str, ...] = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
 
-    Returns an empty tuple when the CLI is missing, unauthenticated, times out,
+# Probe token that no model menu should ever advertise.
+_PROBE_EFFORT = "__ductor_probe__"
+
+# Conservative default when a probe fails. Matches current grok-4.5 menu.
+_FALLBACK_EFFORTS: tuple[str, ...] = ("low", "medium", "high")
+
+
+@dataclass(frozen=True, slots=True)
+class GrokModelInfo:
+    """A Grok Build model with the reasoning-effort levels its menu accepts."""
+
+    id: str
+    supported_efforts: tuple[str, ...]
+    default_effort: str
+
+
+async def discover_grok_models() -> list[GrokModelInfo]:
+    """Return models reported by ``grok models``, each with probed efforts.
+
+    Returns an empty list when the CLI is missing, unauthenticated, times out,
     or errors — callers then fall back to the cached or hardcoded list.
+
+    Effort menus are **per model**. The CLI documents a full vocabulary
+    (none/minimal/low/.../max) but only accepts levels the active model
+    advertises; probing with an invalid level returns that menu without
+    starting a turn.
     """
+    model_ids = await _discover_model_ids()
+    if not model_ids:
+        return []
+
+    results = await asyncio.gather(
+        *(_probe_model_efforts(model_id) for model_id in model_ids),
+        return_exceptions=True,
+    )
+
+    models: list[GrokModelInfo] = []
+    for model_id, result in zip(model_ids, results, strict=True):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Grok effort probe failed for %s; using fallback levels",
+                model_id,
+                exc_info=result,
+            )
+            efforts = _FALLBACK_EFFORTS
+        else:
+            efforts = result or _FALLBACK_EFFORTS
+        models.append(
+            GrokModelInfo(
+                id=model_id,
+                supported_efforts=efforts,
+                default_effort=_pick_default_effort(efforts),
+            )
+        )
+
+    logger.info(
+        "Grok discovery found %d models: %s",
+        len(models),
+        ", ".join(f"{m.id}[{'/'.join(m.supported_efforts)}]" for m in models),
+    )
+    return models
+
+
+async def _discover_model_ids() -> tuple[str, ...]:
+    """Return model IDs from ``grok models`` (no effort probing)."""
     binary = which("grok")
     if not binary:
         logger.debug("grok not available for model discovery")
@@ -74,6 +149,93 @@ async def discover_grok_models() -> tuple[str, ...]:
         return ()
 
     return _parse_models(output)
+
+
+async def _probe_model_efforts(model_id: str) -> tuple[str, ...]:
+    """Probe the effort menu for *model_id* via an intentional invalid level."""
+    binary = which("grok")
+    if not binary:
+        return ()
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            "--output-format",
+            "json",
+            "--permission-mode",
+            "bypassPermissions",
+            "--always-approve",
+            "--model",
+            model_id,
+            "--reasoning-effort",
+            _PROBE_EFFORT,
+            "-p",
+            "x",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            creationflags=_CREATION_FLAGS,
+        )
+    except (OSError, ValueError):
+        logger.debug("grok effort probe spawn failed for %s", model_id, exc_info=True)
+        return ()
+
+    try:
+        async with asyncio.timeout(_EFFORT_PROBE_TIMEOUT):
+            stdout_bytes, stderr_bytes = await proc.communicate()
+    except TimeoutError:
+        logger.warning("grok effort probe timed out for %s", model_id)
+        force_kill_process_tree(proc.pid)
+        await proc.communicate()
+        return ()
+
+    text = (
+        stdout_bytes.decode(errors="replace")
+        + "\n"
+        + (stderr_bytes.decode(errors="replace") if stderr_bytes else "")
+    )
+    efforts = _parse_supported_efforts(text)
+    if efforts:
+        return efforts
+
+    logger.debug(
+        "Grok effort probe for %s returned no parseable menu (rc=%s)",
+        model_id,
+        proc.returncode,
+    )
+    return ()
+
+
+def _parse_supported_efforts(text: str) -> tuple[str, ...]:
+    """Extract effort levels from a Grok CLI error / help string."""
+    match = _USE_ONE_OF.search(text)
+    if not match:
+        return ()
+    raw_parts = [p.strip().strip(".,;\"'") for p in match.group(1).split(",")]
+    parts = [p for p in raw_parts if p and p != _PROBE_EFFORT]
+    return order_efforts(parts)
+
+
+def order_efforts(efforts: list[str] | tuple[str, ...]) -> tuple[str, ...]:
+    """Order effort labels into the canonical menu sequence."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for level in _EFFORT_ORDER:
+        if level in efforts and level not in seen:
+            ordered.append(level)
+            seen.add(level)
+    for level in efforts:
+        if level not in seen:
+            ordered.append(level)
+            seen.add(level)
+    return tuple(ordered)
+
+
+def _pick_default_effort(efforts: tuple[str, ...]) -> str:
+    """Pick a sensible default from a model's supported set."""
+    for preferred in ("medium", "low", "high"):
+        if preferred in efforts:
+            return preferred
+    return efforts[0] if efforts else "medium"
 
 
 def _parse_models(output: str) -> tuple[str, ...]:

--- a/ductor_bot/cli/param_resolver.py
+++ b/ductor_bot/cli/param_resolver.py
@@ -16,7 +16,6 @@ from ductor_bot.config import (
     CLAUDE_MODELS,
     CLAUDE_SUPPORTED_EFFORTS,
     GROK_MODELS,
-    GROK_SUPPORTED_EFFORTS,
     get_gemini_models,
 )
 
@@ -116,8 +115,14 @@ def _resolve_reasoning_effort(
             requested_effort, CLAUDE_SUPPORTED_EFFORTS, "Claude", model, explicit=explicit
         )
     if provider == "grok":
+        from ductor_bot.config import get_grok_supported_efforts
+
         return _static_effort(
-            requested_effort, GROK_SUPPORTED_EFFORTS, "Grok", model, explicit=explicit
+            requested_effort,
+            get_grok_supported_efforts(model),
+            "Grok",
+            model,
+            explicit=explicit,
         )
 
     if provider == "codex" and codex_cache:

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -624,21 +624,23 @@ GROK_MODELS_ORDERED: tuple[str, ...] = (
     "grok-composer-2.5-fast",
 )
 GROK_MODELS: frozenset[str] = frozenset(GROK_MODELS_ORDERED)
-# Canonical Grok headless levels (plus max alias of xhigh). See grok --help.
+# Conservative Grok reasoning-effort fallback when per-model discovery is
+# unavailable. The CLI vocabulary is larger (none/minimal/low/medium/high/
+# xhigh/max) but each model only accepts levels its menu advertises — e.g.
+# grok-4.5 currently accepts only low/medium/high. Prefer the live Grok model
+# cache over this constant when building /model and /effort menus.
 GROK_SUPPORTED_EFFORTS: tuple[str, ...] = (
-    "none",
-    "minimal",
     "low",
     "medium",
     "high",
-    "xhigh",
-    "max",
 )
 
 _runtime_gemini: list[frozenset[str]] = [frozenset()]
 _runtime_antigravity: list[frozenset[str]] = [frozenset()]
 _runtime_grok: list[frozenset[str]] = [frozenset()]
 _runtime_grok_ordered: list[tuple[str, ...]] = [()]
+# Per-model Grok effort menus from discovery (model_id → ordered levels).
+_runtime_grok_efforts: dict[str, tuple[str, ...]] = {}
 
 
 class ModelRegistry:
@@ -734,6 +736,8 @@ def set_grok_models(models: tuple[str, ...] | frozenset[str] | list[str]) -> Non
 
     Refuses to overwrite with an empty set to prevent cache wipe.
     Preserves discovery order when a sequence is provided.
+    Does not clear effort menus; call :func:`set_grok_model_efforts` when
+    discovery also returns per-model effort support.
     """
     if not models:
         return
@@ -747,7 +751,27 @@ def set_grok_models(models: tuple[str, ...] | frozenset[str] | list[str]) -> Non
     _runtime_grok[0] = frozenset(ordered)
 
 
+def set_grok_model_efforts(efforts: dict[str, tuple[str, ...]]) -> None:
+    """Replace the runtime per-model Grok reasoning-effort menus.
+
+    Keys are model IDs; values are ordered effort levels accepted by that
+    model (as advertised by the Grok CLI). Empty mapping clears the table.
+    """
+    _runtime_grok_efforts.clear()
+    for model_id, levels in efforts.items():
+        mid = str(model_id).strip()
+        if not mid or not levels:
+            continue
+        _runtime_grok_efforts[mid] = tuple(levels)
+
+
+def get_grok_supported_efforts(model_id: str) -> tuple[str, ...]:
+    """Return effort levels for *model_id*, or the conservative fallback."""
+    return _runtime_grok_efforts.get(model_id) or GROK_SUPPORTED_EFFORTS
+
+
 def reset_grok_models() -> None:
     """Clear runtime Grok models. For test teardown only."""
     _runtime_grok[0] = frozenset()
     _runtime_grok_ordered[0] = ()
+    _runtime_grok_efforts.clear()

--- a/ductor_bot/orchestrator/providers.py
+++ b/ductor_bot/orchestrator/providers.py
@@ -135,9 +135,24 @@ class ProviderManager:
         set_antigravity_models(frozenset(models))
         self.refresh_known_model_ids()
 
-    def on_grok_models_refresh(self, models: tuple[str, ...]) -> None:
-        """Callback for GrokCacheObserver: update model registry."""
-        set_grok_models(models)
+    def on_grok_models_refresh(self, models: tuple[object, ...]) -> None:
+        """Callback for GrokCacheObserver: update model registry + effort menus.
+
+        Accepts either legacy ``tuple[str, ...]`` (IDs only) or
+        ``tuple[GrokModelInfo, ...]`` from the effort-aware cache.
+        """
+        from ductor_bot.cli.grok_discovery import GrokModelInfo
+        from ductor_bot.config import set_grok_model_efforts
+
+        if not models:
+            return
+
+        if isinstance(models[0], GrokModelInfo):
+            infos = tuple(m for m in models if isinstance(m, GrokModelInfo))
+            set_grok_models(tuple(m.id for m in infos))
+            set_grok_model_efforts({m.id: m.supported_efforts for m in infos})
+        else:
+            set_grok_models(tuple(str(m) for m in models))
         self.refresh_known_model_ids()
 
     def refresh_gemini_api_key_mode(self) -> bool:

--- a/ductor_bot/orchestrator/selectors/model_selector.py
+++ b/ductor_bot/orchestrator/selectors/model_selector.py
@@ -13,7 +13,6 @@ from ductor_bot.config import (
     CLAUDE_MODELS_ORDERED,
     CLAUDE_SUPPORTED_EFFORTS,
     CODEX_SUPPORTED_EFFORTS_FALLBACK,
-    GROK_SUPPORTED_EFFORTS,
     get_antigravity_models,
     get_gemini_models,
     get_grok_models_ordered,
@@ -105,17 +104,26 @@ def _build_switch_summary(ctx: _SwitchSummaryContext) -> str:
 
 
 def _supported_efforts(orch: Orchestrator, model_id: str) -> tuple[str, ...]:
-    """Return the reasoning-effort levels supported by *model_id*'s provider.
+    """Return the reasoning-effort levels supported by *model_id*.
 
-    Claude accepts a fixed set (incl. ``max``). Codex uses the live model
-    cache when available, else a fallback constant so ``max`` is still
-    rejected. Other providers don't use reasoning effort.
+    Claude accepts a fixed set (incl. ``max``). Codex and Grok use the live
+    model cache when available so the /model and /effort menus only offer
+    levels the active model actually accepts; both fall back to a
+    conservative constant when discovery is unavailable.
     """
     provider = orch.models.provider_for(model_id)
     if provider == "claude":
         return CLAUDE_SUPPORTED_EFFORTS
     if provider == "grok":
-        return GROK_SUPPORTED_EFFORTS
+        grok_cache = (
+            orch._observers.grok_cache_obs.get_cache() if orch._observers.grok_cache_obs else None
+        )
+        model_info = grok_cache.get_model(model_id) if grok_cache else None
+        if model_info is not None and model_info.supported_efforts:
+            return tuple(model_info.supported_efforts)
+        from ductor_bot.config import get_grok_supported_efforts
+
+        return get_grok_supported_efforts(model_id)
     if provider == "codex":
         codex_cache = (
             orch._observers.codex_cache_obs.get_cache() if orch._observers.codex_cache_obs else None

--- a/tests/cli/test_grok_discovery.py
+++ b/tests/cli/test_grok_discovery.py
@@ -1,4 +1,4 @@
-"""Tests for dynamic Grok Build model discovery and caching."""
+"""Tests for dynamic Grok Build model discovery, effort probing, and caching."""
 
 from __future__ import annotations
 
@@ -11,11 +11,19 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ductor_bot.cli.grok_cache import _FALLBACK_GROK_MODELS, GrokModelCache
-from ductor_bot.cli.grok_discovery import _parse_models, discover_grok_models
+from ductor_bot.cli.grok_discovery import (
+    GrokModelInfo,
+    _parse_models,
+    _parse_supported_efforts,
+    discover_grok_models,
+    order_efforts,
+)
 from ductor_bot.config import (
     ModelRegistry,
     get_grok_models_ordered,
+    get_grok_supported_efforts,
     reset_grok_models,
+    set_grok_model_efforts,
     set_grok_models,
 )
 
@@ -27,6 +35,13 @@ Available models:
   * grok-4.5 (default)
   - grok-composer-2.5-fast
 """
+
+_PROBE_ERROR = (
+    '{"type":"error","message":"--effort/--reasoning-effort: unknown effort level '
+    "'__ductor_probe__'; use one of: high, medium, low\"}\n"
+    "Error: --effort/--reasoning-effort: unknown effort level '__ductor_probe__'; "
+    "use one of: high, medium, low\n"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -56,25 +71,57 @@ def test_parse_models_skips_duplicates() -> None:
     assert _parse_models(raw) == ("grok-4.5", "grok-new")
 
 
-def _mock_proc(stdout: bytes, returncode: int = 0) -> AsyncMock:
+def test_parse_supported_efforts_from_cli_error() -> None:
+    assert _parse_supported_efforts(_PROBE_ERROR) == ("low", "medium", "high")
+
+
+def test_parse_supported_efforts_orders_canonical_levels() -> None:
+    assert order_efforts(("xhigh", "none", "medium", "low")) == (
+        "none",
+        "low",
+        "medium",
+        "xhigh",
+    )
+
+
+def test_parse_supported_efforts_empty_when_no_menu() -> None:
+    assert _parse_supported_efforts("some unrelated failure") == ()
+
+
+def _mock_proc(stdout: bytes, returncode: int = 0, stderr: bytes = b"") -> AsyncMock:
     proc = AsyncMock(spec=asyncio.subprocess.Process)
     proc.returncode = returncode
     proc.pid = 4242
-    proc.communicate = AsyncMock(return_value=(stdout, b""))
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
     return proc
 
 
-async def test_discover_returns_models_on_success() -> None:
+async def test_discover_returns_models_with_probed_efforts() -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def _spawn(*args: object, **_kwargs: object) -> AsyncMock:
+        cmd = tuple(str(a) for a in args)
+        calls.append(cmd)
+        if len(args) >= 2 and args[1] == "models":
+            return _mock_proc(_SAMPLE_OUTPUT.encode())
+        # Effort probe: argv contains --model <id>
+        return _mock_proc(b"", returncode=1, stderr=_PROBE_ERROR.encode())
+
     with (
         patch("ductor_bot.cli.grok_discovery.which", return_value="/usr/bin/grok"),
         patch(
             "ductor_bot.cli.grok_discovery.asyncio.create_subprocess_exec",
-            return_value=_mock_proc(_SAMPLE_OUTPUT.encode()),
+            side_effect=_spawn,
         ),
     ):
         models = await discover_grok_models()
 
-    assert models == ("grok-4.5", "grok-composer-2.5-fast")
+    assert [m.id for m in models] == ["grok-4.5", "grok-composer-2.5-fast"]
+    assert all(m.supported_efforts == ("low", "medium", "high") for m in models)
+    assert all(m.default_effort == "medium" for m in models)
+    # models list + one probe per model
+    assert sum(1 for c in calls if len(c) >= 2 and c[1] == "models") == 1
+    assert sum(1 for c in calls if "--reasoning-effort" in c) == 2
 
 
 async def test_discover_returns_empty_when_not_logged_in() -> None:
@@ -85,25 +132,81 @@ async def test_discover_returns_empty_when_not_logged_in() -> None:
             return_value=_mock_proc(b"not logged in\nrun `grok login`\n", returncode=1),
         ),
     ):
-        assert await discover_grok_models() == ()
+        assert await discover_grok_models() == []
 
 
 async def test_discover_returns_empty_when_binary_missing() -> None:
     with patch("ductor_bot.cli.grok_discovery.which", return_value=None):
-        assert await discover_grok_models() == ()
+        assert await discover_grok_models() == []
 
 
-async def test_cache_persists_discovered_models(tmp_path: Path) -> None:
+async def test_discover_uses_fallback_efforts_when_probe_unparseable() -> None:
+    async def _spawn(*args: object, **_kwargs: object) -> AsyncMock:
+        if len(args) >= 2 and args[1] == "models":
+            return _mock_proc(b"  * grok-4.5\n")
+        return _mock_proc(b"boom", returncode=1)
+
+    with (
+        patch("ductor_bot.cli.grok_discovery.which", return_value="/usr/bin/grok"),
+        patch(
+            "ductor_bot.cli.grok_discovery.asyncio.create_subprocess_exec",
+            side_effect=_spawn,
+        ),
+    ):
+        models = await discover_grok_models()
+
+    assert len(models) == 1
+    assert models[0].id == "grok-4.5"
+    assert models[0].supported_efforts == ("low", "medium", "high")
+
+
+async def test_cache_persists_discovered_models_and_efforts(tmp_path: Path) -> None:
     path = tmp_path / "grok_models.json"
+    discovered = [
+        GrokModelInfo(
+            id="grok-4.5",
+            supported_efforts=("low", "medium", "high"),
+            default_effort="medium",
+        ),
+        GrokModelInfo(
+            id="grok-future",
+            supported_efforts=("none", "minimal", "low", "medium", "high", "xhigh", "max"),
+            default_effort="medium",
+        ),
+    ]
     with patch(
         "ductor_bot.cli.grok_cache.discover_grok_models",
-        return_value=("grok-4.5", "grok-future"),
+        return_value=discovered,
     ):
         cache = await GrokModelCache.load_or_refresh(path, force_refresh=True)
-    assert cache.models == ("grok-4.5", "grok-future")
+    assert [m.id for m in cache.models] == ["grok-4.5", "grok-future"]
+    assert cache.get_model("grok-4.5") is not None
+    assert cache.get_model("grok-4.5").supported_efforts == ("low", "medium", "high")  # type: ignore[union-attr]
+    assert cache.validate_reasoning_effort("grok-4.5", "minimal") is False
+    assert cache.validate_reasoning_effort("grok-4.5", "low") is True
     assert path.is_file()
     loaded = GrokModelCache.from_json(json.loads(path.read_text()))
-    assert loaded.models == cache.models
+    assert [m.id for m in loaded.models] == [m.id for m in cache.models]
+    assert loaded.get_model("grok-future").supported_efforts == (  # type: ignore[union-attr]
+        "none",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    )
+
+
+def test_cache_from_json_accepts_legacy_id_only_format() -> None:
+    cache = GrokModelCache.from_json(
+        {
+            "last_updated": "2026-07-29T00:00:00+00:00",
+            "models": ["grok-4.5", "grok-composer-2.5-fast"],
+        }
+    )
+    assert [m.id for m in cache.models] == ["grok-4.5", "grok-composer-2.5-fast"]
+    assert cache.get_model("grok-4.5").supported_efforts == ("low", "medium", "high")  # type: ignore[union-attr]
 
 
 def test_set_grok_models_updates_registry_and_order() -> None:
@@ -113,5 +216,14 @@ def test_set_grok_models_updates_registry_and_order() -> None:
     assert ModelRegistry.provider_for("grok-a") == "grok"
 
 
-def test_fallback_models_match_hardcoded() -> None:
-    assert "grok-4.5" in _FALLBACK_GROK_MODELS
+def test_set_grok_model_efforts_drives_lookup() -> None:
+    set_grok_models(("grok-4.5",))
+    set_grok_model_efforts({"grok-4.5": ("low", "medium", "high")})
+    assert get_grok_supported_efforts("grok-4.5") == ("low", "medium", "high")
+    # Unknown model falls back to conservative constant.
+    assert get_grok_supported_efforts("grok-unknown") == ("low", "medium", "high")
+
+
+def test_fallback_models_include_grok_45() -> None:
+    assert any(m.id == "grok-4.5" for m in _FALLBACK_GROK_MODELS)
+    assert all(m.supported_efforts for m in _FALLBACK_GROK_MODELS)

--- a/tests/cli/test_param_resolver.py
+++ b/tests/cli/test_param_resolver.py
@@ -211,6 +211,61 @@ def test_resolve_claude_rejects_invalid_reasoning(
         )
 
 
+def test_resolve_grok_accepts_discovered_efforts(
+    base_config: AgentConfig, codex_cache: CodexModelCache
+) -> None:
+    """Grok effort validation follows per-model discovery menus."""
+    from ductor_bot.config import reset_grok_models, set_grok_model_efforts, set_grok_models
+
+    reset_grok_models()
+    set_grok_models(("grok-4.5",))
+    set_grok_model_efforts({"grok-4.5": ("low", "medium", "high")})
+
+    ok = resolve_cli_config(
+        base_config,
+        codex_cache,
+        task_overrides=TaskOverrides(
+            provider="grok",
+            model="grok-4.5",
+            reasoning_effort="low",
+        ),
+    )
+    assert ok.provider == "grok"
+    assert ok.reasoning_effort == "low"
+
+    with pytest.raises(DuctorError, match="Invalid reasoning effort"):
+        resolve_cli_config(
+            base_config,
+            codex_cache,
+            task_overrides=TaskOverrides(
+                provider="grok",
+                model="grok-4.5",
+                reasoning_effort="minimal",
+            ),
+        )
+
+    reset_grok_models()
+
+
+def test_resolve_grok_fallback_rejects_canonical_only_levels(
+    base_config: AgentConfig, codex_cache: CodexModelCache
+) -> None:
+    """Without discovery, Grok only allows the conservative low/medium/high set."""
+    from ductor_bot.config import reset_grok_models
+
+    reset_grok_models()
+    with pytest.raises(DuctorError, match="Invalid reasoning effort"):
+        resolve_cli_config(
+            base_config,
+            codex_cache,
+            task_overrides=TaskOverrides(
+                provider="grok",
+                model="grok-4.5",
+                reasoning_effort="xhigh",
+            ),
+        )
+
+
 def test_resolve_gemini_model_from_discovery(
     base_config: AgentConfig, codex_cache: CodexModelCache
 ) -> None:


### PR DESCRIPTION
## Summary

Grok Build CLI documents a full reasoning-effort vocabulary (`none` / `minimal` / `low` / `medium` / `high` / `xhigh` / `max`), but **each model only accepts the levels its own menu advertises**. Ductor previously treated the full vocabulary as supported for every Grok model.

On current `grok-4.5` that means:

| Effort offered by Ductor | Accepted by `grok-4.5` |
|---|---|
| `none` | no |
| `minimal` | no |
| `low` | yes |
| `medium` | yes |
| `high` | yes |
| `xhigh` | no |
| `max` | no |

Selecting Minimal / None / XHigh / Max from `/model` or `/effort` succeeded in the Telegram UI, then failed on the next turn with:

```text
--effort/--reasoning-effort: unknown effort level 'minimal'; use one of: high, medium, low
```

### Fix

1. **Per-model effort discovery** (`grok_discovery.py`)
   - Still lists models via `grok models`.
   - For each model, probes with an intentional invalid effort (`__ductor_probe__`).
   - Parses the CLI error menu: `use one of: high, medium, low`.
   - Orders levels into the canonical sequence and picks a sensible default (`medium` preferred).

2. **Richer Grok cache** (`grok_cache.py`)
   - Stores `GrokModelInfo { id, supported_efforts, default_effort }` (Codex-style).
   - Persists efforts in `grok_models.json`.
   - **Backward compatible** with legacy caches that only stored bare model ID strings.

3. **UI + validation wiring**
   - `/model` and `/effort` read efforts from the live Grok cache (`model_selector.py`).
   - Cron/webhook/`resolve_cli_config` validate against per-model menus (`param_resolver.py` + runtime effort map in `config.py`).
   - Conservative fallback when discovery is offline: **`low` / `medium` / `high`** (not the full vocabulary).

4. **Registry refresh**
   - `on_grok_models_refresh` accepts either legacy ID tuples or `GrokModelInfo` records and updates both the model list and the effort map.

## Test plan

- [x] Unit tests: effort parse order, probe discovery, cache persist/roundtrip, legacy JSON load
- [x] Unit tests: `resolve_cli_config` accepts discovered levels and rejects `minimal` / `xhigh` for `grok-4.5`
- [x] `pytest tests/cli/test_grok_discovery.py tests/cli/test_param_resolver.py` — 35 passed
- [x] `pytest tests/cli/test_grok_provider.py tests/orchestrator/test_model_selector.py tests/orchestrator/test_optional_model_observers.py tests/cli/test_param_resolver.py` — 120 passed
- [x] Live smoke against installed Grok CLI (`grok 0.2.111`):
  - `discover_grok_models()` → `grok-4.5: ('low', 'medium', 'high')`
  - cache `validate_reasoning_effort('grok-4.5', 'minimal') is False`
  - cache `validate_reasoning_effort('grok-4.5', 'medium') is True`

### Manual check after merge

1. Restart ductor with Grok authenticated.
2. `/model` → Grok → `grok-4.5` → effort step should only show **Low / Medium / High**.
3. `/effort` on an active Grok session should match.
4. Confirm a turn with `medium` still works; no spawn-time unknown-effort errors.

## Notes for maintainers

- Probe is intentionally invalid and fails fast (no model turn). Timeout is 8s per model; probes run in parallel via `asyncio.gather`.
- If the CLI later adds richer effort APIs, discovery can switch without changing the cache schema.
- Happy to iterate on naming / probe strategy if you prefer a different approach.

Thanks for Grok Build support in ductor — this patch is from production use where the Telegram model menu offered levels the active model rejects.