### PR TITLE
fix(config): detect hot reloads by file content

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -574,7 +574,7 @@ Toggles are read live from `config.json` on each skill-sync tick (independent of
 
 ## Runtime hot-reload (`config_reload.py`)
 
-`Orchestrator.create()` starts `ConfigReloader`, which polls `config.json` every 5 seconds, validates it with `AgentConfig`, diffs top-level fields, and applies safe changes without restart.
+`Orchestrator.create()` starts `ConfigReloader`, which polls `config.json` content every 5 seconds, validates it with `AgentConfig`, diffs top-level fields, and applies safe changes without restart. Content comparison avoids missing rapid or equal-size rewrites on filesystems with coarse timestamp updates.
 
 Hot-reloadable top-level fields:
 

--- a/docs/modules/config_reload.md
+++ b/docs/modules/config_reload.md
@@ -10,7 +10,7 @@ Centralized runtime config hot-reload watcher.
 
 Avoid unnecessary restarts when safe `config.json` fields change.
 
-`ConfigReloader` polls `~/.ductor/config/config.json` every 5 seconds, validates with `AgentConfig`, diffs top-level schema fields, and:
+`ConfigReloader` polls `~/.ductor/config/config.json` every 5 seconds, compares the file content (so equal-timestamp and equal-size rewrites are not missed), validates with `AgentConfig`, diffs top-level schema fields, and:
 
 - applies hot-reloadable fields immediately,
 - logs restart-required field changes through callback.

--- a/ductor_bot/config_reload.py
+++ b/ductor_bot/config_reload.py
@@ -1,6 +1,6 @@
 """Centralized config hot-reload: watch config.json and apply safe changes at runtime.
 
-Mtime-based watcher (5-second poll) that detects config file changes, validates
+Content-based watcher (5-second poll) that detects config file changes, validates
 the new config via Pydantic, diffs against the current config, and applies
 hot-reloadable fields without restart. Fields requiring restart are logged as
 warnings.
@@ -121,16 +121,16 @@ class ConfigReloader:
         self._config = current_config
         self._on_hot_reload = on_hot_reload
         self._on_restart_needed = on_restart_needed
-        self._last_mtime: float = 0.0
+        self._last_content: bytes | None = None
         self._task: asyncio.Task[None] | None = None
-        self._init_mtime()
+        self._init_content()
 
-    def _init_mtime(self) -> None:
-        """Read the initial mtime so we don't trigger on first poll."""
+    def _init_content(self) -> None:
+        """Read the initial content so we don't trigger on first poll."""
         try:
-            self._last_mtime = self._path.stat().st_mtime
+            self._last_content = self._path.read_bytes()
         except OSError:
-            self._last_mtime = 0.0
+            self._last_content = None
 
     async def start(self) -> None:
         """Start the background polling task."""
@@ -150,25 +150,26 @@ class ConfigReloader:
         logger.info("Config reloader stopped")
 
     async def _poll_loop(self) -> None:
-        """Poll config file mtime and trigger reload on change."""
+        """Poll config file content and trigger reload on change."""
         while True:
             await asyncio.sleep(_POLL_INTERVAL)
             await self._check()
 
     async def _check(self) -> None:
-        """Check mtime, load, diff, and apply if changed."""
+        """Read, diff, and apply the config if its content changed."""
         try:
-            stat = self._path.stat()
+            raw = await asyncio.to_thread(self._path.read_bytes)
         except OSError:
+            self._last_content = None
             return
 
-        if stat.st_mtime <= self._last_mtime:
+        if raw == self._last_content:
             return
 
-        self._last_mtime = stat.st_mtime
+        self._last_content = raw
         logger.info("Config file changed, reloading...")
 
-        new_config = await self._load_config()
+        new_config = self._load_config(raw)
         if new_config is None:
             return
 
@@ -185,10 +186,9 @@ class ConfigReloader:
         if restart and self._on_restart_needed:
             self._on_restart_needed(restart)
 
-    async def _load_config(self) -> AgentConfig | None:
+    def _load_config(self, raw: bytes) -> AgentConfig | None:
         """Load and validate config.json. Returns None on error."""
         try:
-            raw = await asyncio.to_thread(self._path.read_text, "utf-8")
             data = json.loads(raw)
             return AgentConfig(**data)
         except (OSError, json.JSONDecodeError) as exc:

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -228,6 +228,16 @@ class TestConfigReloader:
         assert cfg.project_roots == {"my-project": "~/code/my-project"}
         assert applied.get("project_roots") == {"my-project": "~/code/my-project"}
 
+    async def test_equal_length_rewrite_is_detected(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.json"
+        cfg = self._write_config(config_path, model="opus")
+        reloader = ConfigReloader(config_path, cfg)
+
+        self._write_config(config_path, model="haiku")
+        await reloader._check()
+
+        assert cfg.model == "haiku"
+
     async def test_same_content_rewrite_no_callback(self, tmp_path: Path) -> None:
         config_path = tmp_path / "config.json"
         cfg = self._write_config(config_path, model="sonnet")
@@ -235,7 +245,7 @@ class TestConfigReloader:
         on_hot = MagicMock()
         reloader = ConfigReloader(config_path, cfg, on_hot_reload=on_hot)
 
-        # Rewrite with same content (mtime changes but no diff)
+        # Rewrite with same content (filesystem metadata may change, content does not).
         self._write_config(config_path, model="sonnet")
 
         await reloader._check()


### PR DESCRIPTION
## Summary

- compare `config.json` contents instead of relying on filesystem mtimes
- parse the same bytes used for change detection to avoid read/stat races
- document the content-based watcher behavior

## Root cause

The reloader skipped a write whenever the observed mtime did not advance. Rapid rewrites can retain the same timestamp on filesystems with coarse timestamp resolution, so an equal-size configuration update could be missed until a later write.

## Impact

Hot-reloadable configuration changes are detected consistently across platforms. Rewriting identical content remains a no-op, while changed content is validated and applied once.

## Test plan

- [x] `pytest -q tests/test_config_reload.py` (22 passed)
- [x] `ruff check .`
- [x] `ruff format --check .`
