### PR TITLE
Improve Telegram task progress and Codex event filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Bot:   → task has a question? It asks the agent → agent asks you → you ans
 ```
 
 Each task gets its own memory file (`TASKMEMORY.md`) and can be resumed with follow-ups.
+On Telegram, one task-status message is updated every 30 seconds while the worker runs and
+while the parent agent reviews its result, then that message changes to the terminal state.
 
 ### 5. Sub-agents (fully isolated second agent)
 

--- a/config.example.json
+++ b/config.example.json
@@ -135,6 +135,8 @@
     },
     "tasks": {
         "enabled": true,
+        "progress_updates": true,
+        "progress_interval_seconds": 30.0,
         "max_parallel": 5,
         "timeout_seconds": 3600.0,
         "finished_retention_hours": 168,

--- a/docs/config.md
+++ b/docs/config.md
@@ -234,6 +234,8 @@ Implementation status note:
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `enabled` | `bool` | `true` | Enables shared delegated task system (`TaskHub`) |
+| `progress_updates` | `bool` | `true` | Enables Telegram's single-message TaskHub lifecycle status |
+| `progress_interval_seconds` | `float` | `30.0` | Seconds between Telegram status edits (`>= 10.0`) |
 | `max_parallel` | `int` | `5` | Max concurrent running tasks per chat in `TaskHub` |
 | `timeout_seconds` | `float` | `3600.0` | Timeout per delegated task run |
 | `finished_retention_hours` | `int` | `168` | Age limit for finished task history (done/failed/cancelled); `0` disables age pruning |

--- a/docs/modules/tasks.md
+++ b/docs/modules/tasks.md
@@ -6,7 +6,7 @@ Delegated background task system (`TaskHub`) for long-running autonomous work.
 
 - `tasks/hub.py`: task lifecycle (submit/run/resume/question/cancel/shutdown)
 - `tasks/registry.py`: persistent registry + task-folder seeding + cleanup/delete
-- `tasks/models.py`: `TaskSubmit`, `TaskEntry`, `TaskInFlight`, `TaskResult`
+- `tasks/models.py`: `TaskSubmit`, `TaskEntry`, `TaskInFlight`, `TaskProgress`, `TaskResult`
 - `orchestrator/selectors/task_selector.py`: `/tasks` UI callbacks (`tsc:*`)
 - `_home_defaults/workspace/tools/task_tools/*.py`: CLI tools (`create`, `resume`, `ask_parent`, `list`, `cancel`, `delete`)
 
@@ -17,10 +17,10 @@ Run long work asynchronously while keeping parent chat responsive.
 High-level flow:
 
 1. create (`/tasks/create`)
-2. execute (`TaskHub._run`)
+2. emit `running`, then execute (`TaskHub._run`)
 3. optional question (`/tasks/ask_parent`)
 4. optional resume (`/tasks/resume`)
-5. result delivery + parent-session injection
+5. emit `reviewing`, then perform result delivery + parent-session injection
 6. optional permanent deletion (`/tasks/delete`)
 
 ## Persistence and folders
@@ -44,8 +44,18 @@ Startup/maintenance behavior:
 ## Config (`AgentConfig.tasks`)
 
 - `enabled`
+- `progress_updates` (default `true`)
+- `progress_interval_seconds` (default `30.0`, minimum `10.0`)
 - `max_parallel` (per chat)
 - `timeout_seconds`
+
+## Telegram lifecycle status
+
+Telegram keeps one status message per `(chat_id, topic_id, task_id)` and edits it on the
+configured interval. The timer continues through the parent model's result review, then the
+same message becomes completed, failed, cancelled, waiting, or timed out. Task prompts, tool
+arguments, and model reasoning are never used as progress text. Matrix and Slack retain their
+existing terminal-result behavior.
 
 ## Execution model (`TaskHub`)
 

--- a/docs/superpowers/plans/2026-08-16-telegram-task-progress.md
+++ b/docs/superpowers/plans/2026-08-16-telegram-task-progress.md
@@ -1,0 +1,120 @@
+# Telegram Background Task Progress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Provide authoritative, non-spamming Telegram progress for Ductor TaskHub workers through final parent review.
+
+**Architecture:** TaskHub emits running and reviewing lifecycle events through MessageBus. Telegram owns a local tracker that edits one status message every 30 seconds and finalizes it when TaskResult arrives; other transports retain current behavior.
+
+**Tech Stack:** Python 3.11, asyncio, aiogram 3, Pydantic 2, pytest, ruff, mypy.
+
+---
+
+### Task 1: Lifecycle contract and bus adapter
+
+**Files:**
+- Modify: ductor_bot/tasks/models.py
+- Modify: ductor_bot/bus/envelope.py
+- Modify: ductor_bot/bus/adapters.py
+- Test: tests/bus/test_adapters.py
+
+- [ ] Add a TaskProgress dataclass carrying task_id, chat_id, parent_agent, name, stage, elapsed_seconds, provider, model and thread_id.
+- [ ] Add Origin.TASK_PROGRESS and from_task_progress(), using LockMode.NONE and needs_injection=False.
+- [ ] Run the focused adapter test first and verify it fails because the contract is missing.
+- [ ] Implement the minimum model and adapter.
+- [ ] Run:
+
+~~~bash
+.venv/bin/pytest -q tests/bus/test_adapters.py
+~~~
+
+Expected: all tests pass.
+
+### Task 2: TaskHub lifecycle delivery
+
+**Files:**
+- Modify: ductor_bot/tasks/hub.py
+- Modify: ductor_bot/tasks/models.py
+- Modify: ductor_bot/multiagent/supervisor.py
+- Modify: ductor_bot/messenger/protocol.py
+- Modify: ductor_bot/messenger/multi.py
+- Test: tests/tasks/test_hub.py
+- Test: tests/multiagent/test_supervisor.py
+- Test: tests/messenger/test_multi.py
+
+- [ ] Add failing tests that running is emitted after successful registry creation and before CLI execute, reviewing is emitted after worker return and before TaskResult delivery, and failed submission emits nothing.
+- [ ] Add set_progress_handler() and best-effort _deliver_progress(); progress callback failures must be logged and must not fail the worker.
+- [ ] Wire each agent stack's on_task_progress callback and fan out in MultiMessengerBot.
+- [ ] Give MatrixBot and SlackBot explicit no-op on_task_progress methods.
+- [ ] Run:
+
+~~~bash
+.venv/bin/pytest -q tests/tasks/test_hub.py tests/multiagent/test_supervisor.py tests/messenger/test_multi.py
+~~~
+
+Expected: all tests pass.
+
+### Task 3: Telegram single-message tracker
+
+**Files:**
+- Create: ductor_bot/messenger/telegram/task_progress.py
+- Modify: ductor_bot/messenger/telegram/transport.py
+- Modify: ductor_bot/messenger/telegram/app.py
+- Test: tests/messenger/telegram/test_task_progress.py
+- Test: tests/messenger/telegram/test_transport.py
+
+- [ ] Write failing tests for initial send, same-message heartbeat edits, running-to-reviewing transition, all terminal states, chat/topic/task isolation, edit replacement, rate-limit retry, late-tick protection, resume and shutdown.
+- [ ] Implement TelegramTaskProgressTracker with a map keyed by chat_id, topic_id and task_id and one asyncio timer per task.
+- [ ] Add TASK_PROGRESS transport handling and finalize the tracker before TaskResult body delivery. Preserve the old completion notice when no tracker exists.
+- [ ] Store the TelegramTransport instance on TelegramBot and await tracker shutdown before closing the Bot session.
+- [ ] Run:
+
+~~~bash
+.venv/bin/pytest -q tests/messenger/telegram/test_task_progress.py tests/messenger/telegram/test_transport.py
+~~~
+
+Expected: all tests pass.
+
+### Task 4: Configuration and documentation
+
+**Files:**
+- Modify: ductor_bot/config.py
+- Modify: config.example.json
+- Modify: docs/config.md
+- Modify: docs/modules/tasks.md
+- Modify: README.md
+- Create: tests/tasks/test_progress_config.py
+
+- [ ] Add failing assertions for progress_updates=True and progress_interval_seconds=30.0 with a minimum of 10 seconds.
+- [ ] Implement fields and update example/docs.
+- [ ] Run:
+
+~~~bash
+.venv/bin/pytest -q tests/tasks/test_progress_config.py
+~~~
+
+Expected: all tests pass.
+
+### Task 5: Verification, version and release
+
+**Files:**
+- Modify: pyproject.toml
+- Modify: ductor_bot/__init__.py
+- Use the verified commit summary as the GitHub release body; this repository has no tracked changelog file.
+
+- [ ] Run focused progress regression.
+- [ ] Run all tests; classify only the already recorded Docker/config baseline failures if they remain identical.
+- [ ] Run:
+
+~~~bash
+.venv/bin/ruff format --check .
+.venv/bin/ruff check .
+.venv/bin/mypy ductor_bot
+git diff --check
+.venv/bin/python -m build
+~~~
+
+- [ ] Perform independent code review and fix any findings.
+- [ ] Bump patch version, build wheel and sdist, verify isolated installation and version.
+- [ ] Commit, merge/fast-forward to main, push main and tag, publish GitHub release assets.
+- [ ] Upgrade the pipx installation, restart ductor.service, and verify version, active state, polling and zero startup errors.

--- a/docs/superpowers/specs/2026-08-16-telegram-task-progress-design.md
+++ b/docs/superpowers/specs/2026-08-16-telegram-task-progress-design.md
@@ -1,0 +1,74 @@
+# Telegram Background Task Progress Design
+
+Date: 2026-08-16
+Executor: Codex
+
+## Outcome
+
+When Ductor successfully creates a TaskHub worker from a Telegram request, Telegram shows one authoritative status message immediately and keeps editing that same message until the final task result is delivered. The status remains alive while the parent model reviews the worker result, which is the silent phase observed in production.
+
+## Evidence and problem boundary
+
+The reported message corresponded to real TaskHub task 750eb552. The worker ran for 32.68 seconds, then parent-session review ran non-streaming for 185.44 seconds. TaskHub currently exposes completion and question callbacks only. MessageBus injects the result into the parent session before transport delivery, so Telegram receives nothing during parent review.
+
+Raw model commentary is not a valid progress source. v0.20.2 intentionally suppresses model text adjacent to tool events to prevent thinking and internal tool narration from leaking.
+
+## Considered approaches
+
+1. Forward model commentary. Rejected because it reintroduces the leak fixed in v0.20.2 and cannot prove a worker exists.
+2. Send a new Telegram message every interval. Rejected because concurrent long tasks would spam group topics.
+3. Recommended: emit authoritative TaskHub lifecycle events and let Telegram maintain one editable status message with a local timer.
+
+## Architecture
+
+TaskHub emits TaskProgress events only after a registry entry exists:
+
+- running: worker was created and is executing.
+- reviewing: worker returned and the parent session is preparing the final response.
+
+The existing TaskResult remains the terminal event. The new TaskProgress event uses the existing Envelope and MessageBus path with no session lock and no prompt injection.
+
+TelegramTransport delegates status ownership to a small tracker keyed by chat_id, topic_id, and task_id. On running it sends a plain-text message and starts a 30-second asyncio heartbeat. Each tick edits the same message_id with elapsed time. On reviewing it changes the phase but keeps the timer alive. On TaskResult it first stops and awaits the timer, then edits the same message to done, failed, cancelled, or waiting before delivering the final response.
+
+Matrix and Slack keep their existing terminal behavior. Their BotProtocol implementations accept TaskProgress as a no-op so the change remains Telegram-specific without breaking multi-transport stacks.
+
+## Error handling and concurrency
+
+- A failed initial send never fails the worker; a later progress event may retry.
+- message is not modified is treated as success.
+- Telegram rate limits sleep for retry_after and retry one edit.
+- A deleted/uneditable status message is replaced once, and future ticks edit the replacement.
+- Terminal handling marks the tracker final before cancelling its timer so a late tick cannot overwrite the terminal text.
+- Resume of the same task_id starts a fresh tracker generation.
+- Telegram shutdown cancels and awaits every tracker timer before closing the Bot session.
+- Names are displayed as plain text; original prompts, tool parameters, upstream details and model reasoning are never included.
+
+## Configuration
+
+TasksConfig gains:
+
+- progress_updates: true by default.
+- progress_interval_seconds: 30.0, minimum 10 seconds.
+
+Existing user configurations gain defaults through Ductor's deep-merge behavior.
+
+## Testing
+
+Tests must prove:
+
+- no running event is emitted when submit fails;
+- running precedes CLI execution and reviewing precedes result delivery;
+- one task edits one message_id across repeated ticks;
+- reviewing continues ticking while final result injection is blocked;
+- terminal statuses stop the timer and cannot be overwritten;
+- chat/topic/task keys isolate concurrent work;
+- send, edit, rate-limit and shutdown failures do not affect task execution;
+- multi-messenger wiring remains valid;
+- config defaults, examples and docs agree.
+
+## Non-goals
+
+- Streaming the parent review.
+- Displaying tool-level or token-level detail.
+- Re-enabling arbitrary pre-tool model text.
+- Changing payment-system data or task-worker permissions.

--- a/ductor_bot/bus/adapters.py
+++ b/ductor_bot/bus/adapters.py
@@ -15,7 +15,7 @@ from ductor_bot.bus.envelope import DeliveryMode, Envelope, LockMode, Origin
 if TYPE_CHECKING:
     from ductor_bot.background.models import BackgroundResult
     from ductor_bot.multiagent.bus import AsyncInterAgentResult
-    from ductor_bot.tasks.models import TaskResult
+    from ductor_bot.tasks.models import TaskProgress, TaskResult
     from ductor_bot.webhook.models import WebhookResult
 
 
@@ -250,7 +250,28 @@ def from_interagent_result(
     )
 
 
-# -- Task results & questions --------------------------------------------------
+# -- Task progress, results & questions ---------------------------------------
+
+
+def from_task_progress(progress: TaskProgress) -> Envelope:
+    """Convert a background task lifecycle update."""
+    return Envelope(
+        origin=Origin.TASK_PROGRESS,
+        chat_id=progress.chat_id,
+        topic_id=progress.thread_id,
+        status=progress.stage,
+        delivery=DeliveryMode.UNICAST,
+        lock_mode=LockMode.NONE,
+        needs_injection=False,
+        elapsed_seconds=progress.elapsed_seconds,
+        provider=progress.provider,
+        model=progress.model,
+        metadata={
+            "task_id": progress.task_id,
+            "name": progress.name,
+            "parent_agent": progress.parent_agent,
+        },
+    )
 
 
 def from_task_result(result: TaskResult) -> Envelope:

--- a/ductor_bot/bus/adapters.py
+++ b/ductor_bot/bus/adapters.py
@@ -270,6 +270,8 @@ def from_task_progress(progress: TaskProgress) -> Envelope:
             "task_id": progress.task_id,
             "name": progress.name,
             "parent_agent": progress.parent_agent,
+            "output_text": progress.output_text,
+            "tool_name": progress.tool_name,
         },
     )
 

--- a/ductor_bot/bus/envelope.py
+++ b/ductor_bot/bus/envelope.py
@@ -17,6 +17,7 @@ class Origin(enum.Enum):
     WEBHOOK_CRON = "webhook_cron"
     HEARTBEAT = "heartbeat"
     INTERAGENT = "interagent"
+    TASK_PROGRESS = "task_progress"
     TASK_RESULT = "task_result"
     TASK_QUESTION = "task_question"
     USER = "user"

--- a/ductor_bot/cli/codex_events.py
+++ b/ductor_bot/cli/codex_events.py
@@ -41,6 +41,7 @@ def parse_codex_jsonl(raw: str) -> tuple[str, str | None, dict[str, Any] | None]
     result_parts: list[str] = []
     thread_id: str | None = None
     usage: dict[str, Any] | None = None
+    started_file_changes: set[str] = set()
 
     for raw_line in lines:
         stripped = raw_line.strip()
@@ -53,7 +54,7 @@ def parse_codex_jsonl(raw: str) -> tuple[str, str | None, dict[str, Any] | None]
 
         thread_id = _extract_thread_id(data, thread_id)
         usage = _extract_usage(data, usage)
-        if _is_tool_boundary_event(data):
+        if _is_tool_boundary_event(data, started_file_changes):
             result_parts.clear()
         _extract_text(data, result_parts)
 
@@ -115,7 +116,7 @@ def _is_tool_item(data: dict[str, Any]) -> bool:
     }
 
 
-def _is_tool_boundary_event(data: dict[str, Any]) -> bool:
+def _is_tool_boundary_event(data: dict[str, Any], started_file_changes: set[str]) -> bool:
     """识别 Codex 各类工具首次可见的事件边界."""
     if not _is_tool_item(data):
         return False
@@ -123,7 +124,15 @@ def _is_tool_boundary_event(data: dict[str, Any]) -> bool:
     if not isinstance(item, dict):
         return False
     if item.get("type") == "file_change":
-        return data.get("type") in {"item.started", "item.completed"}
+        event_type = data.get("type")
+        item_id = item.get("id")
+        if event_type == "item.started":
+            if isinstance(item_id, str):
+                started_file_changes.add(item_id)
+            return True
+        if event_type == "item.completed":
+            return not isinstance(item_id, str) or item_id not in started_file_changes
+        return False
     return data.get("type") == "item.started"
 
 
@@ -257,7 +266,7 @@ def _parse_codex_item(data: dict[str, Any]) -> list[StreamEvent]:
             return []
         text = item.get("text", "")
         if _is_tagged_thinking(text):
-            return [ThinkingEvent(type="assistant", text=text)]
+            return []
         return [AssistantTextDelta(type="assistant", text=text)] if text else []
 
     if item_type == "reasoning":
@@ -310,6 +319,7 @@ class CodexThinkingFilter:
 
     def __init__(self) -> None:
         self._buffered: list[StreamEvent] = []
+        self._emitted_tool_ids: set[str] = set()
 
     def process(self, event: StreamEvent) -> list[StreamEvent]:
         """Process one event, returning zero or more events to emit."""
@@ -318,6 +328,10 @@ class CodexThinkingFilter:
             return []
 
         if isinstance(event, ToolUseEvent):
+            if event.tool_id is not None:
+                if event.tool_id in self._emitted_tool_ids:
+                    return []
+                self._emitted_tool_ids.add(event.tool_id)
             self._buffered.clear()
             return [event]
 

--- a/ductor_bot/cli/codex_events.py
+++ b/ductor_bot/cli/codex_events.py
@@ -18,6 +18,11 @@ from ductor_bot.cli.stream_events import (
 logger = logging.getLogger(__name__)
 
 
+def _is_tagged_thinking(text: object) -> bool:
+    """识别被 Codex 错标为普通助手消息的 thinking 内容."""
+    return isinstance(text, str) and text.lstrip().lower().startswith("<thinking>")
+
+
 def _tool_parameters(item: dict[str, Any]) -> dict[str, Any] | None:
     for key in ("arguments", "parameters", "input"):
         value = item.get(key)
@@ -138,7 +143,7 @@ def _extract_item_text(data: dict[str, Any], parts: list[str], event_type: str) 
         and event_type == "item.completed"
     ):
         text = item.get("text", "")
-        if text:
+        if text and not _is_tagged_thinking(text):
             parts.append(text)
 
 
@@ -147,7 +152,7 @@ def _extract_message_blocks(data: dict[str, Any], parts: list[str]) -> None:
     for block in data.get("content", []):
         if isinstance(block, dict) and block.get("type") == "text":
             text = block.get("text", "")
-            if text:
+            if text and not _is_tagged_thinking(text):
                 parts.append(text)
 
 
@@ -156,7 +161,7 @@ def _extract_fallback_text(data: dict[str, Any], parts: list[str]) -> None:
     item = data.get("item")
     if isinstance(item, dict) and isinstance(item.get("text"), str):
         item_type = str(item.get("type", "")).lower()
-        if item_type in ("", "agent_message"):
+        if item_type in ("", "agent_message") and not _is_tagged_thinking(item["text"]):
             parts.append(item["text"])
 
 
@@ -239,6 +244,8 @@ def _parse_codex_item(data: dict[str, Any]) -> list[StreamEvent]:
         if event_type != "item.completed":
             return []
         text = item.get("text", "")
+        if _is_tagged_thinking(text):
+            return [ThinkingEvent(type="assistant", text=text)]
         return [AssistantTextDelta(type="assistant", text=text)] if text else []
 
     if item_type == "reasoning":

--- a/ductor_bot/cli/codex_events.py
+++ b/ductor_bot/cli/codex_events.py
@@ -53,10 +53,7 @@ def parse_codex_jsonl(raw: str) -> tuple[str, str | None, dict[str, Any] | None]
 
         thread_id = _extract_thread_id(data, thread_id)
         usage = _extract_usage(data, usage)
-        # Only clear pre-tool "thinking" text on item.started; clearing on
-        # item.updated / item.completed would discard the final agent response
-        # if the model emits it before calling a tool.
-        if _is_tool_item(data) and data.get("type") == "item.started":
+        if _is_tool_boundary_event(data):
             result_parts.clear()
         _extract_text(data, result_parts)
 
@@ -112,7 +109,22 @@ def _is_tool_item(data: dict[str, Any]) -> bool:
     if not isinstance(item, dict):
         return False
     item_type = item.get("type", "")
-    return item_type in _CODEX_ITEM_TOOL_MAP or item_type == "mcp_tool_call"
+    return item_type in _CODEX_ITEM_TOOL_MAP or item_type in {
+        "mcp_tool_call",
+        "collab_tool_call",
+    }
+
+
+def _is_tool_boundary_event(data: dict[str, Any]) -> bool:
+    """识别 Codex 各类工具首次可见的事件边界."""
+    if not _is_tool_item(data):
+        return False
+    item = data.get("item")
+    if not isinstance(item, dict):
+        return False
+    if item.get("type") == "file_change":
+        return data.get("type") in {"item.started", "item.completed"}
+    return data.get("type") == "item.started"
 
 
 def _extract_text(data: dict[str, Any], parts: list[str]) -> None:
@@ -255,11 +267,15 @@ def _parse_codex_item(data: dict[str, Any]) -> list[StreamEvent]:
 
 
 def _parse_tool_item(item: dict[str, Any], item_type: str, event_type: str) -> list[StreamEvent]:
-    """Extract tool indicator from a Codex item (``item.started`` only)."""
-    if event_type != "item.started":
+    """Extract a tool indicator from the first event Codex emits for the tool."""
+    valid_events = (
+        {"item.started", "item.completed"} if item_type == "file_change" else {"item.started"}
+    )
+    if event_type not in valid_events:
         return []
-    if item_type == "mcp_tool_call":
-        name = item.get("name") or item.get("tool_name") or "MCP"
+    if item_type in {"mcp_tool_call", "collab_tool_call"}:
+        fallback_name = "MCP" if item_type == "mcp_tool_call" else "Agent"
+        name = item.get("name") or item.get("tool_name") or item.get("tool") or fallback_name
         return [
             ToolUseEvent(
                 type="assistant",

--- a/ductor_bot/cli/codex_provider.py
+++ b/ductor_bot/cli/codex_provider.py
@@ -225,11 +225,11 @@ class CodexCLI(BaseCLI):
                 for event in thinking_filter.process(raw_event):
                     state.track(event)
                     yield event
+
+        async def post_handler(result: SubprocessResult) -> AsyncGenerator[StreamEvent, None]:
             for event in thinking_filter.flush():
                 state.track(event)
                 yield event
-
-        async def post_handler(result: SubprocessResult) -> AsyncGenerator[StreamEvent, None]:
             yield _codex_final_result(
                 result,
                 state.accumulated_text,

--- a/ductor_bot/config.py
+++ b/ductor_bot/config.py
@@ -236,6 +236,8 @@ class TasksConfig(BaseModel):
     """Settings for background task delegation."""
 
     enabled: bool = True
+    progress_updates: bool = True
+    progress_interval_seconds: float = Field(default=30.0, ge=10.0)
     max_parallel: int = 5
     timeout_seconds: float = 3600.0
     finished_retention_hours: int = 168

--- a/ductor_bot/messenger/matrix/bot.py
+++ b/ductor_bot/messenger/matrix/bot.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from ductor_bot.infra.updater import UpdateObserver
     from ductor_bot.multiagent.bus import AsyncInterAgentResult
     from ductor_bot.orchestrator.core import Orchestrator
-    from ductor_bot.tasks.models import TaskResult
+    from ductor_bot.tasks.models import TaskProgress, TaskResult
     from ductor_bot.workspace.paths import DuctorPaths
 
 logger = logging.getLogger(__name__)
@@ -1246,6 +1246,9 @@ class MatrixBot:
         env = from_task_result(result)
         env.transport = "mx"
         await self._bus.submit(env)
+
+    async def on_task_progress(self, progress: TaskProgress) -> None:
+        """显式忽略仅供 Telegram 消费的任务进度更新."""
 
     async def on_task_question(
         self,

--- a/ductor_bot/messenger/multi.py
+++ b/ductor_bot/messenger/multi.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ductor_bot.messenger.protocol import BotProtocol
     from ductor_bot.multiagent.bus import AsyncInterAgentResult
     from ductor_bot.orchestrator.core import Orchestrator
-    from ductor_bot.tasks.models import TaskResult
+    from ductor_bot.tasks.models import TaskProgress, TaskResult
     from ductor_bot.workspace.paths import DuctorPaths
 
 logger = logging.getLogger(__name__)
@@ -99,6 +99,10 @@ class MultiBotAdapter:
     async def on_async_interagent_result(self, result: AsyncInterAgentResult) -> None:
         for bot in self._all:
             await bot.on_async_interagent_result(result)
+
+    async def on_task_progress(self, progress: TaskProgress) -> None:
+        for bot in self._all:
+            await bot.on_task_progress(progress)
 
     async def on_task_result(self, result: TaskResult) -> None:
         for bot in self._all:

--- a/ductor_bot/messenger/protocol.py
+++ b/ductor_bot/messenger/protocol.py
@@ -11,13 +11,13 @@ if TYPE_CHECKING:
     from ductor_bot.messenger.notifications import NotificationService
     from ductor_bot.multiagent.bus import AsyncInterAgentResult
     from ductor_bot.orchestrator.core import Orchestrator
-    from ductor_bot.tasks.models import TaskResult
+    from ductor_bot.tasks.models import TaskProgress, TaskResult
     from ductor_bot.workspace.paths import DuctorPaths
 
 
 @runtime_checkable
 class BotProtocol(Protocol):
-    """Interface that both TelegramBot and MatrixBot implement.
+    """每个传输 bot 都应实现的接口.
 
     The supervisor, AgentStack, and InterAgentBus depend ONLY on this protocol,
     never on transport-specific classes.
@@ -50,6 +50,10 @@ class BotProtocol(Protocol):
 
     async def on_async_interagent_result(self, result: AsyncInterAgentResult) -> None:
         """Handle async inter-agent result delivery."""
+        ...
+
+    async def on_task_progress(self, progress: TaskProgress) -> None:
+        """处理权威后台任务生命周期更新."""
         ...
 
     async def on_task_result(self, result: TaskResult) -> None:

--- a/ductor_bot/messenger/slack/bot.py
+++ b/ductor_bot/messenger/slack/bot.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from ductor_bot.infra.updater import UpdateObserver
     from ductor_bot.multiagent.bus import AsyncInterAgentResult
     from ductor_bot.orchestrator.core import Orchestrator
-    from ductor_bot.tasks.models import TaskResult
+    from ductor_bot.tasks.models import TaskProgress, TaskResult
     from ductor_bot.workspace.paths import DuctorPaths
 
 if TYPE_CHECKING:
@@ -1033,6 +1033,9 @@ class SlackBot:
         env = from_task_result(result)
         env.transport = "sl"
         await self._bus.submit(env)
+
+    async def on_task_progress(self, progress: TaskProgress) -> None:
+        """显式忽略仅供 Telegram 消费的任务进度更新."""
 
     async def on_task_question(
         self,

--- a/ductor_bot/messenger/telegram/app.py
+++ b/ductor_bot/messenger/telegram/app.py
@@ -87,7 +87,7 @@ from ductor_bot.messenger.telegram.welcome import (
 )
 from ductor_bot.multiagent.bus import AsyncInterAgentResult
 from ductor_bot.session.key import SessionKey
-from ductor_bot.tasks.models import TaskResult
+from ductor_bot.tasks.models import TaskProgress, TaskResult
 from ductor_bot.text.response_format import SEP, fmt
 from ductor_bot.workspace.paths import DuctorPaths
 
@@ -1537,6 +1537,12 @@ class TelegramBot:
             return
         set_log_context(operation="task", chat_id=chat_id)
         await self._bus.submit(from_task_result(result))
+
+    async def on_task_progress(self, progress: TaskProgress) -> None:
+        """经消息总线处理权威任务生命周期进度."""
+        from ductor_bot.bus.adapters import from_task_progress
+
+        await self._bus.submit(from_task_progress(progress))
 
     async def on_task_question(
         self,

--- a/ductor_bot/messenger/telegram/app.py
+++ b/ductor_bot/messenger/telegram/app.py
@@ -223,7 +223,8 @@ class TelegramBot:
 
         from ductor_bot.messenger.telegram.transport import TelegramTransport
 
-        self._bus.register_transport(TelegramTransport(self))
+        self._transport = TelegramTransport(self)
+        self._bus.register_transport(self._transport)
         self._sequential = SequentialMiddleware(
             lock_pool=self._lock_pool,
             topic_names=self._topic_names,
@@ -246,6 +247,7 @@ class TelegramBot:
         self._register_member_handlers()
         self._dp.include_router(self._router)
         self._dp.startup.register(self._on_startup)
+        self._dp.shutdown.register(self._on_dispatcher_shutdown)
 
     @property
     def _orch(self) -> Orchestrator:
@@ -1662,7 +1664,12 @@ class TelegramBot:
         )
         return self._exit_code
 
+    async def _on_dispatcher_shutdown(self, **_: object) -> None:
+        """Stop heartbeats while aiogram still owns an open Bot session."""
+        await self._transport.shutdown()
+
     async def shutdown(self) -> None:
+        await self._transport.shutdown()
         await _cancel_task(self._restart_watcher)
         await _cancel_task(self._group_audit_task)
         if self._update_observer:

--- a/ductor_bot/messenger/telegram/task_progress.py
+++ b/ductor_bot/messenger/telegram/task_progress.py
@@ -20,7 +20,7 @@ TaskProgressKey = tuple[int, int | None, str]
 
 @dataclass(frozen=True, slots=True)
 class TaskProgressUpdate:
-    """Authoritative non-terminal lifecycle data for one background task."""
+    """Authoritative lifecycle and streamed output for one background task."""
 
     chat_id: int
     topic_id: int | None
@@ -28,6 +28,8 @@ class TaskProgressUpdate:
     name: str
     stage: str
     elapsed_seconds: float
+    output_text: str = ""
+    tool_name: str = ""
 
 
 @dataclass(slots=True)
@@ -40,6 +42,8 @@ class _ProgressState:
     stage: str
     started_at: float
     generation: int
+    output_text: str = ""
+    tool_name: str = ""
     message_id: int | None = None
     terminal: bool = False
     replacement_attempted: bool = False
@@ -83,6 +87,10 @@ class TelegramTaskProgressTracker:
 
         state.name = _display_name(update.name, update.task_id)
         state.stage = update.stage
+        if update.output_text:
+            state.output_text = update.output_text
+        if update.tool_name:
+            state.tool_name = update.tool_name
         await self._publish(state)
 
     async def finish(
@@ -147,6 +155,8 @@ class TelegramTaskProgressTracker:
                 stage=update.stage,
                 started_at=loop.time() - max(0.0, update.elapsed_seconds),
                 generation=self._generation,
+                output_text=update.output_text,
+                tool_name=update.tool_name,
             )
             self._states[key] = state
 
@@ -292,7 +302,12 @@ class TelegramTaskProgressTracker:
             title = f'🔎 Task "{state.name}" is reviewing the worker result'
         else:
             title = f'⏳ Task "{state.name}" is running'
-        return f"{title}\nID: {state.task_id}\nElapsed: {elapsed}s"
+        parts = [title, f"ID: {state.task_id}", f"Elapsed: {elapsed}s"]
+        if state.tool_name:
+            parts.append(f"[TOOL: {state.tool_name}]")
+        if state.output_text:
+            parts.append("\n" + state.output_text[-3000:])
+        return "\n".join(parts)
 
     def _terminal_text(self, state: _ProgressState, status: str) -> str:
         labels = {

--- a/ductor_bot/messenger/telegram/task_progress.py
+++ b/ductor_bot/messenger/telegram/task_progress.py
@@ -1,0 +1,318 @@
+"""Single-message progress tracking for Telegram TaskHub workers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from aiogram.exceptions import TelegramBadRequest, TelegramRetryAfter
+
+if TYPE_CHECKING:
+    from aiogram import Bot
+
+logger = logging.getLogger(__name__)
+
+TaskProgressKey = tuple[int, int | None, str]
+
+
+@dataclass(frozen=True, slots=True)
+class TaskProgressUpdate:
+    """Authoritative non-terminal lifecycle data for one background task."""
+
+    chat_id: int
+    topic_id: int | None
+    task_id: str
+    name: str
+    stage: str
+    elapsed_seconds: float
+
+
+@dataclass(slots=True)
+class _ProgressState:
+    key: TaskProgressKey
+    chat_id: int
+    topic_id: int | None
+    task_id: str
+    name: str
+    stage: str
+    started_at: float
+    generation: int
+    message_id: int | None = None
+    terminal: bool = False
+    replacement_attempted: bool = False
+    timer: asyncio.Task[None] | None = field(default=None, repr=False)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+
+
+class TelegramTaskProgressTracker:
+    """Own one editable Telegram status message for each active TaskHub run."""
+
+    def __init__(
+        self,
+        bot: Bot,
+        *,
+        interval_seconds: float = 30.0,
+        enabled: bool = True,
+    ) -> None:
+        self._bot = bot
+        self._interval_seconds = interval_seconds
+        self._enabled = enabled
+        self._states: dict[TaskProgressKey, _ProgressState] = {}
+        self._states_lock = asyncio.Lock()
+        self._generation = 0
+        self._closed = False
+
+    async def update(self, update: TaskProgressUpdate) -> None:
+        """Start or update one authoritative running/reviewing lifecycle state."""
+        if not self._enabled or self._closed:
+            return
+
+        key = (update.chat_id, update.topic_id, update.task_id)
+        if update.stage == "running":
+            await self._start_generation(update)
+            return
+
+        async with self._states_lock:
+            state = self._states.get(key)
+        if state is None:
+            await self._start_generation(update)
+            return
+
+        state.name = _display_name(update.name, update.task_id)
+        state.stage = update.stage
+        await self._publish(state)
+
+    async def finish(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        task_id: str,
+        status: str,
+    ) -> bool:
+        """Stop a task heartbeat and replace its status message with a terminal state."""
+        if not self._enabled:
+            return False
+
+        key = (chat_id, topic_id, task_id)
+        async with self._states_lock:
+            state = self._states.get(key)
+            if state is None:
+                return False
+            state.terminal = True
+
+        await self._cancel_timer(state)
+        async with state.lock:
+            text = self._terminal_text(state, status)
+            updated = await self._write(state, text, terminal=True)
+
+        async with self._states_lock:
+            if self._states.get(key) is state:
+                del self._states[key]
+        return updated
+
+    async def shutdown(self) -> None:
+        """Cancel and await every heartbeat before the Telegram session closes."""
+        if self._closed:
+            return
+        self._closed = True
+        async with self._states_lock:
+            states = list(self._states.values())
+            self._states.clear()
+            for state in states:
+                state.terminal = True
+
+        await asyncio.gather(*(self._cancel_timer(state) for state in states))
+        for state in states:
+            async with state.lock:
+                pass
+
+    async def _start_generation(self, update: TaskProgressUpdate) -> None:
+        key = (update.chat_id, update.topic_id, update.task_id)
+        loop = asyncio.get_running_loop()
+        async with self._states_lock:
+            previous = self._states.get(key)
+            if previous is not None:
+                previous.terminal = True
+            self._generation += 1
+            state = _ProgressState(
+                key=key,
+                chat_id=update.chat_id,
+                topic_id=update.topic_id,
+                task_id=update.task_id,
+                name=_display_name(update.name, update.task_id),
+                stage=update.stage,
+                started_at=loop.time() - max(0.0, update.elapsed_seconds),
+                generation=self._generation,
+            )
+            self._states[key] = state
+
+        if previous is not None:
+            await self._cancel_timer(previous)
+        await self._publish(state)
+
+        async with self._states_lock:
+            if self._closed or state.terminal or self._states.get(key) is not state:
+                return
+            state.timer = asyncio.create_task(
+                self._heartbeat_loop(state),
+                name=f"task-progress:{update.task_id}:{state.generation}",
+            )
+
+    async def _heartbeat_loop(self, state: _ProgressState) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._interval_seconds)
+                if not self._is_current_active(state):
+                    return
+                await self._publish(state)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Task progress heartbeat failed task=%s", state.task_id)
+
+    async def _publish(self, state: _ProgressState) -> bool:
+        if not self._is_current_active(state):
+            return False
+        async with state.lock:
+            if not self._is_current_active(state):
+                return False
+            return await self._write(state, self._active_text(state), terminal=False)
+
+    async def _write(self, state: _ProgressState, text: str, *, terminal: bool) -> bool:
+        if state.message_id is None:
+            return await self._send(state, text)
+        return await self._edit(state, text, terminal=terminal)
+
+    async def _send(self, state: _ProgressState, text: str) -> bool:
+        try:
+            message = await self._bot.send_message(
+                chat_id=state.chat_id,
+                text=text,
+                parse_mode=None,
+                message_thread_id=state.topic_id,
+            )
+        except Exception:
+            logger.warning(
+                "Task progress send failed task=%s chat=%s topic=%s",
+                state.task_id,
+                state.chat_id,
+                state.topic_id,
+                exc_info=True,
+            )
+            return False
+
+        message_id = getattr(message, "message_id", None)
+        if not isinstance(message_id, int):
+            logger.warning("Task progress send returned no message_id task=%s", state.task_id)
+            return False
+        state.message_id = message_id
+        return True
+
+    async def _edit(self, state: _ProgressState, text: str, *, terminal: bool) -> bool:
+        error = await self._attempt_edit(state, text)
+        if isinstance(error, TelegramRetryAfter):
+            await asyncio.sleep(max(0.0, float(error.retry_after)))
+            if not terminal and not self._is_current_active(state):
+                return False
+            error = await self._attempt_edit(state, text)
+        if error is None:
+            return True
+        if (
+            isinstance(error, TelegramBadRequest)
+            and "message is not modified" in str(error).lower()
+        ):
+            return True
+        if isinstance(error, TelegramRetryAfter):
+            logger.warning("Task progress edit remained rate-limited task=%s", state.task_id)
+            return False
+        return await self._replace_once(state, text, error)
+
+    async def _attempt_edit(self, state: _ProgressState, text: str) -> Exception | None:
+        try:
+            await self._edit_once(state, text)
+        except Exception as exc:
+            return exc
+        else:
+            return None
+
+    async def _edit_once(self, state: _ProgressState, text: str) -> None:
+        assert state.message_id is not None
+        await self._bot.edit_message_text(
+            chat_id=state.chat_id,
+            message_id=state.message_id,
+            text=text,
+            parse_mode=None,
+        )
+
+    async def _replace_once(
+        self,
+        state: _ProgressState,
+        text: str,
+        error: Exception,
+    ) -> bool:
+        if state.replacement_attempted:
+            logger.warning(
+                "Task progress edit failed after replacement task=%s: %s",
+                state.task_id,
+                type(error).__name__,
+            )
+            return False
+        state.replacement_attempted = True
+        logger.warning(
+            "Replacing uneditable task progress message task=%s: %s",
+            state.task_id,
+            type(error).__name__,
+        )
+        state.message_id = None
+        return await self._send(state, text)
+
+    async def _cancel_timer(self, state: _ProgressState) -> None:
+        timer = state.timer
+        if timer is None or timer.done():
+            return
+        timer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await timer
+
+    def _is_current_active(self, state: _ProgressState) -> bool:
+        return (
+            self._enabled
+            and not self._closed
+            and not state.terminal
+            and self._states.get(state.key) is state
+        )
+
+    def _active_text(self, state: _ProgressState) -> str:
+        elapsed = self._elapsed(state)
+        if state.stage == "reviewing":
+            title = f'🔎 Task "{state.name}" is reviewing the worker result'
+        else:
+            title = f'⏳ Task "{state.name}" is running'
+        return f"{title}\nID: {state.task_id}\nElapsed: {elapsed}s"
+
+    def _terminal_text(self, state: _ProgressState, status: str) -> str:
+        labels = {
+            "done": ("✅", "completed"),
+            "failed": ("❌", "failed"),
+            "cancelled": ("⏹", "cancelled"),
+            "waiting": ("❔", "waiting for input"),
+            "timeout": ("⌛", "timed out"),
+        }
+        icon, label = labels.get(status, ("Info", f"finished ({status})"))
+        return (
+            f'{icon} Task "{state.name}" {label}\n'
+            f"ID: {state.task_id}\nElapsed: {self._elapsed(state)}s"
+        )
+
+    @staticmethod
+    def _elapsed(state: _ProgressState) -> int:
+        return max(0, int(asyncio.get_running_loop().time() - state.started_at))
+
+
+def _display_name(name: str, task_id: str) -> str:
+    cleaned = " ".join(name.split()) or task_id
+    return cleaned[:160]

--- a/ductor_bot/messenger/telegram/task_progress.py
+++ b/ductor_bot/messenger/telegram/task_progress.py
@@ -318,10 +318,15 @@ class TelegramTaskProgressTracker:
             "timeout": ("⌛", "timed out"),
         }
         icon, label = labels.get(status, ("Info", f"finished ({status})"))
-        return (
+        text = (
             f'{icon} Task "{state.name}" {label}\n'
             f"ID: {state.task_id}\nElapsed: {self._elapsed(state)}s"
         )
+        if state.tool_name:
+            text += f"\n[TOOL: {state.tool_name}]"
+        if state.output_text:
+            text += "\n\n" + state.output_text[-3000:]
+        return text
 
     @staticmethod
     def _elapsed(state: _ProgressState) -> int:

--- a/ductor_bot/messenger/telegram/transport.py
+++ b/ductor_bot/messenger/telegram/transport.py
@@ -236,6 +236,8 @@ class TelegramTransport:
                 name=env.metadata.get("name", task_id),
                 stage=env.status,
                 elapsed_seconds=env.elapsed_seconds,
+                output_text=env.metadata.get("output_text", ""),
+                tool_name=env.metadata.get("tool_name", ""),
             )
         )
 

--- a/ductor_bot/messenger/telegram/transport.py
+++ b/ductor_bot/messenger/telegram/transport.py
@@ -15,6 +15,10 @@ from typing import TYPE_CHECKING
 from ductor_bot.bus.cron_sanitize import sanitize_cron_result_text
 from ductor_bot.bus.envelope import Envelope, Origin
 from ductor_bot.messenger.telegram.sender import SendRichOpts, send_rich
+from ductor_bot.messenger.telegram.task_progress import (
+    TaskProgressUpdate,
+    TelegramTaskProgressTracker,
+)
 from ductor_bot.text.response_format import SEP, fmt
 
 if TYPE_CHECKING:
@@ -33,6 +37,14 @@ class TelegramTransport:
 
     def __init__(self, bot: TelegramBot) -> None:
         self._bot = bot
+        tasks_config = bot.config.tasks
+        enabled = bool(getattr(tasks_config, "progress_updates", True))
+        interval = float(getattr(tasks_config, "progress_interval_seconds", 30.0))
+        self._task_progress = TelegramTaskProgressTracker(
+            bot.bot_instance,
+            interval_seconds=interval,
+            enabled=enabled,
+        )
 
     # -- Protocol methods ---------------------------------------------------
 
@@ -55,6 +67,10 @@ class TelegramTransport:
             await handler(self, envelope)
         else:
             logger.warning("No broadcast handler for origin=%s", envelope.origin.value)
+
+    async def shutdown(self) -> None:
+        """Stop Telegram-local timers before the Bot session closes."""
+        await self._task_progress.shutdown()
 
     # -- Internal helpers ---------------------------------------------------
 
@@ -182,17 +198,24 @@ class TelegramTransport:
         """Deliver task result notification + injected response."""
         opts = self._opts(env)
         name = env.metadata.get("name", env.metadata.get("task_id", "?"))
+        task_id = env.metadata.get("task_id", "?")
+        tracked = await self._task_progress.finish(
+            chat_id=env.chat_id,
+            topic_id=env.topic_id,
+            task_id=task_id,
+            status=env.status,
+        )
 
         # 1. Notification (skip "waiting" — question already shown)
         note = ""
-        if env.status == "done":
+        if not tracked and env.status == "done":
             duration = f"{env.elapsed_seconds:.0f}s"
             target = f"{env.provider}/{env.model}" if env.provider else ""
             detail = f"{duration}, {target}" if target else duration
             note = f"**Task `{name}` completed** ({detail})"
-        elif env.status == "cancelled":
+        elif not tracked and env.status == "cancelled":
             note = f"**Task `{name}` cancelled**"
-        elif env.status == "failed":
+        elif not tracked and env.status == "failed":
             note = f"**Task `{name}` failed**\nReason: {env.metadata.get('error', 'unknown')}"
 
         if note:
@@ -201,6 +224,20 @@ class TelegramTransport:
         # 2. Injected response (filled by bus injection for done/failed)
         if env.needs_injection and env.result_text:
             await send_rich(self._bot.bot_instance, env.chat_id, env.result_text, opts)
+
+    async def _deliver_task_progress(self, env: Envelope) -> None:
+        """Start or update the Telegram-local task status heartbeat."""
+        task_id = env.metadata.get("task_id", "?")
+        await self._task_progress.update(
+            TaskProgressUpdate(
+                chat_id=env.chat_id,
+                topic_id=env.topic_id,
+                task_id=task_id,
+                name=env.metadata.get("name", task_id),
+                stage=env.status,
+                elapsed_seconds=env.elapsed_seconds,
+            )
+        )
 
     async def _deliver_task_question(self, env: Envelope) -> None:
         """Deliver task question notification + injected agent response."""
@@ -313,6 +350,7 @@ _HANDLERS: dict[Origin, _Handler] = {
     Origin.CRON: TelegramTransport._deliver_cron,
     Origin.HEARTBEAT: TelegramTransport._deliver_heartbeat,
     Origin.INTERAGENT: TelegramTransport._deliver_interagent,
+    Origin.TASK_PROGRESS: TelegramTransport._deliver_task_progress,
     Origin.TASK_RESULT: TelegramTransport._deliver_task_result,
     Origin.TASK_QUESTION: TelegramTransport._deliver_task_question,
     Origin.WEBHOOK_WAKE: TelegramTransport._deliver_webhook_wake,

--- a/ductor_bot/multiagent/supervisor.py
+++ b/ductor_bot/multiagent/supervisor.py
@@ -471,6 +471,7 @@ class AgentSupervisor:
         # live (each orchestrator owns its own — see Orchestrator.__init__).
         hub.set_agent_process_registry(name, orch.process_registry)
 
+        hub.set_progress_handler(name, stack.bot.on_task_progress)
         hub.set_result_handler(name, stack.bot.on_task_result)
         hub.set_question_handler(name, stack.bot.on_task_question)
 

--- a/ductor_bot/tasks/hub.py
+++ b/ductor_bot/tasks/hub.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
     from ductor_bot.cli.process_registry import ProcessRegistry
     from ductor_bot.cli.service import CLIService
+    from ductor_bot.cli.stream_events import ToolUseEvent
     from ductor_bot.config import TasksConfig
     from ductor_bot.tasks.registry import TaskRegistry
     from ductor_bot.workspace.paths import DuctorPaths
@@ -519,7 +520,30 @@ class TaskHub:
             timeout = self._config.timeout_seconds
             await self._deliver_progress(entry, "running", time.monotonic() - t0)
             request = await self._prepare_request(entry, prompt, cli, resume_session)
-            response = await cli.execute(request)
+            streamed_parts: list[str] = []
+
+            async def _on_text_delta(text: str) -> None:
+                streamed_parts.append(text)
+                await self._deliver_progress(
+                    entry,
+                    "running",
+                    time.monotonic() - t0,
+                    output_text="".join(streamed_parts),
+                )
+
+            async def _on_tool_activity(event: ToolUseEvent) -> None:
+                await self._deliver_progress(
+                    entry,
+                    "running",
+                    time.monotonic() - t0,
+                    tool_name=event.tool_name,
+                )
+
+            response = await cli.execute_streaming(
+                request,
+                on_text_delta=_on_text_delta,
+                on_tool_activity=_on_tool_activity,
+            )
 
             elapsed = time.monotonic() - t0
             await self._deliver_progress(entry, "reviewing", elapsed)
@@ -672,6 +696,9 @@ class TaskHub:
         entry: TaskEntry,
         stage: str,
         elapsed_seconds: float,
+        *,
+        output_text: str = "",
+        tool_name: str = "",
     ) -> None:
         """尽力投递一条权威任务生命周期更新, 不影响 worker 执行."""
         handler = self._progress_handlers.get(entry.parent_agent)
@@ -689,6 +716,8 @@ class TaskHub:
                     provider=entry.provider,
                     model=entry.model,
                     thread_id=entry.thread_id,
+                    output_text=output_text,
+                    tool_name=tool_name,
                 )
             )
         except Exception:

--- a/ductor_bot/tasks/hub.py
+++ b/ductor_bot/tasks/hub.py
@@ -13,6 +13,7 @@ from ductor_bot.cli.types import AgentRequest
 from ductor_bot.tasks.models import (
     TaskEntry,
     TaskInFlight,
+    TaskProgress,
     TaskResult,
     TaskSubmit,
     normalise_priority,
@@ -35,6 +36,7 @@ _RESUMABLE = frozenset({"done", "failed", "cancelled", "waiting"})
 _MAINTENANCE_INTERVAL = 5 * 3600  # 5 hours
 
 TaskResultCallback = Callable[[TaskResult], Awaitable[None]]
+TaskProgressCallback = Callable[[TaskProgress], Awaitable[None]]
 QuestionHandler = Callable[[str, str, str, int, int | None], Awaitable[None]]
 # QuestionHandler(task_id, question, prompt_preview, chat_id, thread_id) -> None
 
@@ -93,6 +95,7 @@ class TaskHub:
         self._config = config
         self._in_flight: dict[str, TaskInFlight] = {}
         self._result_handlers: dict[str, TaskResultCallback] = {}
+        self._progress_handlers: dict[str, TaskProgressCallback] = {}
         self._question_handlers: dict[str, QuestionHandler] = {}
         self._agent_chat_ids: dict[str, int] = {}
         self._maintenance_task: asyncio.Task[None] | None = None
@@ -119,6 +122,10 @@ class TaskHub:
     def set_result_handler(self, agent_name: str, handler: TaskResultCallback) -> None:
         """Register callback for delivering results to a parent agent."""
         self._result_handlers[agent_name] = handler
+
+    def set_progress_handler(self, agent_name: str, handler: TaskProgressCallback) -> None:
+        """注册任务生命周期更新的投递回调."""
+        self._progress_handlers[agent_name] = handler
 
     def set_question_handler(self, agent_name: str, handler: QuestionHandler) -> None:
         """Register handler for task-agent questions (ask_parent)."""
@@ -510,10 +517,12 @@ class TaskHub:
         final_delivery_started = False
         try:
             timeout = self._config.timeout_seconds
+            await self._deliver_progress(entry, "running", time.monotonic() - t0)
             request = await self._prepare_request(entry, prompt, cli, resume_session)
             response = await cli.execute(request)
 
             elapsed = time.monotonic() - t0
+            await self._deliver_progress(entry, "reviewing", elapsed)
             inflight = self._in_flight.get(entry.task_id)
             has_pending = bool(inflight and inflight.has_pending_question)
             status, error = _classify_task_response(response, timeout, has_pending)
@@ -656,6 +665,38 @@ class TaskHub:
                 "Error delivering task result id=%s to '%s'",
                 result.task_id,
                 result.parent_agent,
+            )
+
+    async def _deliver_progress(
+        self,
+        entry: TaskEntry,
+        stage: str,
+        elapsed_seconds: float,
+    ) -> None:
+        """尽力投递一条权威任务生命周期更新, 不影响 worker 执行."""
+        handler = self._progress_handlers.get(entry.parent_agent)
+        if handler is None:
+            return
+        try:
+            await handler(
+                TaskProgress(
+                    task_id=entry.task_id,
+                    chat_id=entry.chat_id,
+                    parent_agent=entry.parent_agent,
+                    name=entry.name,
+                    stage=stage,
+                    elapsed_seconds=elapsed_seconds,
+                    provider=entry.provider,
+                    model=entry.model,
+                    thread_id=entry.thread_id,
+                )
+            )
+        except Exception:
+            logger.exception(
+                "Task progress delivery failed id=%s stage=%s parent='%s'",
+                entry.task_id,
+                stage,
+                entry.parent_agent,
             )
 
 

--- a/ductor_bot/tasks/models.py
+++ b/ductor_bot/tasks/models.py
@@ -142,7 +142,7 @@ class TaskInFlight:
 
 @dataclass(slots=True)
 class TaskProgress:
-    """Lifecycle update emitted while a background task is active."""
+    """Lifecycle and streaming update emitted while a background task is active."""
 
     task_id: str
     chat_id: int
@@ -153,6 +153,8 @@ class TaskProgress:
     provider: str
     model: str
     thread_id: int | None = None
+    output_text: str = ""
+    tool_name: str = ""
 
 
 @dataclass(slots=True)

--- a/ductor_bot/tasks/models.py
+++ b/ductor_bot/tasks/models.py
@@ -141,6 +141,21 @@ class TaskInFlight:
 
 
 @dataclass(slots=True)
+class TaskProgress:
+    """Lifecycle update emitted while a background task is active."""
+
+    task_id: str
+    chat_id: int
+    parent_agent: str
+    name: str
+    stage: str
+    elapsed_seconds: float
+    provider: str
+    model: str
+    thread_id: int | None = None
+
+
+@dataclass(slots=True)
 class TaskResult:
     """Outcome delivered to parent agent after task completion."""
 

--- a/tests/bus/test_adapters.py
+++ b/tests/bus/test_adapters.py
@@ -9,12 +9,14 @@ from ductor_bot.bus.adapters import (
     from_cron_result,
     from_heartbeat,
     from_interagent_result,
+    from_task_progress,
     from_task_question,
     from_task_result,
     from_webhook_cron_result,
     from_webhook_wake,
 )
 from ductor_bot.bus.envelope import DeliveryMode, LockMode, Origin
+from ductor_bot.tasks.models import TaskProgress
 
 # -- Fake result types (avoid importing real models with heavy deps) -----------
 
@@ -296,6 +298,37 @@ def test_from_task_result_preserves_parent_agent() -> None:
     sub-agent's bot (not the main agent's)."""
     env = from_task_result(_FakeTaskResult(parent_agent="sonic"))
     assert env.metadata["parent_agent"] == "sonic"
+
+
+def test_from_task_progress_creates_non_injecting_envelope() -> None:
+    progress = TaskProgress(
+        task_id="t1",
+        chat_id=100,
+        parent_agent="main",
+        name="research",
+        stage="running",
+        elapsed_seconds=5.0,
+        provider="claude",
+        model="sonnet",
+        thread_id=42,
+    )
+    env = from_task_progress(progress)
+
+    assert env.origin == Origin.TASK_PROGRESS
+    assert env.chat_id == 100
+    assert env.topic_id == 42
+    assert env.status == "running"
+    assert env.delivery == DeliveryMode.UNICAST
+    assert env.lock_mode == LockMode.NONE
+    assert not env.needs_injection
+    assert env.elapsed_seconds == 5.0
+    assert env.provider == "claude"
+    assert env.model == "sonnet"
+    assert env.metadata == {
+        "task_id": "t1",
+        "name": "research",
+        "parent_agent": "main",
+    }
 
 
 def test_from_task_question() -> None:

--- a/tests/bus/test_adapters.py
+++ b/tests/bus/test_adapters.py
@@ -328,6 +328,8 @@ def test_from_task_progress_creates_non_injecting_envelope() -> None:
         "task_id": "t1",
         "name": "research",
         "parent_agent": "main",
+        "output_text": "",
+        "tool_name": "",
     }
 
 

--- a/tests/cli/test_codex_events.py
+++ b/tests/cli/test_codex_events.py
@@ -86,7 +86,7 @@ def test_parse_ignores_tagged_thinking_before_final_message() -> None:
                     "type": "item.completed",
                     "item": {
                         "type": "agent_message",
-                        "text": "  \n<thinking>内部推理</thinking>",
+                        "text": "  \n<thinking>内部推理</thinking>\n工具调用仍在重试",
                     },
                 }
             ),
@@ -214,7 +214,7 @@ def test_stream_tagged_agent_message_is_thinking() -> None:
             "type": "item.completed",
             "item": {
                 "type": "agent_message",
-                "text": "  \n<thinking>内部推理</thinking>",
+                "text": "  \n<thinking>内部推理</thinking>\n工具调用仍在重试",
             },
         }
     )

--- a/tests/cli/test_codex_events.py
+++ b/tests/cli/test_codex_events.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from ductor_bot.cli.codex_events import parse_codex_jsonl, parse_codex_stream_event
 from ductor_bot.cli.stream_events import (
     AssistantTextDelta,
@@ -88,6 +90,39 @@ def test_parse_ignores_tagged_thinking_before_final_message() -> None:
                     },
                 }
             ),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "最终答复"},
+                }
+            ),
+        ]
+    )
+
+    text, _, _ = parse_codex_jsonl(lines)
+
+    assert text == "最终答复"
+
+
+@pytest.mark.parametrize(
+    ("event_type", "tool_type"),
+    [
+        ("item.started", "collab_tool_call"),
+        ("item.completed", "file_change"),
+    ],
+)
+def test_parse_discards_pre_tool_text_for_all_codex_tool_boundaries(
+    event_type: str, tool_type: str
+) -> None:
+    lines = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "内部预告"},
+                }
+            ),
+            json.dumps({"type": event_type, "item": {"type": tool_type}}),
             json.dumps(
                 {
                     "type": "item.completed",

--- a/tests/cli/test_codex_events.py
+++ b/tests/cli/test_codex_events.py
@@ -76,6 +76,32 @@ def test_parse_multiple_lines() -> None:
     assert "Part 2" in text
 
 
+def test_parse_ignores_tagged_thinking_before_final_message() -> None:
+    lines = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "agent_message",
+                        "text": "  \n<thinking>内部推理</thinking>",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "最终答复"},
+                }
+            ),
+        ]
+    )
+
+    text, _, _ = parse_codex_jsonl(lines)
+
+    assert text == "最终答复"
+
+
 def test_unparseable_lines_skipped() -> None:
     raw = "not json\n" + json.dumps(
         {
@@ -145,6 +171,23 @@ def test_stream_agent_message() -> None:
     assert len(events) == 1
     assert isinstance(events[0], AssistantTextDelta)
     assert events[0].text == "Hello"
+
+
+def test_stream_tagged_agent_message_is_thinking() -> None:
+    line = json.dumps(
+        {
+            "type": "item.completed",
+            "item": {
+                "type": "agent_message",
+                "text": "  \n<thinking>内部推理</thinking>",
+            },
+        }
+    )
+
+    events = parse_codex_stream_event(line)
+
+    assert len(events) == 1
+    assert isinstance(events[0], ThinkingEvent)
 
 
 def test_stream_reasoning() -> None:

--- a/tests/cli/test_codex_events.py
+++ b/tests/cli/test_codex_events.py
@@ -6,7 +6,11 @@ import json
 
 import pytest
 
-from ductor_bot.cli.codex_events import parse_codex_jsonl, parse_codex_stream_event
+from ductor_bot.cli.codex_events import (
+    CodexThinkingFilter,
+    parse_codex_jsonl,
+    parse_codex_stream_event,
+)
 from ductor_bot.cli.stream_events import (
     AssistantTextDelta,
     ResultEvent,
@@ -137,6 +141,36 @@ def test_parse_discards_pre_tool_text_for_all_codex_tool_boundaries(
     assert text == "最终答复"
 
 
+def test_parse_keeps_final_text_after_completed_file_change() -> None:
+    """A completion paired with a start must not clear the completed reply."""
+    lines = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "item.started",
+                    "item": {"type": "file_change", "id": "change-1"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "最终答复"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "file_change", "id": "change-1"},
+                }
+            ),
+        ]
+    )
+
+    text, _, _ = parse_codex_jsonl(lines)
+
+    assert text == "最终答复"
+
+
 def test_unparseable_lines_skipped() -> None:
     raw = "not json\n" + json.dumps(
         {
@@ -208,7 +242,7 @@ def test_stream_agent_message() -> None:
     assert events[0].text == "Hello"
 
 
-def test_stream_tagged_agent_message_is_thinking() -> None:
+def test_stream_tagged_agent_message_is_suppressed() -> None:
     line = json.dumps(
         {
             "type": "item.completed",
@@ -221,8 +255,7 @@ def test_stream_tagged_agent_message_is_thinking() -> None:
 
     events = parse_codex_stream_event(line)
 
-    assert len(events) == 1
-    assert isinstance(events[0], ThinkingEvent)
+    assert events == []
 
 
 def test_stream_reasoning() -> None:
@@ -261,6 +294,32 @@ def test_stream_file_change() -> None:
     assert len(events) == 1
     assert isinstance(events[0], ToolUseEvent)
     assert events[0].tool_name == "Edit"
+
+
+def test_thinking_filter_deduplicates_file_change_lifecycle_events() -> None:
+    """A file-change completion must not repeat its already-emitted progress event."""
+    filter_ = CodexThinkingFilter()
+    started = parse_codex_stream_event(
+        json.dumps(
+            {
+                "type": "item.started",
+                "item": {"type": "file_change", "id": "change-1"},
+            }
+        )
+    )[0]
+    completed = parse_codex_stream_event(
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "file_change", "id": "change-1"},
+            }
+        )
+    )[0]
+
+    assert filter_.process(started) == [started]
+    assert filter_.process(AssistantTextDelta(type="assistant", text="Final answer")) == []
+    assert filter_.process(completed) == []
+    assert filter_.flush() == [AssistantTextDelta(type="assistant", text="Final answer")]
 
 
 def test_stream_mcp_tool_call() -> None:

--- a/tests/cli/test_codex_provider.py
+++ b/tests/cli/test_codex_provider.py
@@ -825,6 +825,43 @@ class TestSendStreaming:
         assert result_events[0].is_error is True
         proc.wait.assert_awaited_once()
 
+    async def test_streaming_timeout_discards_unclassified_agent_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cli = _make_cli(monkeypatch)
+        proc = AsyncMock(spec=asyncio.subprocess.Process)
+        proc.returncode = None
+        proc.pid = 12345
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+
+        internal_line = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "尚未确定是否为最终答复"},
+            }
+        )
+        stdout_mock = AsyncMock()
+        stdout_mock.readline = AsyncMock(side_effect=[f"{internal_line}\n".encode(), TimeoutError])
+        proc.stdout = stdout_mock
+
+        stderr_mock = AsyncMock()
+        stderr_mock.read = AsyncMock(return_value=b"")
+        proc.stderr = stderr_mock
+
+        with patch("ductor_bot.cli.executor.asyncio") as mock_asyncio:
+            mock_asyncio.timeout = asyncio.timeout
+            mock_asyncio.subprocess = asyncio.subprocess
+            mock_asyncio.create_subprocess_exec = AsyncMock(return_value=proc)
+            mock_asyncio.create_task = asyncio.ensure_future
+
+            events = await _collect_events(cli.send_streaming("hello", timeout_seconds=0.01))
+
+        assert not any(isinstance(event, AssistantTextDelta) for event in events)
+        result_events = [event for event in events if isinstance(event, ResultEvent)]
+        assert len(result_events) == 1
+        assert result_events[0].is_error is True
+
     async def test_streaming_no_stdout_raises_runtime_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/test_codex_provider.py
+++ b/tests/cli/test_codex_provider.py
@@ -742,6 +742,45 @@ class TestSendStreaming:
         assert result_events[0].is_error is False
         assert result_events[0].session_id == "th-stream-1"
 
+    async def test_streaming_discards_pre_tool_agent_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cli = _make_cli(monkeypatch)
+        lines = [
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "内部预告"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "item.started",
+                    "item": {"type": "mcp_tool_call", "name": "search_docs"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "最终答复"},
+                }
+            ),
+            json.dumps({"type": "turn.completed", "usage": {}}),
+        ]
+        proc = _make_streaming_process(lines, returncode=0)
+
+        with patch("ductor_bot.cli.executor.asyncio") as mock_asyncio:
+            mock_asyncio.timeout = asyncio.timeout
+            mock_asyncio.subprocess = asyncio.subprocess
+            mock_asyncio.create_subprocess_exec = AsyncMock(return_value=proc)
+            mock_asyncio.create_task = asyncio.ensure_future
+
+            events = await _collect_events(cli.send_streaming("hello"))
+
+        text_events = [event.text for event in events if isinstance(event, AssistantTextDelta)]
+        result_events = [event for event in events if isinstance(event, ResultEvent)]
+        assert (text_events, result_events[-1].result) == (["最终答复"], "最终答复")
+
     async def test_streaming_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cli = _make_cli(monkeypatch)
 

--- a/tests/cli/test_codex_provider.py
+++ b/tests/cli/test_codex_provider.py
@@ -742,8 +742,26 @@ class TestSendStreaming:
         assert result_events[0].is_error is False
         assert result_events[0].session_id == "th-stream-1"
 
+    @pytest.mark.parametrize(
+        "tool_event",
+        [
+            {
+                "type": "item.started",
+                "item": {"type": "mcp_tool_call", "name": "search_docs"},
+            },
+            {
+                "type": "item.started",
+                "item": {"type": "collab_tool_call", "tool": "spawn_agent"},
+            },
+            {
+                "type": "item.completed",
+                "item": {"type": "file_change", "changes": []},
+            },
+        ],
+        ids=["mcp", "collab", "file-change"],
+    )
     async def test_streaming_discards_pre_tool_agent_message(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tool_event: dict[str, object]
     ) -> None:
         cli = _make_cli(monkeypatch)
         lines = [
@@ -753,12 +771,7 @@ class TestSendStreaming:
                     "item": {"type": "agent_message", "text": "内部预告"},
                 }
             ),
-            json.dumps(
-                {
-                    "type": "item.started",
-                    "item": {"type": "mcp_tool_call", "name": "search_docs"},
-                }
-            ),
+            json.dumps(tool_event),
             json.dumps(
                 {
                     "type": "item.completed",

--- a/tests/messenger/telegram/test_app.py
+++ b/tests/messenger/telegram/test_app.py
@@ -182,6 +182,16 @@ class TestTelegramBotInit:
         with pytest.raises(RuntimeError, match="Orchestrator not initialized"):
             _ = tg_bot._orch
 
+    async def test_dispatcher_shutdown_stops_progress_before_aiogram_closes_session(
+        self,
+    ) -> None:
+        tg_bot, _ = _make_tg_bot()
+        tg_bot._transport.shutdown = AsyncMock()
+
+        await tg_bot._dp.emit_shutdown()
+
+        tg_bot._transport.shutdown.assert_awaited_once()
+
 
 class TestTelegramBotRun:
     async def test_run_returns_exit_code(self) -> None:
@@ -241,6 +251,27 @@ class TestTelegramBotRun:
         tg_bot._dp.stop_polling.assert_called_once()
         bot_instance.delete_webhook.assert_called_once_with(drop_pending_updates=False)
         bot_instance.session.close.assert_called_once()
+
+    async def test_explicit_shutdown_stops_progress_before_bot_session(self) -> None:
+        tg_bot, bot_instance = _make_tg_bot()
+        tg_bot._orchestrator = MagicMock()
+        tg_bot._orchestrator.shutdown = AsyncMock()
+        order: list[str] = []
+
+        async def _stop_progress() -> None:
+            order.append("progress")
+
+        async def _close_session() -> None:
+            order.append("session")
+
+        tg_bot._transport.shutdown = AsyncMock(side_effect=_stop_progress)
+        tg_bot._dp.stop_polling = AsyncMock()
+        bot_instance.session = MagicMock()
+        bot_instance.session.close = AsyncMock(side_effect=_close_session)
+
+        await tg_bot.shutdown()
+
+        assert order == ["progress", "session"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/messenger/telegram/test_task_progress.py
+++ b/tests/messenger/telegram/test_task_progress.py
@@ -1,0 +1,292 @@
+"""Tests for Telegram's single-message TaskHub progress tracker."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiogram.exceptions import TelegramBadRequest, TelegramRetryAfter
+
+from ductor_bot.messenger.telegram.task_progress import (
+    TaskProgressUpdate,
+    TelegramTaskProgressTracker,
+)
+
+
+def _message(message_id: int) -> MagicMock:
+    message = MagicMock()
+    message.message_id = message_id
+    return message
+
+
+def _bot(*, message_ids: list[int] | None = None) -> MagicMock:
+    bot = MagicMock()
+    ids = iter(message_ids or [101])
+    bot.send_message = AsyncMock(side_effect=lambda **_: _message(next(ids)))
+    bot.edit_message_text = AsyncMock()
+    return bot
+
+
+async def _wait_until(predicate: object, limit_seconds: float = 0.5) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + limit_seconds
+    while not callable(predicate) or not predicate():
+        if loop.time() >= deadline:
+            raise AssertionError("condition did not become true")
+        await asyncio.sleep(0.002)
+
+
+async def _running(
+    tracker: TelegramTaskProgressTracker,
+    *,
+    chat_id: int = 10,
+    topic_id: int | None = 20,
+    task_id: str = "task-1",
+    name: str = "Read-only investigation",
+) -> None:
+    await tracker.update(
+        TaskProgressUpdate(
+            chat_id=chat_id,
+            topic_id=topic_id,
+            task_id=task_id,
+            name=name,
+            stage="running",
+            elapsed_seconds=0.0,
+        )
+    )
+
+
+class TestTelegramTaskProgressTracker:
+    async def test_running_sends_plain_status_message_to_origin_topic(self) -> None:
+        bot = _bot()
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=30.0)
+
+        await _running(tracker, name="<thinking>must not be parsed</thinking>")
+
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["chat_id"] == 10
+        assert kwargs["message_thread_id"] == 20
+        assert kwargs["parse_mode"] is None
+        assert "running" in kwargs["text"]
+        assert "Prompt:" not in kwargs["text"]
+        await tracker.shutdown()
+
+    async def test_heartbeat_edits_the_original_message_without_spam(self) -> None:
+        bot = _bot(message_ids=[101])
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=0.01)
+
+        await _running(tracker)
+        await _wait_until(lambda: bot.edit_message_text.await_count >= 1)
+
+        assert bot.send_message.await_count == 1
+        assert {call.kwargs["message_id"] for call in bot.edit_message_text.await_args_list} == {
+            101
+        }
+        await tracker.shutdown()
+
+    async def test_reviewing_keeps_the_same_heartbeat_message_alive(self) -> None:
+        bot = _bot(message_ids=[101])
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=0.01)
+
+        await _running(tracker)
+        await tracker.update(
+            TaskProgressUpdate(
+                chat_id=10,
+                topic_id=20,
+                task_id="task-1",
+                name="Read-only investigation",
+                stage="reviewing",
+                elapsed_seconds=12.0,
+            )
+        )
+        await _wait_until(lambda: bot.edit_message_text.await_count >= 2)
+
+        assert bot.send_message.await_count == 1
+        assert bot.edit_message_text.await_args.kwargs["message_id"] == 101
+        assert "reviewing" in bot.edit_message_text.await_args.kwargs["text"]
+        await tracker.shutdown()
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            ("done", "completed"),
+            ("failed", "failed"),
+            ("cancelled", "cancelled"),
+            ("waiting", "waiting"),
+            ("timeout", "timed out"),
+            ("unexpected", "finished"),
+        ],
+    )
+    async def test_terminal_status_stops_heartbeat_and_edits_terminal_text(
+        self, status: str, expected: str
+    ) -> None:
+        bot = _bot(message_ids=[101])
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=0.01)
+
+        await _running(tracker)
+        handled = await tracker.finish(
+            chat_id=10,
+            topic_id=20,
+            task_id="task-1",
+            status=status,
+        )
+        count_after_finish = bot.edit_message_text.await_count
+        await asyncio.sleep(0.04)
+
+        assert handled is True
+        assert expected in bot.edit_message_text.await_args.kwargs["text"]
+        assert bot.edit_message_text.await_count == count_after_finish
+        await tracker.shutdown()
+
+    async def test_tasks_are_isolated_by_chat_topic_and_task_id(self) -> None:
+        bot = _bot(message_ids=[101, 102, 103])
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=30.0)
+
+        await _running(tracker, chat_id=10, topic_id=20, task_id="one")
+        await _running(tracker, chat_id=10, topic_id=21, task_id="one")
+        await _running(tracker, chat_id=11, topic_id=20, task_id="one")
+        await tracker.update(
+            TaskProgressUpdate(
+                chat_id=10,
+                topic_id=20,
+                task_id="one",
+                name="Read-only investigation",
+                stage="reviewing",
+                elapsed_seconds=1.0,
+            )
+        )
+
+        assert len(tracker._states) == 3
+        assert bot.edit_message_text.await_args.kwargs["message_id"] == 101
+        await tracker.shutdown()
+
+    async def test_uneditable_status_message_is_replaced_once(self) -> None:
+        bot = _bot(message_ids=[101, 202])
+        bot.edit_message_text = AsyncMock(
+            side_effect=TelegramBadRequest(MagicMock(), "message to edit not found")
+        )
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=30.0)
+
+        await _running(tracker)
+        await tracker.update(
+            TaskProgressUpdate(
+                chat_id=10,
+                topic_id=20,
+                task_id="task-1",
+                name="Read-only investigation",
+                stage="reviewing",
+                elapsed_seconds=1.0,
+            )
+        )
+        await tracker.update(
+            TaskProgressUpdate(
+                chat_id=10,
+                topic_id=20,
+                task_id="task-1",
+                name="Read-only investigation",
+                stage="reviewing",
+                elapsed_seconds=2.0,
+            )
+        )
+
+        assert bot.send_message.await_count == 2
+        assert tracker._states[(10, 20, "task-1")].message_id == 202
+        await tracker.shutdown()
+
+    async def test_rate_limit_retries_one_edit_of_the_same_message(self) -> None:
+        bot = _bot(message_ids=[101])
+        bot.edit_message_text = AsyncMock(
+            side_effect=[TelegramRetryAfter(MagicMock(), "retry", retry_after=0), None]
+        )
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=30.0)
+
+        await _running(tracker)
+        await tracker.update(
+            TaskProgressUpdate(
+                chat_id=10,
+                topic_id=20,
+                task_id="task-1",
+                name="Read-only investigation",
+                stage="reviewing",
+                elapsed_seconds=1.0,
+            )
+        )
+
+        assert bot.edit_message_text.await_count == 2
+        assert {call.kwargs["message_id"] for call in bot.edit_message_text.await_args_list} == {
+            101
+        }
+        await tracker.shutdown()
+
+    async def test_terminal_finish_wins_over_a_late_heartbeat_edit(self) -> None:
+        bot = _bot(message_ids=[101])
+        edit_started = asyncio.Event()
+        release_edit = asyncio.Event()
+
+        async def _block_first_edit(**_: object) -> None:
+            edit_started.set()
+            await release_edit.wait()
+
+        bot.edit_message_text = AsyncMock(side_effect=_block_first_edit)
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=0.01)
+
+        await _running(tracker)
+        await asyncio.wait_for(edit_started.wait(), timeout=0.5)
+        finish = asyncio.create_task(
+            tracker.finish(chat_id=10, topic_id=20, task_id="task-1", status="done")
+        )
+        await asyncio.sleep(0)
+        release_edit.set()
+        assert await asyncio.wait_for(finish, timeout=0.5) is True
+
+        assert "completed" in bot.edit_message_text.await_args.kwargs["text"]
+        await tracker.shutdown()
+
+    async def test_resume_same_task_id_starts_a_new_tracker_generation(self) -> None:
+        bot = _bot(message_ids=[101, 202])
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=30.0)
+
+        await _running(tracker)
+        assert await tracker.finish(chat_id=10, topic_id=20, task_id="task-1", status="done")
+        await _running(tracker)
+
+        assert bot.send_message.await_count == 2
+        assert tracker._states[(10, 20, "task-1")].message_id == 202
+        await tracker.shutdown()
+
+    async def test_later_progress_retries_an_initial_send_failure(self) -> None:
+        bot = _bot(message_ids=[202])
+        bot.send_message = AsyncMock(
+            side_effect=[RuntimeError("network unavailable"), _message(202)]
+        )
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=30.0)
+
+        await _running(tracker)
+        await tracker.update(
+            TaskProgressUpdate(
+                chat_id=10,
+                topic_id=20,
+                task_id="task-1",
+                name="Read-only investigation",
+                stage="reviewing",
+                elapsed_seconds=1.0,
+            )
+        )
+
+        assert bot.send_message.await_count == 2
+        assert tracker._states[(10, 20, "task-1")].message_id == 202
+        await tracker.shutdown()
+
+    async def test_shutdown_cancels_all_heartbeats_without_more_edits(self) -> None:
+        bot = _bot(message_ids=[101])
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=0.01)
+
+        await _running(tracker)
+        await tracker.shutdown()
+        count_after_shutdown = bot.edit_message_text.await_count
+        await asyncio.sleep(0.04)
+
+        assert tracker._states == {}
+        assert bot.edit_message_text.await_count == count_after_shutdown

--- a/tests/messenger/telegram/test_task_progress.py
+++ b/tests/messenger/telegram/test_task_progress.py
@@ -99,6 +99,8 @@ class TestTelegramTaskProgressTracker:
                 name="Read-only investigation",
                 stage="reviewing",
                 elapsed_seconds=12.0,
+                output_text="The worker found the requested files.",
+                tool_name="Shell",
             )
         )
         await _wait_until(lambda: bot.edit_message_text.await_count >= 2)
@@ -106,6 +108,11 @@ class TestTelegramTaskProgressTracker:
         assert bot.send_message.await_count == 1
         assert bot.edit_message_text.await_args.kwargs["message_id"] == 101
         assert "reviewing" in bot.edit_message_text.await_args.kwargs["text"]
+        assert (
+            "The worker found the requested files."
+            in bot.edit_message_text.await_args.kwargs["text"]
+        )
+        assert "[TOOL: Shell]" in bot.edit_message_text.await_args.kwargs["text"]
         await tracker.shutdown()
 
     @pytest.mark.parametrize(

--- a/tests/messenger/telegram/test_task_progress.py
+++ b/tests/messenger/telegram/test_task_progress.py
@@ -74,7 +74,7 @@ class TestTelegramTaskProgressTracker:
         await tracker.shutdown()
 
     async def test_heartbeat_edits_the_original_message_without_spam(self) -> None:
-        bot = _bot(message_ids=[101])
+        bot = _bot(message_ids=[101, 102])
         tracker = TelegramTaskProgressTracker(bot, interval_seconds=0.01)
 
         await _running(tracker)
@@ -145,6 +145,27 @@ class TestTelegramTaskProgressTracker:
         assert handled is True
         assert expected in bot.edit_message_text.await_args.kwargs["text"]
         assert bot.edit_message_text.await_count == count_after_finish
+        await tracker.shutdown()
+
+    async def test_terminal_status_keeps_streamed_output_visible(self) -> None:
+        bot = _bot(message_ids=[101, 102])
+        tracker = TelegramTaskProgressTracker(bot, interval_seconds=30.0)
+
+        await _running(tracker)
+        await tracker.update(
+            TaskProgressUpdate(
+                chat_id=10,
+                topic_id=20,
+                task_id="task-1",
+                name="Read-only investigation",
+                stage="running",
+                elapsed_seconds=1.0,
+                output_text="Final worker findings",
+            )
+        )
+        await tracker.finish(chat_id=10, topic_id=20, task_id="task-1", status="done")
+
+        assert "Final worker findings" in bot.edit_message_text.await_args.kwargs["text"]
         await tracker.shutdown()
 
     async def test_tasks_are_isolated_by_chat_topic_and_task_id(self) -> None:

--- a/tests/messenger/telegram/test_transport.py
+++ b/tests/messenger/telegram/test_transport.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from ductor_bot.bus.bus import MessageBus
 from ductor_bot.bus.cron_sanitize import (
     is_cron_transport_ack_line,
     sanitize_cron_result_text,
 )
 from ductor_bot.bus.envelope import Envelope, Origin
+from ductor_bot.messenger.telegram.task_progress import TaskProgressUpdate
 from ductor_bot.messenger.telegram.transport import TelegramTransport
 
 if TYPE_CHECKING:
@@ -29,6 +32,8 @@ def _make_transport() -> tuple[TelegramTransport, MagicMock, AsyncMock]:
     """
     bot = MagicMock()
     bot.bot_instance = MagicMock()
+    bot.config.tasks.progress_updates = True
+    bot.config.tasks.progress_interval_seconds = 30.0
     bot.file_roots.return_value = [Path("/tmp/roots")]
     bot._orch.paths = MagicMock()
     bot._orch.named_sessions.update_after_response = MagicMock()
@@ -360,6 +365,144 @@ class TestInteragentDelivery:
 
 
 class TestTaskResultDelivery:
+    async def test_task_progress_updates_the_single_message_tracker(self) -> None:
+        transport, _, _ = _make_transport()
+        transport._task_progress.update = AsyncMock()
+        env = _env(
+            origin=Origin.TASK_PROGRESS,
+            chat_id=99,
+            topic_id=123,
+            status="reviewing",
+            elapsed_seconds=14.0,
+            metadata={"name": "audit", "task_id": "t1"},
+        )
+
+        await transport.deliver(env)
+
+        transport._task_progress.update.assert_awaited_once_with(
+            TaskProgressUpdate(
+                chat_id=99,
+                topic_id=123,
+                task_id="t1",
+                name="audit",
+                stage="reviewing",
+                elapsed_seconds=14.0,
+            )
+        )
+
+    async def test_tracked_done_finalizes_before_sending_only_injected_body(self) -> None:
+        transport, _, _ = _make_transport()
+        order: list[str] = []
+
+        async def _finish(**_: object) -> bool:
+            order.append("finish")
+            return True
+
+        async def _send(*_: object, **__: object) -> bool:
+            order.append("send")
+            return True
+
+        transport._task_progress.finish = AsyncMock(side_effect=_finish)
+        env = _env(
+            origin=Origin.TASK_RESULT,
+            chat_id=99,
+            topic_id=123,
+            status="done",
+            result_text="Injected answer",
+            needs_injection=True,
+            metadata={"name": "audit", "task_id": "t1"},
+        )
+
+        with patch(
+            "ductor_bot.messenger.telegram.transport.send_rich",
+            new=AsyncMock(side_effect=_send),
+        ) as mock_send:
+            await transport.deliver(env)
+
+        transport._task_progress.finish.assert_awaited_once_with(
+            chat_id=99,
+            topic_id=123,
+            task_id="t1",
+            status="done",
+        )
+        assert order == ["finish", "send"]
+        assert mock_send.await_count == 1
+        assert mock_send.await_args.args[2] == "Injected answer"
+
+    async def test_waiting_finalizes_tracker_without_duplicate_notification(self) -> None:
+        transport, _, _ = _make_transport()
+        transport._task_progress.finish = AsyncMock(return_value=True)
+        env = _env(
+            origin=Origin.TASK_RESULT,
+            chat_id=99,
+            topic_id=123,
+            status="waiting",
+            metadata={"name": "audit", "task_id": "t1"},
+        )
+
+        with patch(
+            "ductor_bot.messenger.telegram.transport.send_rich", new_callable=AsyncMock
+        ) as mock_send:
+            await transport.deliver(env)
+
+        transport._task_progress.finish.assert_awaited_once()
+        mock_send.assert_not_awaited()
+
+    async def test_heartbeat_continues_while_parent_result_injection_is_blocked(self) -> None:
+        transport, bot, _ = _make_transport()
+        bot.bot_instance.send_message = AsyncMock(return_value=MagicMock(message_id=101))
+        heartbeat_edited = asyncio.Event()
+
+        async def _edit(**_: object) -> None:
+            heartbeat_edited.set()
+
+        bot.bot_instance.edit_message_text = AsyncMock(side_effect=_edit)
+        transport._task_progress._interval_seconds = 0.01
+
+        injection_started = asyncio.Event()
+        release_injection = asyncio.Event()
+        injector = MagicMock()
+
+        async def _inject(*_: object, **__: object) -> str:
+            injection_started.set()
+            await release_injection.wait()
+            return "Parent-reviewed answer"
+
+        injector.inject_prompt = AsyncMock(side_effect=_inject)
+        bus = MessageBus()
+        bus.register_transport(transport)
+        bus.set_injector(injector)
+
+        await bus.submit(
+            _env(
+                origin=Origin.TASK_PROGRESS,
+                chat_id=99,
+                topic_id=123,
+                status="running",
+                metadata={"name": "audit", "task_id": "t1"},
+            )
+        )
+        result = _env(
+            origin=Origin.TASK_RESULT,
+            chat_id=99,
+            topic_id=123,
+            status="done",
+            prompt="Review the worker result",
+            needs_injection=True,
+            metadata={"name": "audit", "task_id": "t1"},
+        )
+
+        with patch("ductor_bot.messenger.telegram.transport.send_rich", new_callable=AsyncMock):
+            delivery = asyncio.create_task(bus.submit(result))
+            await asyncio.wait_for(injection_started.wait(), timeout=0.5)
+            await asyncio.wait_for(heartbeat_edited.wait(), timeout=0.5)
+            assert delivery.done() is False
+            release_injection.set()
+            await asyncio.wait_for(delivery, timeout=0.5)
+
+        assert "completed" in bot.bot_instance.edit_message_text.await_args.kwargs["text"]
+        await transport.shutdown()
+
     async def test_done_with_injection(self) -> None:
         transport, _, _ = _make_transport()
         env = _env(

--- a/tests/messenger/test_multi.py
+++ b/tests/messenger/test_multi.py
@@ -11,6 +11,8 @@ import pytest
 
 from ductor_bot.messenger.multi import MultiBotAdapter
 from ductor_bot.messenger.notifications import CompositeNotificationService
+from ductor_bot.messenger.protocol import BotProtocol
+from ductor_bot.tasks.models import TaskProgress
 
 
 def _make_config(transports: list[str] | None = None) -> MagicMock:
@@ -32,6 +34,7 @@ def _make_bot(*, name: str = "bot") -> MagicMock:
     bot.register_startup_hook = MagicMock()
     bot.set_abort_all_callback = MagicMock()
     bot.on_async_interagent_result = AsyncMock()
+    bot.on_task_progress = AsyncMock()
     bot.on_task_result = AsyncMock()
     bot.on_task_question = AsyncMock()
     bot.file_roots = MagicMock(return_value=[Path("/tmp")])
@@ -137,6 +140,9 @@ class TestMultiBotAdapterProperties:
 
 
 class TestMultiBotAdapterDelegation:
+    def test_protocol_declares_task_progress_handler(self) -> None:
+        assert hasattr(BotProtocol, "on_task_progress")
+
     def test_register_startup_hook_delegates_to_primary(self) -> None:
         config = _make_config()
         fake_tg = _make_bot()
@@ -200,6 +206,67 @@ class TestMultiBotAdapterDelegation:
         await adapter.on_task_result(result)
         fake_tg.on_task_result.assert_awaited_once_with(result)
         fake_mx.on_task_result.assert_awaited_once_with(result)
+
+    async def test_on_task_progress_fans_out(self) -> None:
+        config = _make_config()
+        fake_tg = _make_bot()
+        fake_mx = _make_bot()
+
+        with patch(
+            "ductor_bot.messenger.registry._create_single_bot",
+            side_effect=[fake_tg, fake_mx],
+        ):
+            adapter = MultiBotAdapter(config)
+
+        progress = TaskProgress(
+            task_id="t1",
+            chat_id=123,
+            parent_agent="main",
+            name="Task",
+            stage="running",
+            elapsed_seconds=0.0,
+            provider="claude",
+            model="opus",
+            thread_id=456,
+        )
+        await adapter.on_task_progress(progress)
+
+        fake_tg.on_task_progress.assert_awaited_once_with(progress)
+        fake_mx.on_task_progress.assert_awaited_once_with(progress)
+
+    async def test_matrix_and_slack_task_progress_handlers_are_explicit_noops(self) -> None:
+        from ductor_bot.messenger.matrix.bot import MatrixBot
+        from ductor_bot.messenger.slack.bot import SlackBot
+
+        progress = MagicMock()
+
+        assert await MatrixBot.on_task_progress(MagicMock(), progress) is None
+        assert await SlackBot.on_task_progress(MagicMock(), progress) is None
+
+    async def test_telegram_task_progress_handler_submits_safe_bus_envelope(self) -> None:
+        from ductor_bot.bus.envelope import Origin
+        from ductor_bot.messenger.telegram.app import TelegramBot
+
+        bot = MagicMock()
+        bot._bus.submit = AsyncMock()
+        progress = TaskProgress(
+            task_id="t1",
+            chat_id=123,
+            parent_agent="main",
+            name="Task",
+            stage="running",
+            elapsed_seconds=0.0,
+            provider="claude",
+            model="opus",
+            thread_id=456,
+        )
+
+        await TelegramBot.on_task_progress(bot, progress)
+
+        envelope = bot._bus.submit.await_args.args[0]
+        assert envelope.origin is Origin.TASK_PROGRESS
+        assert envelope.prompt == ""
+        assert envelope.prompt_preview == ""
 
     async def test_on_task_question_fans_out(self) -> None:
         config = _make_config()

--- a/tests/multiagent/test_supervisor.py
+++ b/tests/multiagent/test_supervisor.py
@@ -12,6 +12,7 @@ import pytest
 from ductor_bot.config import AgentConfig
 from ductor_bot.multiagent.health import AgentHealth
 from ductor_bot.multiagent.models import SubAgentConfig
+from ductor_bot.multiagent.stack import AgentStack
 from ductor_bot.multiagent.supervisor import (
     _MAX_RESTART_RETRIES,
     AgentSupervisor,
@@ -46,6 +47,30 @@ class TestSupervisorInit:
 
     def test_agents_path(self, supervisor: AgentSupervisor, tmp_path: Path) -> None:
         assert supervisor._agents_path == tmp_path / "agents.json"
+
+
+class TestTaskHubWiring:
+    def test_wires_progress_handler_for_agent_stack(
+        self, supervisor: AgentSupervisor, main_config: AgentConfig, tmp_path: Path
+    ) -> None:
+        hub = MagicMock()
+        supervisor._task_hub = hub
+
+        orchestrator = MagicMock()
+        bot = MagicMock()
+        bot.orchestrator = orchestrator
+        bot.on_task_progress = AsyncMock()
+        stack = AgentStack(
+            name="main",
+            config=main_config,
+            paths=MagicMock(tasks_dir=tmp_path / "tasks"),
+            bot=bot,
+            is_main=True,
+        )
+
+        supervisor._wire_task_hub(stack)
+
+        hub.set_progress_handler.assert_called_once_with("main", bot.on_task_progress)
 
 
 class TestStartupFailures:

--- a/tests/tasks/test_hub.py
+++ b/tests/tasks/test_hub.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ductor_bot.cli.process_registry import ProcessRegistry
+from ductor_bot.cli.stream_events import ToolUseEvent
 from ductor_bot.tasks.hub import TaskHub
 from ductor_bot.tasks.models import TaskProgress, TaskResult, TaskSubmit
 from ductor_bot.tasks.registry import TaskRegistry
@@ -44,6 +45,11 @@ def _make_cli_service(
     response.timed_out = False
     response.num_turns = num_turns
     cli.execute = AsyncMock(return_value=response)
+
+    async def _streaming(request: object, **_: object) -> MagicMock:
+        return await cli.execute(request)
+
+    cli.execute_streaming = AsyncMock(side_effect=_streaming)
     cli.resolve_provider = MagicMock(return_value=("claude", "opus"))
     return cli
 
@@ -112,6 +118,36 @@ class TestSubmit:
 
 
 class TestRunAndDeliver:
+    async def test_streamed_worker_output_is_emitted_as_progress(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        cli = _make_cli_service("final output")
+        progress_updates: list[TaskProgress] = []
+
+        async def _streaming(_: object, **callbacks: object) -> object:
+            on_text = callbacks["on_text_delta"]
+            on_tool = callbacks["on_tool_activity"]
+            await on_tool(ToolUseEvent(type="assistant", tool_name="Shell"))  # type: ignore[operator]
+            await on_text("partial reply")  # type: ignore[operator]
+            return cli.execute.return_value
+
+        cli.execute_streaming = AsyncMock(side_effect=_streaming)
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=cli,
+            config=_make_config(),
+        )
+        hub.set_progress_handler("main", progress_updates.append)
+        hub.set_result_handler("main", AsyncMock())
+
+        hub.submit(_submit())
+        await asyncio.sleep(0.1)
+
+        assert any(update.tool_name == "Shell" for update in progress_updates)
+        assert any(update.output_text == "partial reply" for update in progress_updates)
+        await hub.shutdown()
+
     async def test_running_progress_follows_registry_create_and_precedes_execute(
         self, registry: TaskRegistry, tmp_path: Path
     ) -> None:

--- a/tests/tasks/test_hub.py
+++ b/tests/tasks/test_hub.py
@@ -10,7 +10,7 @@ import pytest
 
 from ductor_bot.cli.process_registry import ProcessRegistry
 from ductor_bot.tasks.hub import TaskHub
-from ductor_bot.tasks.models import TaskResult, TaskSubmit
+from ductor_bot.tasks.models import TaskProgress, TaskResult, TaskSubmit
 from ductor_bot.tasks.registry import TaskRegistry
 from ductor_bot.workspace.paths import DuctorPaths
 
@@ -112,6 +112,137 @@ class TestSubmit:
 
 
 class TestRunAndDeliver:
+    async def test_running_progress_follows_registry_create_and_precedes_execute(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        events: list[str] = []
+        cli = _make_cli_service("task output")
+        response = cli.execute.return_value
+
+        async def _execute(_: object) -> object:
+            events.append("execute")
+            return response
+
+        async def _progress(progress: TaskProgress) -> None:
+            assert registry.get(progress.task_id) is not None
+            events.append(progress.stage)
+
+        delivered = asyncio.Event()
+
+        async def _result(_: TaskResult) -> None:
+            delivered.set()
+
+        cli.execute = AsyncMock(side_effect=_execute)
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=cli,
+            config=_make_config(),
+        )
+        hub.set_progress_handler("main", _progress)
+        hub.set_result_handler("main", _result)
+
+        hub.submit(_submit())
+        await asyncio.wait_for(delivered.wait(), timeout=1)
+
+        assert events.index("running") < events.index("execute")
+        await hub.shutdown()
+
+    async def test_reviewing_progress_follows_worker_and_precedes_result_delivery(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        events: list[str] = []
+        cli = _make_cli_service("task output")
+        response = cli.execute.return_value
+
+        async def _execute(_: object) -> object:
+            events.append("worker-return")
+            return response
+
+        async def _progress(progress: TaskProgress) -> None:
+            events.append(progress.stage)
+
+        delivered = asyncio.Event()
+
+        async def _result(_: TaskResult) -> None:
+            events.append("result")
+            delivered.set()
+
+        cli.execute = AsyncMock(side_effect=_execute)
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=cli,
+            config=_make_config(),
+        )
+        hub.set_progress_handler("main", _progress)
+        hub.set_result_handler("main", _result)
+
+        hub.submit(_submit())
+        await asyncio.wait_for(delivered.wait(), timeout=1)
+
+        assert events.index("worker-return") < events.index("reviewing")
+        assert events.index("reviewing") < events.index("result")
+        await hub.shutdown()
+
+    async def test_submit_failure_emits_no_progress(
+        self, registry: TaskRegistry, tmp_path: Path
+    ) -> None:
+        registry.create = MagicMock(side_effect=OSError("registry unavailable"))  # type: ignore[method-assign]
+        progress_handler = AsyncMock()
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=_make_cli_service(),
+            config=_make_config(),
+        )
+        hub.set_progress_handler("main", progress_handler)
+
+        with pytest.raises(OSError, match="registry unavailable"):
+            hub.submit(_submit())
+
+        await asyncio.sleep(0)
+        progress_handler.assert_not_awaited()
+        await hub.shutdown()
+
+    async def test_progress_handler_failure_does_not_fail_worker_or_result(
+        self,
+        registry: TaskRegistry,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        progress_handler = AsyncMock(side_effect=RuntimeError("progress unavailable"))
+        delivered = asyncio.Event()
+
+        async def _result(_: TaskResult) -> None:
+            delivered.set()
+
+        result_handler = AsyncMock(side_effect=_result)
+        cli = _make_cli_service("task output")
+        hub = TaskHub(
+            registry,
+            MagicMock(workspace=tmp_path),
+            cli_service=cli,
+            config=_make_config(),
+        )
+        hub.set_progress_handler("main", progress_handler)
+        hub.set_result_handler("main", result_handler)
+
+        with caplog.at_level("ERROR", logger="ductor_bot.tasks.hub"):
+            task_id = hub.submit(_submit())
+            await asyncio.wait_for(delivered.wait(), timeout=1)
+
+        cli.execute.assert_awaited_once()
+        result_handler.assert_awaited_once()
+        assert registry.get(task_id) is not None
+        assert registry.get(task_id).status == "done"  # type: ignore[union-attr]
+        assert progress_handler.await_count == 2
+        assert (
+            sum("progress delivery failed" in record.message.lower() for record in caplog.records)
+            == 2
+        )
+        await hub.shutdown()
+
     async def test_delivers_success_result(self, registry: TaskRegistry, tmp_path: Path) -> None:
         delivered: list[TaskResult] = []
         handler = AsyncMock(side_effect=delivered.append)

--- a/tests/tasks/test_priority.py
+++ b/tests/tasks/test_priority.py
@@ -128,6 +128,11 @@ def _make_cli_service() -> MagicMock:
     response.timed_out = False
     response.num_turns = 1
     cli.execute = AsyncMock(return_value=response)
+
+    async def _streaming(request: object, **_: object) -> MagicMock:
+        return await cli.execute(request)
+
+    cli.execute_streaming = AsyncMock(side_effect=_streaming)
     cli.resolve_provider = MagicMock(return_value=("claude", "opus"))
     return cli
 

--- a/tests/tasks/test_progress_config.py
+++ b/tests/tasks/test_progress_config.py
@@ -1,0 +1,49 @@
+"""Contract tests for Telegram TaskHub progress configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from ductor_bot.config import AgentConfig, deep_merge_config
+
+
+def test_task_progress_defaults_are_enabled_at_thirty_seconds() -> None:
+    tasks = AgentConfig().tasks
+
+    assert tasks.progress_updates is True
+    assert tasks.progress_interval_seconds == 30.0
+
+
+def test_task_progress_interval_rejects_values_below_ten_seconds() -> None:
+    with pytest.raises(ValidationError, match="progress_interval_seconds"):
+        AgentConfig(tasks={"progress_interval_seconds": 9.9})
+
+    assert (
+        AgentConfig(tasks={"progress_interval_seconds": 10.0}).tasks.progress_interval_seconds
+        == 10.0
+    )
+
+
+def test_existing_tasks_config_receives_progress_defaults_without_losing_values() -> None:
+    defaults = AgentConfig().model_dump(mode="json")
+    merged, changed = deep_merge_config({"tasks": {"enabled": False, "max_parallel": 2}}, defaults)
+
+    tasks = merged["tasks"]
+    assert isinstance(tasks, dict)
+    assert changed is True
+    assert tasks["enabled"] is False
+    assert tasks["max_parallel"] == 2
+    assert tasks["progress_updates"] is True
+    assert tasks["progress_interval_seconds"] == 30.0
+
+
+def test_config_example_documents_the_runtime_progress_defaults() -> None:
+    root = Path(__file__).resolve().parents[2]
+    example = json.loads((root / "config.example.json").read_text(encoding="utf-8"))
+
+    assert example["tasks"]["progress_updates"] is True
+    assert example["tasks"]["progress_interval_seconds"] == 30.0


### PR DESCRIPTION
## Summary
- add configurable Telegram progress updates for background tasks, including lifecycle handling across supported transports
- stream background worker text and tool activity into the existing Telegram progress message while the task is running
- suppress Codex internal pre-tool and tagged reasoning messages from user-facing output
- avoid duplicate file-change progress events while preserving the final assistant response

## Validation
- `pytest -q tests/tasks tests/bus tests/messenger/telegram tests/messenger/test_multi.py tests/messenger/test_registry.py` (894 passed)
- `mypy ductor_bot`
- `ruff format --check` on changed files
- `git diff --check`

## Notes
- The full suite has unrelated pre-existing failures in `test_log_redact` and Docker-dependent tests in this environment.
- Full-repository Ruff checks also report existing project-wide copyright-rule violations and one unchanged documentation formatting issue.