### PR TITLE
fix(codex): preserve CLI parameters when resuming sessions

### DIFF
--- a/ductor_bot/cli/codex_provider.py
+++ b/ductor_bot/cli/codex_provider.py
@@ -122,6 +122,8 @@ class CodexCLI(BaseCLI):
             cmd += ["--model", cfg.model]
         if cfg.reasoning_effort and cfg.reasoning_effort != "default":
             cmd += ["-c", f"model_reasoning_effort={cfg.reasoning_effort}"]
+        if cfg.cli_parameters:
+            cmd.extend(cfg.cli_parameters)
         cmd += ["--", session_id]
         cmd.append("-")
         return cmd

--- a/tests/cli/test_codex_provider.py
+++ b/tests/cli/test_codex_provider.py
@@ -303,6 +303,14 @@ class TestBuildCommand:
         assert "resume" in cmd
         assert "--json" not in cmd
 
+    def test_resume_session_includes_cli_parameters(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cli = _make_cli(monkeypatch, cli_parameters=["--disable", "plugins"])
+
+        cmd = cli._build_command("hello", resume_session="th-1")
+
+        separator = cmd.index("--")
+        assert cmd[separator - 2 : separator] == ["--disable", "plugins"]
+
     def test_prompt_composed_in_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cli = _make_cli(monkeypatch, system_prompt="SYS", append_system_prompt="APPEND")
         cmd = cli._build_command("user msg")


### PR DESCRIPTION
## Summary

- append configured Codex CLI parameters to `codex exec resume` commands
- keep the parameters before the `-- <session-id>` separator
- add regression coverage for resumed sessions

## Root cause

`cli_parameters.codex` was applied when starting a Codex session but omitted by the separate resume command builder. Options such as `--disable plugins` therefore changed behavior after the first turn of the same conversation.

## Impact

New and resumed Codex turns now use the same configured CLI options. Existing command construction is unchanged when no extra parameters are configured.

## Test plan

- [x] `pytest -q tests/cli/test_codex_provider.py tests/integration/test_cli_parameter_flow.py -k "codex"` (103 passed, 3 deselected)
- [x] `ruff check .`
- [x] `ruff format --check .`
