### PR TITLE
feat(docker): add Grok sandbox support

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,6 +1,6 @@
 # Dockerfile.sandbox -- lightweight sandbox for ductor CLI execution.
-# Based on Node 22 (Debian bookworm) with Python 3, Claude Code CLI,
-# and Codex CLI pre-installed.  The container runs "sleep infinity" so
+# Based on Node 22 (Debian bookworm) with Python 3 and the Claude Code,
+# Codex, Gemini, and Grok CLIs pre-installed.  The container runs "sleep infinity" so
 # ductor can `docker exec` into it on demand.
 
 FROM node:22-bookworm-slim
@@ -35,6 +35,42 @@ RUN rm -f /usr/lib/python*/EXTERNALLY-MANAGED
 
 # Install Claude Code CLI and Codex CLI
 RUN npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli
+
+# xAI Grok CLI. The npm package is a thin trampoline: it materializes a ~158MB
+# native binary into $GROK_HOME on first run and then execs it without a version
+# check. $GROK_HOME doubles as the auth directory, which is bind-mounted from the
+# host, so a materialized binary would outlive image rebuilds and pin the version
+# forever. Relocate the binary into the image instead, so the image -- not the
+# writable auth home -- owns the version, matching the other three CLIs.
+RUN set -eu; \
+    export GROK_HOME=/tmp/grok-build; \
+    export npm_config_cache=/tmp/grok-npm-cache; \
+    npm install -g @xai-official/grok; \
+    VER="$(node -p "require('/usr/local/lib/node_modules/@xai-official/grok/package.json').version")"; \
+    printf '%s\n' "$VER" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; \
+    grok --version > /dev/null; \
+    SRC="$(readlink -e "$GROK_HOME/bin/grok")"; \
+    case "$SRC" in "$GROK_HOME"/bin/*) ;; *) exit 1 ;; esac; \
+    [ -f "$SRC" ] && [ -x "$SRC" ]; \
+    mkdir -p /usr/local/lib/grok; \
+    mv "$SRC" /usr/local/lib/grok/grok; \
+    chmod 0755 /usr/local/lib/grok/grok; \
+    /usr/local/lib/grok/grok --version > /tmp/grok-v1.txt; \
+    grep -Fq "grok $VER " /tmp/grok-v1.txt; \
+    npm uninstall -g @xai-official/grok; \
+    rmdir /usr/local/lib/node_modules/@xai-official 2>/dev/null || true; \
+    printf '%s\n' \
+        '#!/bin/sh' \
+        '# Installed via npm; the binary was relocated so the image owns the version.' \
+        'export GROK_MANAGED_BY_NPM=1' \
+        'export GROK_DISABLE_AUTOUPDATER=1' \
+        'exec /usr/local/lib/grok/grok "$@"' > /usr/local/bin/grok; \
+    chmod 0755 /usr/local/bin/grok; \
+    grok --version > /tmp/grok-v2.txt; \
+    grep -Fq "grok $VER " /tmp/grok-v2.txt; \
+    echo "grok CLI baked into image: $VER"; \
+    rm -rf "$GROK_HOME" "$npm_config_cache" \
+           /tmp/grok-v1.txt /tmp/grok-v2.txt
 
 # Prepare a writable data directory
 RUN mkdir -p /data && chown node:node /data

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,7 @@
      Note: since 2026-06-18 Gemini CLI no longer serves requests for individual
      Google accounts (free/Pro/Ultra) — it requires an API key or a Gemini Code
      Assist license. For the free individual tier, use Antigravity (`agy`) instead.
+   - Grok CLI: `npm install -g @xai-official/grok` and authenticate in `grok`.
 4. One of these messaging transports:
     - **Telegram**: Bot token from [@BotFather](https://t.me/BotFather) + user ID from [@userinfobot](https://t.me/userinfobot)
     - **Matrix**: install Matrix support first (`ductor install matrix` or `pip install \"ductor[matrix]\"`), then provide homeserver URL, user ID, and password/access token
@@ -145,6 +146,13 @@ Notes:
 - Container is reused between calls.
 - On Linux, ductor maps UID/GID to avoid root-owned files.
 - If Docker setup fails at startup, ductor logs warning and falls back to host execution.
+
+Grok sandbox behavior:
+
+- Only the default `~/.grok` directory is mounted, and only when it exists before the container starts.
+- If `~/.grok` does not exist, create an empty directory before logging in inside the container; otherwise the login is lost when the container is recreated.
+- Custom `GROK_HOME` locations are unsupported, as with the other providers.
+- Running `grok update` inside the container is unsupported. The image owns the CLI version; run `ductor docker rebuild` to update it.
 
 Docker CLI shortcuts:
 

--- a/docs/modules/infra.md
+++ b/docs/modules/infra.md
@@ -59,9 +59,12 @@ Restart code: `42` (`EXIT_RESTART`).
 - container (re)start
 - mounts:
   - `~/.ductor -> /ductor`
-  - provider homes (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.claude.json` when present)
+  - provider homes (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.grok`, `~/.claude.json` when present)
   - optional host cache mount
   - user-configured `docker.mounts` to `/mnt/<name>`
+
+The sandbox image owns the Grok CLI version. `grok update` inside the container is unsupported;
+use `ductor docker rebuild` to update it.
 
 Docker extras (`docker_extras.py`):
 

--- a/ductor_bot/infra/docker.py
+++ b/ductor_bot/infra/docker.py
@@ -199,7 +199,7 @@ class DockerManager:
                 f"[bold cyan]Building sandbox image '{image}'...[/bold cyan]\n"
                 "[dim]  Downloading Debian bookworm + Node.js 22 base image\n"
                 "  Installing Python, build tools, Git\n"
-                f"  Installing Claude, Codex, and Gemini CLIs{extras_msg}\n"
+                f"  Installing Claude, Codex, Gemini, and Grok CLIs{extras_msg}\n"
                 "  This may take a few minutes on first run...[/dim]"
             )
             if not await self._build_image(image):
@@ -368,6 +368,7 @@ class DockerManager:
             (home / ".claude", f"{container_home}/.claude", "rw"),
             (home / ".codex", f"{container_home}/.codex", "rw"),
             (home / ".gemini", f"{container_home}/.gemini", "rw"),
+            (home / ".grok", f"{container_home}/.grok", "rw"),
         ]
 
         # Optional: mount host cache dir for browser profiles & binaries.

--- a/tests/infra/test_docker_mounts.py
+++ b/tests/infra/test_docker_mounts.py
@@ -133,6 +133,121 @@ def docker_paths(tmp_path: Path) -> DuctorPaths:
 class TestDockerManagerMounts:
     """Integration tests: verify mounts appear in the docker run command."""
 
+    async def test_existing_grok_home_is_mounted(
+        self, tmp_path: Path, docker_paths: DuctorPaths
+    ) -> None:
+        (tmp_path / ".grok").mkdir()
+        config = DockerConfig(enabled=True)
+        from ductor_bot.infra.docker import DockerManager
+
+        mgr = DockerManager(config, docker_paths)
+        run_args: list[str] = []
+
+        async def mock_exec(*args: str, **_kwargs: object) -> tuple[int, str]:
+            cmd = " ".join(args)
+            if "docker info" in cmd:
+                return 0, "ok"
+            if "image inspect" in cmd:
+                return 0, "ok"
+            if "container inspect" in cmd:
+                return 1, ""
+            if "rm -f" in cmd:
+                return 0, ""
+            if "docker run" in cmd:
+                run_args.extend(args)
+                return 0, "cid"
+            return 0, ""
+
+        with (
+            patch("ductor_bot.infra.docker.which", return_value="/usr/bin/docker"),
+            patch.object(Path, "home", return_value=tmp_path),
+            patch.object(mgr, "_exec", side_effect=mock_exec),
+        ):
+            await mgr.setup()
+
+        expected = ["-v", f"{tmp_path}/.grok:/home/node/.grok:rw"]
+        assert any(run_args[index : index + 2] == expected for index in range(len(run_args) - 1))
+
+    async def test_missing_grok_home_is_not_mounted(
+        self, tmp_path: Path, docker_paths: DuctorPaths
+    ) -> None:
+        config = DockerConfig(enabled=True)
+        from ductor_bot.infra.docker import DockerManager
+
+        mgr = DockerManager(config, docker_paths)
+        run_args: list[str] = []
+
+        async def mock_exec(*args: str, **_kwargs: object) -> tuple[int, str]:
+            cmd = " ".join(args)
+            if "docker info" in cmd:
+                return 0, "ok"
+            if "image inspect" in cmd:
+                return 0, "ok"
+            if "container inspect" in cmd:
+                return 1, ""
+            if "rm -f" in cmd:
+                return 0, ""
+            if "docker run" in cmd:
+                run_args.extend(args)
+                return 0, "cid"
+            return 0, ""
+
+        with (
+            patch("ductor_bot.infra.docker.which", return_value="/usr/bin/docker"),
+            patch.object(Path, "home", return_value=tmp_path),
+            patch.object(mgr, "_exec", side_effect=mock_exec),
+        ):
+            await mgr.setup()
+
+        assert run_args
+        mount_args = [run_args[index + 1] for index, arg in enumerate(run_args[:-1]) if arg == "-v"]
+        assert all(str(tmp_path / ".grok") not in arg for arg in mount_args)
+        assert all("/home/node/.grok" not in arg for arg in mount_args)
+
+    async def test_existing_provider_homes_remain_mounted(
+        self, tmp_path: Path, docker_paths: DuctorPaths
+    ) -> None:
+        provider_homes = [".claude", ".codex", ".gemini"]
+        for provider_home in provider_homes:
+            (tmp_path / provider_home).mkdir()
+
+        config = DockerConfig(enabled=True)
+        from ductor_bot.infra.docker import DockerManager
+
+        mgr = DockerManager(config, docker_paths)
+        run_args: list[str] = []
+
+        async def mock_exec(*args: str, **_kwargs: object) -> tuple[int, str]:
+            cmd = " ".join(args)
+            if "docker info" in cmd:
+                return 0, "ok"
+            if "image inspect" in cmd:
+                return 0, "ok"
+            if "container inspect" in cmd:
+                return 1, ""
+            if "rm -f" in cmd:
+                return 0, ""
+            if "docker run" in cmd:
+                run_args.extend(args)
+                return 0, "cid"
+            return 0, ""
+
+        with (
+            patch("ductor_bot.infra.docker.which", return_value="/usr/bin/docker"),
+            patch.object(Path, "home", return_value=tmp_path),
+            patch.object(mgr, "_exec", side_effect=mock_exec),
+        ):
+            await mgr.setup()
+
+        for provider_home in provider_homes:
+            expected = [
+                "-v",
+                f"{tmp_path}/{provider_home}:/home/node/{provider_home}:rw",
+            ]
+            assert any(
+                run_args[index : index + 2] == expected for index in range(len(run_args) - 1)
+            )
+
     async def test_single_mount_in_run_cmd(self, tmp_path: Path, docker_paths: DuctorPaths) -> None:
         proj = tmp_path / "myapp"
         proj.mkdir()


### PR DESCRIPTION
## Problem

With `docker.enabled = true` every CLI runs inside the sandbox image, but Grok
never got sandbox support:

- `Dockerfile.sandbox` installs only `@anthropic-ai/claude-code`, `@openai/codex`
  and `@google/gemini-cli`
- `DockerManager` mounts only `~/.claude`, `~/.codex` and `~/.gemini`

So selecting Grok in sandbox mode cannot work: the CLI is absent from the image,
and even with it present the auth home would not survive container recreation.

## Why this needs more than one more npm package

The other three CLIs ship their executable inside the npm package, so the image
owns the version and the home directory holds only config and auth.

`@xai-official/grok` is a thin trampoline (~44MB): it materializes a ~158MB
native binary into `$GROK_HOME/bin` on first run and afterwards execs it
**without a version check**. `$GROK_HOME` defaults to `~/.grok`, which is exactly
the directory that has to be bind-mounted for auth persistence — so simply adding
the mount would let a materialized binary outlive image rebuilds and pin the CLI
version indefinitely.

The build therefore materializes the binary, relocates it to
`/usr/local/lib/grok/grok` and installs a wrapper at `/usr/local/bin/grok`, all
in one layer, then removes the npm package and the scratch directories. The
wrapper keeps `GROK_MANAGED_BY_NPM=1` and sets `GROK_DISABLE_AUTOUPDATER=1`:
without the former the CLI switches to its internal installer, and a self-update
then writes a binary into the auth home that the image never runs — while
reporting success.

Since the install tracks latest like the other CLIs, the build asserts what it
depends on: the npm version shape, that the canonical path resolves under
`$GROK_HOME/bin` to a regular executable, and that both the relocated binary and
the installed wrapper report that exact version. Any mismatch fails the build.
Tracking latest keeps parity with the other CLIs at the cost of a future
packaging change surfacing as a build failure; pinning would trade that for
reproducibility.

## User-visible contract

Documented in `docs/installation.md`:

- only a pre-existing default `~/.grok` is mounted, the same conditional as the
  other providers
- create an empty `~/.grok` before logging in from inside the container,
  otherwise the login is lost when the container is recreated
- custom `GROK_HOME` is not supported
- `grok update` inside the container is not supported; the image owns the
  version, update with `ductor docker rebuild`

The `Dockerfile.sandbox` header comment also gains Gemini, which was missing
from the pre-installed CLI list before this change.

## Image size

+165,481,664 bytes uncompressed (~66MB compressed). Existing users need
`ductor docker rebuild` to pick Grok up.

## Verification

- image builds on `node:22-bookworm-slim`; `grok --version` matches the version
  recorded during the build
- runs under an arbitrary UID (`--user 12345:12345`), and the auth bind works
  read/write under a non-1000 UID
- a stale binary planted in a bind-mounted `~/.grok/bin` is never executed
- an authenticated `grok -p` call returns the expected output
- fail-closed proven both ways: a version mismatch and a removed materialize
  path each fail the build
- wheel, sdist and a wheel rebuilt from the sdist all carry the change
- new unit tests cover the mount present/absent cases and the existing three
  mounts; the full suite shows no new failures (the two `test_config_reload`
  timing tests are pre-existing flakes, unstable on both sides across repeated
  runs)
